### PR TITLE
fix currentSlice in listeners not being updated when equalityFn returns true

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -61,9 +61,10 @@ export default function create<TState extends State>(
       // the listener from being called.
       // https://github.com/react-spring/zustand/pull/37
       try {
-        const newStateSlice = selector(state)
-        if (!equalityFn(currentSlice, newStateSlice)) {
-          listener((currentSlice = newStateSlice))
+        const previousSlice = currentSlice
+        currentSlice = selector(state)
+        if (!equalityFn(previousSlice, currentSlice)) {
+          listener(currentSlice)
         }
       } catch (error) {
         listener(null, error)

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -438,6 +438,24 @@ it('can subscribe to the store', () => {
   unsub()
 })
 
+it('ensures equalityFn is always called with the correct values', () => {
+  const { setState, subscribe } = create(() => ({ value: 0 }))
+  const equalityFn = jest.fn(() => true);
+
+  subscribe(
+    () => {},
+    (state) => state.value,
+    equalityFn
+  );
+  
+  setState({ value: 1 })
+  expect(equalityFn).toHaveBeenCalledWith(0, 1);
+  setState({ value: 2 })
+  expect(equalityFn).toHaveBeenCalledWith(1, 2);
+  setState({ value: 2 })
+  expect(equalityFn).toHaveBeenCalledWith(2, 2);
+});
+
 it('can destroy the store', () => {
   const { destroy, getState, setState, subscribe } = create(() => ({
     value: 1,


### PR DESCRIPTION
I noticed an issue with the listeners, if the `equalityFn` returns `true` then the internal `currentSlice` doesn't get updated, so the subsequent `equalityFn` calls will receive outdated value in the `previous` param.

**Example**
```js
  const { setState, subscribe } = create(() => ({ value: 0 }))
  const equalityFn = jest.fn(() => true);

  subscribe(
    () => {},
    (state) => state.value,
    equalityFn
  );
  
  setState({ value: 1 })
  expect(equalityFn).toHaveBeenCalledWith(0, 1);
  setState({ value: 2 })
  expect(equalityFn).toHaveBeenCalledWith(1, 2); // this fails as it was called with `0, 2`
  setState({ value: 2 })
  expect(equalityFn).toHaveBeenCalledWith(2, 2); // this fails as it was called with `0, 2`
```
