### PR TITLE
feat: pass `get` into reducer in redux middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,7 +8,7 @@ import {
 } from './vanilla'
 
 export const redux = <S extends State, A extends { type: unknown }>(
-  reducer: (state: S, action: A) => S,
+  reducer: (state: S, action: A, opts: { get: GetState<S> }) => S,
   initial: S
 ) => (
   set: SetState<S>,
@@ -19,7 +19,7 @@ export const redux = <S extends State, A extends { type: unknown }>(
   }
 ): S & { dispatch: (a: A) => A } => {
   api.dispatch = (action: A) => {
-    set((state: S) => reducer(state, action))
+    set((state: S) => reducer(state, action, { get }))
     if (api.devtools) {
       api.devtools.send(api.devtools.prefix + action.type, get())
     }


### PR DESCRIPTION
We recently had a situation where we were storing JS getters in a Zustand store, and when the getters were resolved we wanted to guarantee that they were getting the correct data from the store instead of just the data that was present at the time that the reducer was run.

The core Zustand API supports accessing `get` when a method is called, but the Redux middleware doesn't support this currently. This PR proposes to add that capability.