### PR TITLE
docs: add comment regarding TS State typing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -379,6 +379,8 @@ devtools takes the store function as its first argument, optionally you can name
 ## TypeScript
 
 ```tsx
+// Make sure that `State` is a `type` and not an `interface`, else the typescript compiler 
+// will complain about a missing index signature
 type State = {
   bears: number
   increase: (by: number) => void

--- a/readme.md
+++ b/readme.md
@@ -379,9 +379,23 @@ devtools takes the store function as its first argument, optionally you can name
 ## TypeScript
 
 ```tsx
-// Make sure that `State` is a `type` and not an `interface`, else the typescript compiler 
-// will complain about a missing index signature
 type State = {
+  bears: number
+  increase: (by: number) => void
+}
+
+const useStore = create<State>(set => ({
+  bears: 0,
+  increase: (by) => set(state => ({ bears: state.bears + by })),
+}))
+```
+
+You can also use an `interface`:
+
+```tsx
+import { State as ZustandState } from 'zustand';
+
+interface State extends ZustandState {
   bears: number
   increase: (by: number) => void
 }

--- a/readme.md
+++ b/readme.md
@@ -399,11 +399,6 @@ interface BearState extends State {
   bears: number
   increase: (by: number) => void
 }
-
-const useStore = create<BearState>(set => ({
-  bears: 0,
-  increase: (by) => set(state => ({ bears: state.bears + by })),
-}))
 ```
 
 Or, use `combine` and let tsc infer types.

--- a/readme.md
+++ b/readme.md
@@ -393,14 +393,14 @@ const useStore = create<State>(set => ({
 You can also use an `interface`:
 
 ```tsx
-import { State as ZustandState } from 'zustand';
+import { State } from 'zustand';
 
-interface State extends ZustandState {
+interface BearState extends State {
   bears: number
   increase: (by: number) => void
 }
 
-const useStore = create<State>(set => ({
+const useStore = create<BearState>(set => ({
   bears: 0,
   increase: (by) => set(state => ({ bears: state.bears + by })),
 }))


### PR DESCRIPTION
## Background

The `State` typing provided to the `create` function must extend `Record`. Thus, the `State` typing that users provide needs to be a `type` and not an `interface`. This PR adds a small comment in the TS Recipe to make that clear.

Closes #213 

## Changes

- Add comment in TS recipe's codee

## Testing

- Github markdown preview