### PR TITLE
fix: remove mandatory index signature

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -425,6 +425,7 @@ interface BearState {
   increase: (by: number) => void
 }
 
+// And it is going to work for both
 const useStore = create<BearState>(set => ({
   bears: 0,
   increase: (by) => set(state => ({ bears: state.bears + by })),

--- a/readme.md
+++ b/readme.md
@@ -413,26 +413,22 @@ devtools will only log actions from each separated store unlike in a typical *co
 ## TypeScript
 
 ```tsx
-type State = {
+// You can use `type`
+type BearState = {
   bears: number
   increase: (by: number) => void
 }
 
-const useStore = create<State>(set => ({
+// Or `interface`
+interface BearState {
+  bears: number
+  increase: (by: number) => void
+}
+
+const useStore = create<BearState>(set => ({
   bears: 0,
   increase: (by) => set(state => ({ bears: state.bears + by })),
 }))
-```
-
-You can also use an `interface`:
-
-```tsx
-import { State } from 'zustand';
-
-interface BearState extends State {
-  bears: number
-  increase: (by: number) => void
-}
 ```
 
 Or, use `combine` and let tsc infer types.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -103,7 +103,7 @@ export const devtools = <S extends State>(
           message.payload.nextLiftedState?.computedStates || []
 
         computedStates.forEach(
-          ({ state }: { state: PartialState<S, keyof S> }, index: number) => {
+          ({ state }: { state: PartialState<S> }, index: number) => {
             const action = actions[index] || api.devtools.prefix + 'setState'
 
             if (index === 0) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -103,7 +103,7 @@ export const devtools = <S extends State>(
           message.payload.nextLiftedState?.computedStates || []
 
         computedStates.forEach(
-          ({ state }: { state: PartialState<S> }, index: number) => {
+          ({ state }: { state: PartialState<S, keyof S> }, index: number) => {
             const action = actions[index] || api.devtools.prefix + 'setState'
 
             if (index === 0) {
@@ -136,9 +136,9 @@ export const combine = <
     {},
     initialState,
     create(
-      set as SetState<PrimaryState>,
+      (set as unknown) as SetState<PrimaryState>,
       get as GetState<PrimaryState>,
-      api as StoreApi<PrimaryState>
+      (api as unknown) as StoreApi<PrimaryState>
     )
   )
 
@@ -240,7 +240,8 @@ export const persist = <S extends State>(
 
     if (whitelist) {
       Object.keys(state).forEach((key) => {
-        !whitelist.includes(key) && delete state[key]
+        const keyTyped = key as keyof S
+        !whitelist.includes(keyTyped) && delete state[keyTyped]
       })
     }
     if (blacklist) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -239,9 +239,8 @@ export const persist = <S extends State>(
     const state = { ...get() }
 
     if (whitelist) {
-      Object.keys(state).forEach((key) => {
-        const keyTyped = key as keyof S
-        !whitelist.includes(keyTyped) && delete state[keyTyped]
+      ;(Object.keys(state) as (keyof S)[]).forEach((key) => {
+        !whitelist.includes(key) && delete state[key]
       })
     }
     if (blacklist) {

--- a/src/shallow.ts
+++ b/src/shallow.ts
@@ -1,9 +1,4 @@
-type Obj = Record<string | number | symbol, unknown>
-
-export default function shallow<T extends any, U extends any>(
-  objA: T,
-  objB: U
-) {
+export default function shallow<T, U>(objA: T, objB: U) {
   if (Object.is(objA, objB)) {
     return true
   }
@@ -15,14 +10,14 @@ export default function shallow<T extends any, U extends any>(
   ) {
     return false
   }
-  const keysA = Object.keys(objA as object)
-  if (keysA.length !== Object.keys(objB as object).length) {
+  const keysA = Object.keys(objA)
+  if (keysA.length !== Object.keys(objB).length) {
     return false
   }
   for (let i = 0; i < keysA.length; i++) {
     if (
       !Object.prototype.hasOwnProperty.call(objB, keysA[i]) ||
-      !Object.is((objA as Obj)[keysA[i]], (objB as Obj)[keysA[i]])
+      !Object.is(objA[keysA[i] as keyof T], objB[keysA[i] as keyof U])
     ) {
       return false
     }

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -1,4 +1,8 @@
-export type State = Record<string | number | symbol, unknown>
+// https://github.com/microsoft/TypeScript/issues/42825
+// https://github.com/microsoft/TypeScript/issues/41746
+// https://www.typescriptlang.org/play?#code/C4TwDgpgBAysCGwIFUB2BrVB7A7qqAvFAEoQDGWATgCYA8AzsJQJaoDmUAPlKgK4C2AIwiUuUeiCFYANgBoovDNjwA+AFChIsBEgCCqEIRLkqdRi3Zi+QkWIlS5UeAfVqKqRlABmqNJlz4RLQAKlAQAB5IqNT02ogoSgEqABTwlGwAXFDBAJSEKk7pblgewN6o+oZBoRFRMXF6LqnpWbn5hWxqaqxIlF7wZNAAUhDUzHDxUADealBzUABWo8wAcvD8EFnmrJ3zi8sACrgiWdbClGoAvsWlUCBY1PBZI2MTSEYze0tjaxtZAOQATQe8H+slm82+zCOOBOUAAjAAGK5dHx+ZSoZL3R45NQ+SpYkE5IA
+// TLDR; Record<string, any> matches any object, while Record<string, unknown> requires an index signature.
+export type State = Record<string | number | symbol, any>
 // types inspired by setState from React, see:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/6c49e45842358ba59a508e13130791989911430d/types/react/v16/index.d.ts#L489-L495
 export type PartialState<T extends State, K extends keyof T = keyof T> =
@@ -41,7 +45,9 @@ export default function create<TState extends State>(
   const listeners: Set<StateListener<TState>> = new Set()
 
   const setState: SetState<TState> = (partial, replace) => {
-    const nextState = typeof partial === 'function' ? partial(state) : partial
+    // TODO: Fix me once https://github.com/microsoft/TypeScript/issues/37663 is resolved
+    // https://github.com/microsoft/TypeScript/issues/37663#issuecomment-759728342
+    const nextState = partial instanceof Function ? partial(state) : partial
     if (nextState !== state) {
       const previousState = state
       state = replace

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -1,8 +1,4 @@
-// https://github.com/microsoft/TypeScript/issues/42825
-// https://github.com/microsoft/TypeScript/issues/41746
-// https://www.typescriptlang.org/play?#code/C4TwDgpgBAysCGwIFUB2BrVB7A7qqAvFAEoQDGWATgCYA8AzsJQJaoDmUAPlKgK4C2AIwiUuUeiCFYANgBoovDNjwA+AFChIsBEgCCqEIRLkqdRi3Zi+QkWIlS5UeAfVqKqRlABmqNJlz4RLQAKlAQAB5IqNT02ogoSgEqABTwlGwAXFDBAJSEKk7pblgewN6o+oZBoRFRMXF6LqnpWbn5hWxqaqxIlF7wZNAAUhDUzHDxUADealBzUABWo8wAcvD8EFnmrJ3zi8sACrgiWdbClGoAvsWlUCBY1PBZI2MTSEYze0tjaxtZAOQATQe8H+slm82+zCOOBOUAAjAAGK5dHx+ZSoZL3R45NQ+SpYkE5IA
-// TLDR; Record<string, any> matches any object, while Record<string, unknown> requires an index signature.
-export type State = Record<string | number | symbol, any>
+export type State = object
 // types inspired by setState from React, see:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/6c49e45842358ba59a508e13130791989911430d/types/react/v16/index.d.ts#L489-L495
 export type PartialState<T extends State, K extends keyof T = keyof T> =

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -45,9 +45,12 @@ export default function create<TState extends State>(
   const listeners: Set<StateListener<TState>> = new Set()
 
   const setState: SetState<TState> = (partial, replace) => {
-    // TODO: Fix me once https://github.com/microsoft/TypeScript/issues/37663 is resolved
+    // TODO: Remove type assertion once https://github.com/microsoft/TypeScript/issues/37663 is resolved
     // https://github.com/microsoft/TypeScript/issues/37663#issuecomment-759728342
-    const nextState = partial instanceof Function ? partial(state) : partial
+    const nextState =
+      typeof partial === 'function'
+        ? (partial as (state: TState) => TState)(state)
+        : partial
     if (nextState !== state) {
       const previousState = state
       state = replace

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -661,7 +661,7 @@ it('ensures a subscriber is not mistakenly overwritten', async () => {
 })
 
 it('can use exposed types', () => {
-  interface ExampleState extends State {
+  interface ExampleState {
     num: number
     numGet: () => number
     numGetState: () => number

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -677,8 +677,11 @@ it('can use exposed types', () => {
     }
   }
   const selector: StateSelector<ExampleState, number> = (state) => state.num
-  const partial: PartialState<ExampleState> = { num: 2, numGet: () => 2 }
-  const partialFn: PartialState<ExampleState> = (state) => ({
+  const partial: PartialState<ExampleState, 'num' | 'numGet'> = {
+    num: 2,
+    numGet: () => 2,
+  }
+  const partialFn: PartialState<ExampleState, 'num' | 'numGet'> = (state) => ({
     ...state,
     num: 2,
   })
@@ -717,7 +720,7 @@ it('can use exposed types', () => {
 
   function checkAllTypes(
     _getState: GetState<ExampleState>,
-    _partialState: PartialState<ExampleState>,
+    _partialState: PartialState<ExampleState, 'num' | 'numGet'>,
     _setState: SetState<ExampleState>,
     _state: State,
     _stateListener: StateListener<ExampleState>,


### PR DESCRIPTION
Currently, `type State` in `zustand` forces all users to add an index signature to their state interfaces.

```ts
// We have to add 'extends Record<string, any>'
// which adds an index signature that we do not really want
export interface JediStore extends Record<string, any> {
  jediName: string
  jediPower: number
}
export const useChartComposerDataStore = create<JediStore>(...)
```

With this fix the index signature is no longer mandatory.