### PR TITLE
docs: add testing section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -402,3 +402,34 @@ const useStore = create(
   ),
 )
 ```
+
+## Testing
+
+When running tests, the stores are not automatically reset before each test run. 
+
+Thus, there can be cases where the state of one test can affect another. To make sure all tests run with a pristine store state, you can mock `zustand` during testing and replace it with the following code:
+
+```jsx
+import actualCreate from 'zustand';
+
+// a variable to hold reset functions for all stores declared in the app
+const storeResetFns = new Set();
+
+// when creating a store, we get its initial state, create a reset function and add it in the set
+const create = createState => {
+  const store = actualCreate(createState);
+  const initialState = store.getState();
+  storeResetFns.add(() => store.setState(initialState, true));
+
+  return store;
+};
+
+// Reset all stores after each test run
+afterEach(() => {
+  storeResetFns.forEach(resetFn => resetFn());
+});
+
+export default create;
+```
+
+The way you can mock a depedency depends on your test runner. In [jest](https://jestjs.io/), you can create a `__mocks__/zustand.js` and place the code there.

--- a/readme.md
+++ b/readme.md
@@ -405,31 +405,4 @@ const useStore = create(
 
 ## Testing
 
-When running tests, the stores are not automatically reset before each test run. 
-
-Thus, there can be cases where the state of one test can affect another. To make sure all tests run with a pristine store state, you can mock `zustand` during testing and replace it with the following code:
-
-```jsx
-import actualCreate from 'zustand';
-
-// a variable to hold reset functions for all stores declared in the app
-const storeResetFns = new Set();
-
-// when creating a store, we get its initial state, create a reset function and add it in the set
-const create = createState => {
-  const store = actualCreate(createState);
-  const initialState = store.getState();
-  storeResetFns.add(() => store.setState(initialState, true));
-
-  return store;
-};
-
-// Reset all stores after each test run
-afterEach(() => {
-  storeResetFns.forEach(resetFn => resetFn());
-});
-
-export default create;
-```
-
-The way you can mock a depedency depends on your test runner. In [jest](https://jestjs.io/), you can create a `__mocks__/zustand.js` and place the code there.
+For information regarding testing with Zustand, visit the dedicated [Wiki page](https://github.com/pmndrs/zustand/wiki/Testing).


### PR DESCRIPTION
## Background

This PR adds a testing section in `README.md`, showcasing how someone can make sure that all of the tests run with the same (pristine) `zustand` store state.

The pattern includes mocking the original `zustand` export and replacing it with a "mocked" version that automatically resets all stores after each test. This pattern has been showcased for `jest`, but it can easily be extended to other test runners as well.

## Changes

- Add testing section in README

## Testing

- Github Markdown Preview

