### PR TITLE
Expose previous value in subscribe

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -175,12 +175,15 @@ const unsub1 = useStore.subscribe(console.log)
 const unsub2 = useStore.subscribe(console.log, state => state.paw)
 // Subscribe also supports an optional equality function
 const unsub3 = useStore.subscribe(console.log, state => [state.paw, state.fur], shallow)
+// Subscribe also exposes the previous value
+const unsub4 = useStore.subscribe((paw, previousPaw) => console.log(paw, previousPaw), state => state.paw)
 // Updating state, will trigger listeners
 useStore.setState({ paw: false })
 // Unsubscribe listeners
 unsub1()
 unsub2()
 unsub3()
+unsub4()
 // Destroying the store (removing all listeners)
 useStore.destroy()
 

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -412,7 +412,10 @@ it('can subscribe to the store', () => {
   setState({ value: initialState.value + 1 })
   unsub()
   expect(listener).toHaveBeenCalledTimes(1)
-  expect(listener).toHaveBeenCalledWith(initialState.value + 1)
+  expect(listener).toHaveBeenCalledWith(
+    initialState.value + 1,
+    initialState.value
+  )
 
   // Should not be called when equality checker returns true
   unsub = subscribe(
@@ -435,7 +438,10 @@ it('can subscribe to the store', () => {
   setState({ value: initialState.value + 2 })
   unsub()
   expect(listener).toHaveBeenCalledTimes(1)
-  expect(listener).toHaveBeenCalledWith(initialState.value + 2)
+  expect(listener).toHaveBeenCalledWith(
+    initialState.value + 2,
+    initialState.value + 2
+  )
 
   // Should keep consistent behavior with equality check
   const isRoughEqual = (x: number, y: number) => Math.abs(x - y) < 1
@@ -448,7 +454,7 @@ it('can subscribe to the store', () => {
       // skip assuming values are equal
       return
     }
-    listener(s.value)
+    listener(s.value, prevValue)
     prevValue = s.value
   })
   const unsub2 = subscribe(listener2, (s) => s.value, isRoughEqual as any)
@@ -457,9 +463,9 @@ it('can subscribe to the store', () => {
   unsub()
   unsub2()
   expect(listener).toHaveBeenCalledTimes(1)
-  expect(listener).toHaveBeenCalledWith(1)
+  expect(listener).toHaveBeenCalledWith(1, 0)
   expect(listener2).toHaveBeenCalledTimes(1)
-  expect(listener2).toHaveBeenCalledWith(1)
+  expect(listener2).toHaveBeenCalledWith(1, 0)
 })
 
 it('can destroy the store', () => {


### PR DESCRIPTION
Decided to go ahead with my proposal of #240. I found the second argument was used for the error in case there's an error, but that's undocumented, so I am not sure how much of a breaking change this would be.