### PR TITLE
Expose `StateStorage` type and update persist midlware documentation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -346,7 +346,7 @@ export const useStore = create(persist(
 ```
 
 <details>
-<summary>How to use custom storage options</summary>
+<summary>How to use custom storage engines</summary>
 
 You can use other storage methods outside of `localStorage` and `sessionStorage` by defining your own `StateStorage`. A custom `StateStorage` object also allows you to write middlware for the persisted store when getting or setting store data.
 

--- a/readme.md
+++ b/readme.md
@@ -345,6 +345,42 @@ export const useStore = create(persist(
 ))
 ```
 
+<details>
+<summary>How to use custom storage options</summary>
+
+You can use other storage methods outside of `localStorage` and `sessionStorage` by defining your own `StateStorage`. A custom `StateStorage` object also allows you to write middlware for the persisted store when getting or setting store data.
+
+```tsx
+import create from "zustand"
+import { persist, StateStorage } from "zustand/middleware"
+import { get, set } from 'idb-keyval' // can use anything: IndexedDB, Ionic Storage, etc.
+
+// Custom storage object
+const storage: StateStorage = {
+  getItem: async (name: string): Promise<string | null> => {
+    console.log(name, "has been retrieved");
+    return await get(name) || null
+  },
+  setItem: async (name: string, value: string): Promise<void> => {
+    console.log(name, "with value", value, "has been saved");
+    set(name, value)
+  }
+}
+
+export const useStore = create(persist(
+  (set, get) => ({
+    fishes: 0,
+    addAFish: () => set({ fishes: get().fishes + 1 })
+  }),
+  {
+    name: "food-storage", // unique name
+    getStorage: () => storage,
+  }
+))
+```
+
+</details>
+
 ## Can't live without redux-like reducers and action types?
 
 ```jsx

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -143,7 +143,7 @@ export const combine = <
     )
   )
 
-type StateStorage = {
+export type StateStorage = {
   getItem: (name: string) => string | null | Promise<string | null>
   setItem: (name: string, value: string) => void | Promise<void>
 }


### PR DESCRIPTION
Thanks for zustand!

I've added a details section that explains how to use custom storage engines for the `persist` middleware. The type `StateStorage` is exposed for TS users of zustand. 

Relates to discussion on issue #404 on how to use `IndexedDB` as the storage engine. 

Please let me know any changes and I would be happy to address them.