### PR TITLE
feat: add import of store state json to devtools middleware

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -77,9 +77,9 @@
     }
   },
   "middleware.js": {
-    "bundled": 4870,
-    "minified": 2586,
-    "gzipped": 1180,
+    "bundled": 5547,
+    "minified": 2945,
+    "gzipped": 1293,
     "treeshaked": {
       "rollup": {
         "code": 0,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -94,6 +94,26 @@ export const devtools = <S extends State>(
         message.payload?.type === 'COMMIT'
       ) {
         api.devtools.init(api.getState())
+      } else if (
+        message.type === 'DISPATCH' &&
+        message.payload?.type === 'IMPORT_STATE'
+      ) {
+        const actions = message.payload.nextLiftedState?.actionsById
+        const computedStates =
+          message.payload.nextLiftedState?.computedStates || []
+
+        computedStates.forEach(
+          ({ state }: { state: PartialState<S> }, index: number) => {
+            const action = actions[index] || api.devtools.prefix + 'setState'
+
+            if (index === 0) {
+              api.devtools.init(state)
+            } else {
+              savedSetState(state)
+              api.devtools.send(action, api.getState())
+            }
+          }
+        )
       }
     })
     api.devtools.init(initialState)


### PR DESCRIPTION
Currently it is possible to export the state of the store in redux devtools, but it is not possible to import, this PR adds this functionality.


https://user-images.githubusercontent.com/57798333/116010627-0ba94280-a618-11eb-8f1a-101b57000576.mov