### PR TITLE
update readme.md to link to the 3rd-party wiki

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -450,3 +450,7 @@ const useStore = create(
 ## Testing
 
 For information regarding testing with Zustand, visit the dedicated [Wiki page](https://github.com/pmndrs/zustand/wiki/Testing).
+
+## 3rd-Party Libraries
+
+Some users may want to extends Zustand's feature set which can be done using 3rd-party libraries made by the community. For information regarding 3rd-party libraries with Zustand, visit the dedicated [Wiki page](https://github.com/pmndrs/zustand/wiki/3rd-Party-Libraries).


### PR DESCRIPTION
@dai-shi requested we add a wiki page containing a list of 3rd-party libs that work with zustand. I have added a link to the readme.md to the wiki page by copying the style used to link to the testing wiki page.

Please give me any comments or critiques! 