### PR TITLE
Allow persist middleware to accept 'localStorage' and 'sessionStorage' for easier usage of session

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -132,7 +132,7 @@ export const persist = <S extends State>(
   config: StateCreator<S>,
   options: PersistOptions<S>
 ) => (set: SetState<S>, get: GetState<S>, api: StoreApi<S>): S => {
-  const storageDummy: StateStorage = {
+  const storageDummy = {
     getItem: () => null,
     setItem: () => {},
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -123,7 +123,7 @@ type StateStorage = {
 }
 type PersistOptions<S> = {
   name: string
-  storage?: StateStorage
+  storage?: StateStorage | 'localStorage' | 'sessionStorage'
   serialize?: (state: S) => string | Promise<string>
   deserialize?: (str: string) => S | Promise<S>
 }
@@ -132,17 +132,20 @@ export const persist = <S extends State>(
   config: StateCreator<S>,
   options: PersistOptions<S>
 ) => (set: SetState<S>, get: GetState<S>, api: StoreApi<S>): S => {
+  
+  const storageDummy = {
+    getItem: () => null,
+    setItem: () => {},
+  }
+
   const {
     name,
-    storage = typeof localStorage !== 'undefined'
-      ? localStorage
-      : {
-          getItem: () => null,
-          setItem: () => {},
-        },
+    storage: providedStorage,
     serialize = JSON.stringify,
     deserialize = JSON.parse,
   } = options || {}
+
+  const storage = typeof window === 'undefined' ? storageDummy : typeof providedStorage === 'string' ? window[providedStorage] as StateStorage : localStorage
 
   const state = config(
     (payload) => {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -132,8 +132,7 @@ export const persist = <S extends State>(
   config: StateCreator<S>,
   options: PersistOptions<S>
 ) => (set: SetState<S>, get: GetState<S>, api: StoreApi<S>): S => {
-  
-  const storageDummy = {
+  const storageDummy: StateStorage = {
     getItem: () => null,
     setItem: () => {},
   }
@@ -145,7 +144,12 @@ export const persist = <S extends State>(
     deserialize = JSON.parse,
   } = options || {}
 
-  const storage = typeof window === 'undefined' ? storageDummy : typeof providedStorage === 'string' ? window[providedStorage] as StateStorage : localStorage
+  const storage =
+    typeof window === 'undefined'
+      ? storageDummy
+      : typeof providedStorage === 'string'
+      ? window[providedStorage]
+      : providedStorage || localStorage
 
   const state = config(
     (payload) => {


### PR DESCRIPTION
Hi there @AnatoleLucet and @dai-shi ! 

After the middleware [localStorage PR](https://github.com/pmndrs/zustand/pull/246) was closed I quickly ran into the situation where we actually wanted to persist state in session. I can imagine though that most developers wouldn't actually want this as the store persist in memory most of the time - but in our specific case we have multiple front-ends hosted on the same domain and the user would switch between them on multiple occasions in the same session, where we actually wanted to get back the stored data when they would come back to our frontend where the Zustand store was initially created. 

Of course it's possible to pass window.sessionStorage, but you are left doing the same check that initially had to be done for localStorage in order to make it work in SSR. Allowing the user to pass 'localStorage' and 'sessionStorage' as string options and retrieving the apis from the window if it's defined solves it - but not sure if this is a welcome change since @dai-shi actually preferred not checking window. 

Let me know what you think