### PR TITLE
feat: callback after persist

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -128,12 +128,12 @@ type PersistOptions<S> = {
   deserialize?: (str: string) => S | Promise<S>
   blacklist?: (keyof S)[]
   whitelist?: (keyof S)[]
+  postRehydrationMiddleware?: () => void
 }
 
 export const persist = <S extends State>(
   config: StateCreator<S>,
-  options: PersistOptions<S>,
-  callback?: () => void
+  options: PersistOptions<S>
 ) => (set: SetState<S>, get: GetState<S>, api: StoreApi<S>): S => {
   const {
     name,
@@ -147,6 +147,7 @@ export const persist = <S extends State>(
     deserialize = JSON.parse,
     blacklist,
     whitelist,
+    postRehydrationMiddleware,
   } = options || {}
 
   const setItem = async () => {
@@ -185,7 +186,7 @@ export const persist = <S extends State>(
     } catch (e) {
       console.error(new Error(`Unable to get to stored state in "${name}"`))
     } finally {
-      callback?.()
+      postRehydrationMiddleware?.()
     }
   })()
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -132,7 +132,8 @@ type PersistOptions<S> = {
 
 export const persist = <S extends State>(
   config: StateCreator<S>,
-  options: PersistOptions<S>
+  options: PersistOptions<S>,
+  callback?: () => void
 ) => (set: SetState<S>, get: GetState<S>, api: StoreApi<S>): S => {
   const {
     name,
@@ -183,6 +184,8 @@ export const persist = <S extends State>(
       if (storedState) set(await deserialize(storedState))
     } catch (e) {
       console.error(new Error(`Unable to get to stored state in "${name}"`))
+    } finally {
+      callback?.()
     }
   })()
 


### PR DESCRIPTION
A callback after ~~persisting~~ rehydration may be helpful.
E.g. in the scenario below, where I need to prevent unnecessary redirection before the store ~~persisting~~ rehydration is done.
```javascript
const PrivateRoute: React.FC<RouteProps> = React.memo((props) => {
  const hasSession = useSessionStore(selectHasSession);

  if (hasSession) {
    return <Route {...props} />;
  }
  return <Redirect to={RootRoutes.LOGIN} />;
});
```

The initial store looks like that:
```javascript
const store = (set: SetState<State>) => ({
  loading: false,
  hasSession: false,
  login: loginAction(set),
  logout: logoutAction(set),
});
```
So in the initial state I have the `hasSession` field set as `false`, and after the store rehydration it will change to `true`. This case implies the unnecesary redirection before the rehydration is done.

The callback after the ~~persisting~~ rehydration would help in this scenario, as I may construct the Promise to watch ~~the store rehydration~~ it:
``` javascript
let onRehydrated: () => void;
export const sessionRehydration = new Promise((res) => {
  onRehydrated = res;
});

const persistedStore = persist(
  store,
  {name: STORE_NAME},
  () => onRehydrated(),
);

export const useStore = create<State>(persistedStore);
```
```javascript
const PrivateRoute: React.FC<RouteProps> = React.memo((props) => {
  const [rehydrated, setRehydrated] = useState(false);
  const hasSession = useSessionStore(selectHasSession);

  useEffect(() => {
    sessionRehydration.then(() => {
      setRehydrated(true);
    });
  }, []);

  if (!rehydrated) {
    return null;
  }
  if (hasSession) {
    return <Route {...props} />;
  }
  return <Redirect to={RootRoutes.LOGIN} />;
});
``` 

This is inspired by the same mechanism in the redux-persist :-)

Edit: sorry for confusing "persisting" with "rehydration" in the description. I just read it second time and catch this mistake.