### PR TITLE
Proposal:  useStoreProxy hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,3 +125,32 @@ export default function create<TState extends State>(
 
   return useStore
 }
+
+/**
+ * Returns a proxy to a Zustand store that allows more convenient access to a store's
+ * properties in a reactive manner.
+ *
+ * @param store The Zustand store to proxy.
+ */
+export const useStoreProxy = <T extends State>(store: UseStore<T>): T => {
+  return new Proxy<Record<any, any>>(
+    {},
+    {
+      get: (cache, prop: keyof T) => {
+        /* Memoize store access */
+        if (!cache.hasOwnProperty(prop)) cache[prop] = store((s) => s[prop])
+
+        return cache[prop]
+      },
+
+      set: (_cache, prop, _value) => {
+        console.error(
+          `You tried to write to the "${String(
+            prop
+          )}" property of a Zustand snapshot, which is not supported.`
+        )
+        return false
+      },
+    }
+  )
+}

--- a/tests/useStoreProxy.test.tsx
+++ b/tests/useStoreProxy.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+import { fireEvent, render } from '@testing-library/react'
+import create, { useStoreProxy } from '../src'
+
+describe('useStoreProxy', () => {
+  it('gives access to the store', async () => {
+    const useStore = create<any>((set) => ({
+      count: 0,
+      inc: () => set((state) => ({ count: state.count + 1 })),
+    }))
+
+    function Counter() {
+      const { count, inc } = useStoreProxy(useStore)
+      React.useEffect(inc, [inc])
+      return <div>count: {count}</div>
+    }
+
+    const { findByText } = render(<Counter />)
+
+    await findByText('count: 1')
+  })
+
+  it('only re-renders if selected state has changed', async () => {
+    const store = create<any>((set) => ({
+      foo: 0,
+      bar: 0,
+      inc: (what: 'foo' | 'bar') =>
+        set((state) => ({ [what]: state[what] + 1 })),
+    }))
+    let fooCounterRenderCount = 0
+    let barCounterRenderCount = 0
+    let controlRenderCount = 0
+
+    function FooCounter() {
+      const { foo } = useStoreProxy(store)
+      fooCounterRenderCount++
+      return <div>Foo: {foo}</div>
+    }
+
+    function BarCounter() {
+      const snapshot = useStoreProxy(store)
+      barCounterRenderCount++
+      return <div>Bar: {snapshot.bar}</div>
+    }
+
+    function Buttons() {
+      const { inc } = useStoreProxy(store)
+      controlRenderCount++
+      return (
+        <>
+          <button onClick={() => inc('foo')}>Increase Foo</button>
+          <button onClick={() => inc('bar')}>Increase Bar</button>
+        </>
+      )
+    }
+
+    const { getByText, findByText } = render(
+      <>
+        <FooCounter />
+        <BarCounter />
+        <Buttons />
+      </>
+    )
+
+    fireEvent.click(getByText('Increase Foo'))
+    fireEvent.click(getByText('Increase Bar'))
+    fireEvent.click(getByText('Increase Bar'))
+
+    await findByText('Foo: 1')
+    await findByText('Bar: 2')
+
+    expect(fooCounterRenderCount).toBe(2)
+    expect(barCounterRenderCount).toBe(3)
+    expect(controlRenderCount).toBe(1)
+  })
+})


### PR DESCRIPTION
### Summary

This is a **proposal** for a new hook named `useStoreProxy`. This hook wraps around a store created with zustand's `create` function and provides what I feel is more convenient access to the store data while maintaining reactive properties. It's inspired by both valtio and me getting tired of writing selector functions:

```ts
const FooCounter = () => {
  const snapshot = useStoreProxy(store)
  return <p>Foo: {snapshot.foo}</p>
}
```

Or:

```ts
const FooCounter = () => {
  const { foo } = useStoreProxy(store)
  return <p>Foo: {foo}</p>
}
```

Both of these will only rerender if any property of the snapshot is accessed, and only if that specific property is changed: essentially, `useStoryProxy(store).foo` is 100% equivalent to `store(s => s.foo)`.

Accessing multiple values reactively becomes very straight-forward:

```ts
const ClickyGame = () => {
  const snapshot = useStoreProxy(store)

  return (
    <>
      <p>Count: {snapshot.count}</p>
      <button onClick={snapshot.api.increaseCounter} />
    </>
  )
}
```

The implementation makes use of a Proxy object, so the usual caveats apply. It should be noted that I've added code to the Proxy that specifically _forbids_ setting instead of reading state.

### Example Sandbox:

https://codesandbox.io/s/broken-https-bgq29?file=/src/App.tsx

### Caveats:

- It uses a Proxy, so it will only work in environments that support it.
- For non-shallow stores, accessing deeper properties will not be as efficient as doing it through a selector function. For example, in the `ClickyGame` example above, `snapshot.api.increaseCounter` will make the component re-render every time `snapshot.api` changes, not `snapshot.api.increaseCounter`. Theoretically, there could be some magic here to wrap nested objects in similar proxies, but this would possible be non-trivial, and may move Zustand too close to Valtio.

### Checklist:

- [x] Implementation
- [x] Tests
- [ ] Feedback? :)
- [ ] Documentation
- [ ] Naming (maybe there's something better than `useStoreProxy`?)

### Complementary Kitten Picture:

![image](https://user-images.githubusercontent.com/1061/102262798-d1b28c00-3f13-11eb-875c-c87e6c76d536.png)
