### PR TITLE
feat: add persist middleware

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -326,12 +326,6 @@ export const useStore = create(persist(
   {
     name: "food-storage", // unique name
     storage: sessionStorage, // (optional) default is 'localStorage'
-    serialize: (state) => { // (optional) default is 'JSON.stringify'
-      // some stuff to serialize the state and return it
-    }, 
-    deserialize: (str) => { // (optional) default is 'JSON.parse'
-      // some stuff to deserialize the state and return it
-    }
   }
 ))
 ```

--- a/readme.md
+++ b/readme.md
@@ -310,6 +310,32 @@ const immer = <T extends State>(
 </details>
 </overview>
 
+## Persist middleware
+
+You can persist you store's data using any kind of storage.
+
+```jsx
+import create from "zustand"
+import { persist } from "zustand/middleware"
+
+export const useStore = create(persist(
+  (set, get) => ({
+    fish: 0,
+    addAFish: () => set({ fish: get().fish + 1 })
+  }),
+  {
+    name: "food-storage", // unique name
+    storage: sessionStorage, // (optional) default is 'localStorage'
+    serialize: (state) => { // (optional) default is 'JSON.stringify'
+      // some stuff to serialize the state and return it
+    }, 
+    deserialize: (str) => { // (optional) default is 'JSON.parse'
+      // some stuff to deserialize the state and return it
+    }
+  }
+))
+```
+
 ## Can't live without redux-like reducers and action types?
 
 ```jsx

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -118,8 +118,8 @@ export const combine = <
   )
 
 export type StateStorage = {
-  getItem: (key: string) => string | null | Promise<string | null>
-  setItem: (key: string, value: string) => void | Promise<void>
+  getItem: (name: string) => string | null | Promise<string | null>
+  setItem: (name: string, value: string) => void | Promise<void>
 }
 export type PersistOptions<S> = {
   name: string

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,10 +1,10 @@
 import {
-  State,
   GetState,
-  SetState,
-  StoreApi,
   PartialState,
+  SetState,
+  State,
   StateCreator,
+  StoreApi,
 } from './vanilla'
 
 export const redux = <S extends State, A extends { type: unknown }>(
@@ -116,3 +116,48 @@ export const combine = <
       api as StoreApi<PrimaryState>
     )
   )
+
+export type StateStorage = {
+  getItem: (key: string) => string | null | Promise<string | null>
+  setItem: (key: string, value: string) => void | Promise<void>
+}
+export type PersistOptions<S> = {
+  name: string
+  storage?: StateStorage
+  serialize?: (state: S) => string | Promise<string>
+  deserialize?: (str: string) => S | Promise<S>
+}
+
+export const persist = <S extends State>(
+  config: StateCreator<S>,
+  options: PersistOptions<S>
+) => (set: SetState<S>, get: GetState<S>, api: StoreApi<S>): S => {
+  const {
+    name,
+    storage = localStorage,
+    serialize = JSON.stringify,
+    deserialize = JSON.parse,
+  } = options || {}
+
+  const state = config(
+    (payload) => {
+      set(payload)
+      ;(async () => {
+        storage.setItem(name, await serialize(get()))
+      })()
+    },
+    get,
+    api
+  )
+
+  ;(async () => {
+    try {
+      const storedState = await storage.getItem(name)
+      if (storedState) set(await deserialize(storedState))
+    } catch (e) {
+      console.error(new Error(`Unable to get to stored state in "${name}"`))
+    }
+  })()
+
+  return state
+}


### PR DESCRIPTION
Hi :wave: I saw [this comment](https://github.com/pmndrs/zustand/issues/214#issuecomment-715895730) so I've decided to open a pr for the middleware I've made and shared [here](https://github.com/pmndrs/zustand/issues/76#issuecomment-670367631).

I've been using it for multiples months on a project at work, and it actually works nicely given its simplicity.
But I still think there's some quite annoying drawbacks that we could probably improve:
- The obligation to give a name to the middleware. It'd be preferable to not hard code the name so the middleware could generate unique names/ids for the user. But I can't come up with a way to do this. 
- Rehydration & merge & update of a stored state that has changed since. I don't think this is possible (?), but it still'd be nice to erase the old (incompatible) stored state by the new one (so there would be some data loss). I have some ideas on how to choose if the stored state needs to be erased or not, but I'd like to have the maintainers' opinions first.