### PR TITLE
Add Combine Store Feature

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,4 @@
-import {
+import create, {
   GetState,
   PartialState,
   SetState,
@@ -258,4 +258,17 @@ export const persist = <S extends State>(
     get,
     api
   )
+}
+
+export const combineStores = <T extends State>(
+  ...storesToCombine: StoreApi<any>[]
+): StoreApi<T> => {
+  let values = {}
+
+  storesToCombine.forEach((store) => {
+    values = Object.assign(values, store.getState())
+  })
+
+  let combinedStore: StoreApi<any> = create(() => ({ ...values }))
+  return combinedStore
 }


### PR DESCRIPTION
I made a way to combine unlimited amount of stores to create one base store. I tested it, everything works amazing, even the setState function. Yet, as you can see from the code, it can't totally infer the types if we don't provide an interface. I hope it can be fixed.

```ts
interface IAge extends State {
  age: number
}

interface IName extends State {
  name: string
}

interface IHealth extends State {
  status: boolean
}

const ageState = create<IAge>(() => ({ age: 5 }))
const nameState = create<IName>(() => ({ name: 'zustand' }))
const healthState = create<IHealth>(() => ({ status: true }))

interface combined extends IAge, IName, IHealth {}

const combined = combineStores<combined>(nameState, ageState, healthState)

console.log(combined)
console.log(combined.getState())
console.log(combined.getState().name)
```
Console Results:
![image](https://user-images.githubusercontent.com/63511519/107404763-a7e2a380-6b17-11eb-99a5-49db2f2c47c5.png)

