### PR TITLE
Readme: be more explicit about equality function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -76,7 +76,16 @@ const nuts = useStore(state => state.nuts)
 const honey = useStore(state => state.honey)
 ```
 
-If you want to construct a single object with multiple state-picks inside, similar to redux's mapStateToProps, you can tell zustand that you want the object to be diffed shallowly by passing an alternative equality function.
+For more control over re-rendering, you may provide an alternative equality function on the second argument.
+
+```jsx
+const treats = useStore(
+  state => state.treats,
+  (oldTreats, newTreats) => compare(oldTreats, newTreats)
+)
+```
+
+For instance, if you want to construct a single object with multiple state-picks inside, similar to redux's mapStateToProps, you can tell zustand that you want the object to be diffed shallowly by passing the `shallow` equality function.
 
 ```jsx
 import shallow from 'zustand/shallow'


### PR DESCRIPTION
Hey!

Although I had already used `shallow`, It took me a while to notice the second argument on the store hook was an equality function, I found it out later reading the typedefs.

I think it would be a good idea (especially for dumb readers like me) to state it more explicitly: "the second argument is an equality function, it has this signature".

Here goes a suggestion. Thank you!