### PR TITLE
Hide warning when not run in browser (middleware)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -50,7 +50,7 @@ export const devtools = <S extends State>(
   } catch {}
 
   if (!extension) {
-    if (process.env.NODE_ENV === 'development') {
+    if (process.env.NODE_ENV === 'development' && typeof window !== 'undefined') {
       console.warn('Please install/enable Redux devtools extension')
     }
     api.devtools = null

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -50,7 +50,10 @@ export const devtools = <S extends State>(
   } catch {}
 
   if (!extension) {
-    if (process.env.NODE_ENV === 'development' && typeof window !== 'undefined') {
+    if (
+      process.env.NODE_ENV === 'development' &&
+      typeof window !== 'undefined'
+    ) {
       console.warn('Please install/enable Redux devtools extension')
     }
     api.devtools = null


### PR DESCRIPTION
I recently started using Zustand with next.js for my client-side state. In order to better debug/track the state, I've also started using the devtools middleware. This works fine on the client-side (in the browser), but results in lots of `console.warn` lines server-side (in the terminal when running the development server) stating "Please install/enable Redux devtools extension", which can obscure actual messages at times due to the number of times it is output. As the server side rendering happens outside of a browser, it seems a safe enough condition to add to this if statement.

The only other alternative I found to fix this locally is to assign the result of `create()` or `create(devtools())` conditionally, which results in a lot of duplicate code, as the devtools middleware requires extra parameters to the `set()` function (a name).

Please let me know if you're not happy with this solution (or if there are any drawbacks I haven't noticed).

I skipped opening an issue as well as the PR - if you prefer I open an issue as well, just drop me a comment.