### PR TITLE
Create a just ESM version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,29 @@
   "files": [
     "**"
   ],
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "default": "./index.cjs.js"
+    },
+    "./vanilla": {
+      "types": "./vanilla.d.ts",
+      "import": "./vanilla.module.js",
+      "default": "./vanilla.js"
+    },
+    "./middleware": {
+      "types": "./middleware.d.ts",
+      "import": "./middleware.module.js",
+      "default": "./middleware.js"
+    },
+    "./shallow": {
+      "types": "./shallow.d.ts",
+      "import": "./shallow.module.js",
+      "default": "./shallow.js"
+    }
+  },
   "sideEffects": false,
   "scripts": {
     "prebuild": "shx rm -rf dist",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -97,9 +97,9 @@ export default [
   createCommonJSConfig('src/vanilla.ts', 'dist/vanilla.js'),
 
   // Create a purely ESM version, can be imported from `zustand/esm`
-  createESMConfig('src/vanilla.ts', 'dist/esm/vanilla.js'),
-  createESMConfig('src/shallow.ts', 'dist/esm/shallow.js'),
-  createESMConfig('src/index.ts', 'dist/esm/index.js'),
-  // I dont get the one below to succeed with rollup :(
-  // createModernESMConfig('src/middleware.ts', 'dist/esm/middleware.js'),
+  createESMConfig('src/vanilla.ts', 'dist/vanilla.module.js'),
+  createESMConfig('src/shallow.ts', 'dist/shallow.module.js'),
+  createESMConfig('src/index.ts', 'dist/index.module.js'),
+  // get this below to succeed with rollup ... fails currently
+  // createModernESMConfig('src/middleware.ts', 'dist/middleware.module.js'),
 ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -99,7 +99,6 @@ export default [
   // Create a purely ESM version, can be imported from `zustand/esm`
   createESMConfig('src/vanilla.ts', 'dist/vanilla.module.js'),
   createESMConfig('src/shallow.ts', 'dist/shallow.module.js'),
-  createESMConfig('src/index.ts', 'dist/index.module.js'),
   // get this below to succeed with rollup ... fails currently
   // createModernESMConfig('src/middleware.ts', 'dist/middleware.module.js'),
 ]

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -95,4 +95,11 @@ export default [
   createCommonJSConfig('src/shallow.ts', 'dist/shallow.js'),
   createCommonJSConfig('src/middleware.ts', 'dist/middleware.js'),
   createCommonJSConfig('src/vanilla.ts', 'dist/vanilla.js'),
+
+  // Create a purely ESM version, can be imported from `zustand/esm`
+  createESMConfig('src/vanilla.ts', 'dist/esm/vanilla.js'),
+  createESMConfig('src/shallow.ts', 'dist/esm/shallow.js'),
+  createESMConfig('src/index.ts', 'dist/esm/index.js'),
+  // I dont get the one below to succeed with rollup :(
+  // createModernESMConfig('src/middleware.ts', 'dist/esm/middleware.js'),
 ]


### PR DESCRIPTION
This PR tries to provide a solution for a pure-ESM package setup.
Solving #334 

This generates a pure ESM version which can be imported like `import create from "zustand/esm"`.
Not sure if this something of interest or if there is a much better and simpler solution.
Looking fwd to feedback.

In this file https://codeberg.org/wolframkriesing/bug-exploration-zustand-and-esm/src/branch/main/src/vanilla-esm.test.js I wrote tests that show this works. Might be a good idea putting them in here!?

Open issues
- [ ] build the middleware.ts