### PR TITLE
Fix Jest jsdom warning about useLayoutEffect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,8 @@ export * from './vanilla'
 const isSSR =
   typeof window === 'undefined' ||
   !window.navigator ||
-  /ServerSideRendering|^Deno\//.test(window.navigator.userAgent)
+  /ServerSideRendering|^Deno\//.test(window.navigator.userAgent) ||
+  Object.keys(window.navigator).length === 0
 
 const useIsomorphicLayoutEffect = isSSR ? useEffect : useLayoutEffect
 


### PR DESCRIPTION
jsdom mock window.navigator with empty object `window.navigator = {}`

https://github.com/olragon/react-gateway2/runs/2564997519?check_suite_focus=true#step:5:20

```
console.error
    Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://fb.me/react-uselayouteffect-ssr for common fixes.
        in GatewayProvider

      4 |
      5 | export const GatewayProvider = ({ children }) => {
    > 6 |   const [resetRegistry] = useGatewayRegistry(state => [state.resetRegistry])
        |                           ^
      7 |
      8 |   React.useMemo(() => {
      9 |     resetRegistry()

      at printWarning (node_modules/react-dom/cjs/react-dom-server.node.development.js:102:30)
      at error (node_modules/react-dom/cjs/react-dom-server.node.development.js:74:5)
      at Object.useLayoutEffect (node_modules/react-dom/cjs/react-dom-server.node.development.js:1274:5)
      at useLayoutEffect (node_modules/react/cjs/react.development.js:1513:21)
      at useStore (node_modules/zustand/index.js:121:5)
      at GatewayProvider (src/GatewayProvider.js:6:27)
      at processChild (node_modules/react-dom/cjs/react-dom-server.node.development.js:3043:14)
```