### PR TITLE
add pipe middlewares example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -269,6 +269,31 @@ const useStore = create(
 )
 ```
 
+
+<overview>
+<summary>How to pipe middlewares</summary>
+<details>
+
+```js
+import create from "zustand"
+import produce from "immer"
+import pipe from "ramda/es/pipe"
+
+/* log and immer functions from previous example */
+/* you can pipe as many middlewares as you want */
+const createStore = pipe(log, immer, create)
+
+const useStore = createStore(set => ({
+  bears: 1,
+  increasePopulation: () => set(state => ({ bears: state.bears + 1 }))
+}))
+
+export default useStore
+```
+For a TS example see the following [discussion](https://github.com/pmndrs/zustand/discussions/224#discussioncomment-118208)
+</details>
+</overview>
+
 <overview>
 <summary>TypeScript</summary>
 <details>


### PR DESCRIPTION
add ramda's pipe middlewares example as discussed [here](https://github.com/pmndrs/zustand/discussions/224)

```js
import create from "zustand"
import produce from "immer"
import pipe from "ramda/es/pipe"

const log = config => (set, get, api) =>
  config(
    args => {
      console.log("  applying", args)
      set(args)
      console.log("  new state", get())
    },
    get,
    api
  )

// Turn the set method into an immer proxy
const immer = config => (set, get, api) =>
  config(fn => set(produce(fn)), get, api)

const createStore = pipe(log, immer, create)

const useStore = createStore(set => ({
  bears: 1,
  increasePopulation: () => set(state => ({ bears: state.bears + 1 })),
}))

export default useStore
```