### PR TITLE
Use Draft<T> in immer typescript middleware

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -303,9 +303,10 @@ For a TS example see the following [discussion](https://github.com/pmndrs/zustan
 
 ```ts
 import { State, StateCreator } from 'zustand'
+import produce, { Draft } from 'immer'
 
 const immer = <T extends State>(
-  config: StateCreator<T, (fn: (draft: T) => void) => void>
+  config: StateCreator<T, (fn: (draft: Draft<T>) => void) => void>
 ): StateCreator<T> => (set, get, api) =>
   config((fn) => set(produce(fn) as (state: T) => T), get, api)
 ```


### PR DESCRIPTION
This was discovered because I defined my state with a bunch of `readonly`s and receiving the error that the property wasn't updated.

See also: https://immerjs.github.io/immer/docs/typescript