### PR TITLE
Combine Store Creators

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -259,3 +259,14 @@ export const persist = <S extends State>(
     api
   )
 }
+
+export const combineStateCreators = <TState extends State>(
+  ...stateCreators: StateCreator<any>[]
+): StateCreator<TState> => (set, get, api) => {
+  let values: any = {}
+
+  stateCreators.forEach((sc) => {
+    values = Object.assign({}, values, sc(set, get, api))
+  })
+  return values
+}


### PR DESCRIPTION
**[Request To Do This](https://github.com/pmndrs/zustand/pull/305#issuecomment-778702029)
#305 Was the first request but we had to create stores which will use memory which will also result in slow starts.
#178 Asked for namespacing/slicing and there is slicing. Namespacing is actually a little bit hard for now because when you use set in store creator, you actually can access to the whole store, so instead of prev.count +1, it is prev.counter.count +1, for example.
Maybe namespacing feature can also be added in future, the code won't change much, I will try to implement on top of this, yet it is hard.**




**With this code, you can now create seperate stores and combine them to one single store with all the types and utilities.**

**Almost no change on bundle size, it is just 11 new line**

**[Try on Code Sandbox](https://codesandbox.io/s/zustand-combine-state-creators-y0eev)**





**Usage is pretty simple, first create store creators**
![image](https://user-images.githubusercontent.com/63511519/107871824-13c96100-6eb6-11eb-8fb6-f6179ec8af63.png)

**Then combine them**
![image](https://user-images.githubusercontent.com/63511519/107871816-044a1800-6eb6-11eb-8d25-0c5a46eed11e.png)

**Usage is also same**
![image](https://user-images.githubusercontent.com/63511519/107871832-25ab0400-6eb6-11eb-828f-411171c55301.png)




