### PR TITLE
Fix a return value type of `combine`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -233,7 +233,7 @@ function Component() {
   const scratchRef = useRef(useStore.getState().scratches)
   // Connect to the store on mount, disconnect on unmount, catch state-changes in a reference
   useEffect(() => useStore.subscribe(
-    scratches => (scratchRef.current = scratches), 
+    scratches => (scratchRef.current = scratches),
     state => state.scratches
   ), [])
 ```
@@ -457,14 +457,14 @@ const useStore = create<BearState>(set => ({
 }))
 ```
 
-Or, use `combine` and let tsc infer types.
+Or, use `combine` and let tsc infer types. This merges two states shallowly.
 
 ```tsx
 import { combine } from 'zustand/middleware'
 
 const useStore = create(
   combine(
-    { bears: 0 }, 
+    { bears: 0 },
     (set) => ({ increase: (by: number) => set((state) => ({ bears: state.bears + by })) })
   ),
 )

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -121,6 +121,7 @@ export const devtools = <S extends State>(
   return initialState
 }
 
+type Combine<T, U> = Omit<T, keyof U> & U
 export const combine = <
   PrimaryState extends State,
   SecondaryState extends State
@@ -131,13 +132,13 @@ export const combine = <
     get: GetState<PrimaryState>,
     api: StoreApi<PrimaryState>
   ) => SecondaryState
-): StateCreator<PrimaryState & SecondaryState> => (set, get, api) =>
+): StateCreator<Combine<PrimaryState, SecondaryState>> => (set, get, api) =>
   Object.assign(
     {},
     initialState,
     create(
       (set as unknown) as SetState<PrimaryState>,
-      get as GetState<PrimaryState>,
+      (get as unknown) as GetState<PrimaryState>,
       (api as unknown) as StoreApi<PrimaryState>
     )
   )


### PR DESCRIPTION
# Summary
Bugfix for TypeScript.

Currently `combine` function accepts two states and merges them using `Object.assign` , but the type is `PrimaryState & SecondaryState` . The Intersection Type ( `&` ) merges deeply unlike shallow merge using `Object.assign` and Spread Operators `...` .

I added `Combine` type, which merges two generic types shallowly like the following, and use it for the return type of `combine` .

```ts
type A = {
  foo: string;
  bar: {
    child1: string;
    child2: number;
  };
};
type B = {
  baz: number;
  bar: {
    child3: boolean;
  };
};

type C = Combine<A, B>;
// {
//    foo: string;
//    baz: number;
//    bar: {
//      child3: boolean;
//    };
// };

// The above is equal to `{ ...a, ...b }` and `Object.assign({}, a, b)`
```


# Bugs
The current version doesn't match types and actual behaviors like the following case.

```ts
const initialStates = {
  posts: postsState, // { xxx: string }
  comments: commentsState,
};
const actions = {
  posts: postsActions, // { yyy: Function }
  comments: commentsActions,
};

const store = craete(combine(initialStates, actions));
store.getState().posts.xxx; // OK in TypeScript, but runtime error (undefined)
store.getState().posts.yyy; // OK in TypeScript, and OK in runtime
```
