### PR TITLE
fix: revert babel runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "@babel/core": "^7.13.14",
     "@babel/plugin-external-helpers": "^7.12.13",
     "@babel/plugin-transform-react-jsx": "^7.13.12",
+    "@babel/plugin-transform-runtime": "^7.13.10",
     "@babel/plugin-transform-typescript": "^7.13.0",
     "@babel/preset-env": "^7.13.12",
     "@rollup/plugin-babel": "^5.3.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,8 +24,12 @@ function getEsbuild(target) {
 function getBabelOptions(targets) {
   const config = createBabelConfig({ env: (env) => env === 'build' }, targets)
   if (targets.ie) {
-    config.plugins = [...config.plugins, '@babel/plugin-transform-regenerator']
-    config.babelHelpers = 'bundled'
+    config.plugins = [
+      ...config.plugins,
+      '@babel/plugin-transform-regenerator',
+      ['@babel/plugin-transform-runtime', { helpers: true, regenerator: true }],
+    ]
+    config.babelHelpers = 'runtime'
   }
   return {
     ...config,

--- a/yarn.lock
+++ b/yarn.lock
@@ -708,6 +708,18 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
 
+"@babel/plugin-transform-runtime@^7.13.10":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.13.10.tgz#a1e40d22e2bf570c591c9c7e5ab42d6bf1e419e1"
+  integrity sha512-Y5k8ipgfvz5d/76tx7JYbKQTcgFSU6VgJ3kKQv4zGTKr+a9T/KBvfRvGtSFgKDQGt/DBykQixV0vNWKIdzWErA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.13"
+    "@babel/helper-plugin-utils" "^7.13.0"
+    babel-plugin-polyfill-corejs2 "^0.1.4"
+    babel-plugin-polyfill-corejs3 "^0.1.3"
+    babel-plugin-polyfill-regenerator "^0.1.2"
+    semver "^6.3.0"
+
 "@babel/plugin-transform-shorthand-properties@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.13.tgz#db755732b70c539d504c6390d9ce90fe64aff7ad"


### PR DESCRIPTION
It seems like our trial (`'bundled'`) in #343 was not successful.
We can revisit it, but for now we should fix v3.4.0.

This reverts babel config for CJS to that in v3.3.3. Resolve #351.

