### PR TITLE
fixed an issue in type infering while using eq function in hooks

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -45,7 +45,7 @@ export default function create<TState extends State>(
       state = replace
         ? (nextState as TState)
         : Object.assign({}, state, nextState)
-      listeners.forEach(listener => listener(state, previousState))
+      listeners.forEach((listener) => listener(state, previousState))
     }
   }
 

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -3,7 +3,7 @@ export type PartialState<T extends State> =
   | Partial<T>
   | ((state: T) => Partial<T>)
 export type StateSelector<T extends State, U> = (state: T) => U
-export type EqualityChecker<T> = (state: T, newState: unknown) => boolean
+export type EqualityChecker<T> = (state: T, newState: T) => boolean
 export type StateListener<T> = (state: T, previousState: T) => void
 export type StateSliceListener<T> = (slice: T, previousSlice: T) => void
 export interface Subscribe<T extends State> {
@@ -45,7 +45,7 @@ export default function create<TState extends State>(
       state = replace
         ? (nextState as TState)
         : Object.assign({}, state, nextState)
-      listeners.forEach((listener) => listener(state, previousState))
+      listeners.forEach(listener => listener(state, previousState))
     }
   }
 

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -1,6 +1,11 @@
-import React from 'react'
-import ReactDOM from 'react-dom'
-import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import React from "react";
+import ReactDOM from "react-dom";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render
+  } from "@testing-library/react";
 import create, {
   State,
   StateListener,
@@ -82,19 +87,19 @@ it('uses the store with selectors', async () => {
 })
 
 it('uses the store with a selector and equality checker', async () => {
-  const useStore = create(() => ({ value: 0 }))
+  const useStore = create(() => ({ item: { value: 0 } }))
   const { setState } = useStore
   let renderCount = 0
 
   function Component() {
     // Prevent re-render if new value === 1.
-    const value = useStore(
-      (s) => s.value,
-      (_, newValue) => newValue === 1
+    const item = useStore(
+      (s) => s.item,
+      (_, newItem) => newItem.value === 1
     )
     return (
       <div>
-        renderCount: {++renderCount}, value: {value}
+        renderCount: {++renderCount}, value: {item.value}
       </div>
     )
   }
@@ -104,11 +109,11 @@ it('uses the store with a selector and equality checker', async () => {
   await findByText('renderCount: 1, value: 0')
 
   // This will not cause a re-render.
-  act(() => setState({ value: 1 }))
+  act(() => setState({ item: { value: 1 } }))
   await findByText('renderCount: 1, value: 0')
 
   // This will cause a re-render.
-  act(() => setState({ value: 2 }))
+  act(() => setState({ item: { value: 2 } }))
   await findByText('renderCount: 2, value: 2')
 })
 

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -1,11 +1,6 @@
-import React from "react";
-import ReactDOM from "react-dom";
-import {
-  act,
-  cleanup,
-  fireEvent,
-  render
-  } from "@testing-library/react";
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import create, {
   State,
   StateListener,


### PR DESCRIPTION
Typescript could not properly infer type of newState in state equality function.

```js
//new is typed as unknown giving type errors
const state = useSomeState(s => s.item, (oldItem, newItem) => oldItem.id === newItem.id)
```
After that change above snippet compiles and works properly.