### PR TITLE
Remove usage of `any` from tests

### DIFF
--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -212,7 +212,7 @@ it('can update the selector', async () => {
 
 it('can update the equality checker', async () => {
   type State = { value: number }
-  type Props = { equalityFn: EqualityChecker<State> }
+  type Props = { equalityFn: EqualityChecker<number> }
   const useStore = create<State>(() => ({ value: 0 }))
   const { setState } = useStore
   const selector: StateSelector<State, number> = (s) => s.value
@@ -256,7 +256,7 @@ it('can call useStore with progressively more arguments', async () => {
 
   let renderCount = 0
   function Component({ selector, equalityFn }: Props) {
-    const value = useStore(selector, equalityFn)
+    const value = useStore(selector as any, equalityFn)
     return (
       <div>
         renderCount: {++renderCount}, value: {JSON.stringify(value)}

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -212,10 +212,10 @@ it('can update the selector', async () => {
 
 it('can update the equality checker', async () => {
   type State = { value: number }
-  type Props = { equalityFn: () => boolean }
+  type Props = { equalityFn: EqualityChecker<State> }
   const useStore = create<State>(() => ({ value: 0 }))
   const { setState } = useStore
-  const selector = (s: State) => s.value
+  const selector: StateSelector<State, number> = (s) => s.value
 
   let renderCount = 0
   function Component({ equalityFn }: Props) {
@@ -251,7 +251,7 @@ it('can call useStore with progressively more arguments', async () => {
     equalityFn?: EqualityChecker<State>
   }
 
-  const useStore = create(() => ({ value: 0 }))
+  const useStore = create<State>(() => ({ value: 0 }))
   const { setState } = useStore
 
   let renderCount = 0

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -376,10 +376,15 @@ it('can throw an error in equality checker', async () => {
 })
 
 it('can get the store', () => {
-  const { getState } = create<any>((_, get) => ({
+  type State = {
+    value: number
+    getState1: () => State
+    getState2: () => State
+  }
+  const { getState } = create<State>((_, get) => ({
     value: 1,
     getState1: () => get(),
-    getState2: () => getState(),
+    getState2: (): State => getState(),
   }))
 
   expect(getState().getState1().value).toBe(1)

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -394,15 +394,14 @@ it('can get the store', () => {
 it('can set the store', () => {
   type State = {
     value: number
-    setState1: (v: Arg) => void
-    setState2: (v: Arg) => void
+    setState1: SetState<State>
+    setState2: SetState<State>
   }
-  type Arg = Partial<State> | ((s: State) => Partial<State>)
 
   const { setState, getState } = create<State>((set) => ({
     value: 1,
-    setState1: (v: Arg) => set(v),
-    setState2: (v: Arg) => setState(v),
+    setState1: (v) => set(v),
+    setState2: (v) => setState(v),
   }))
 
   getState().setState1({ value: 2 })

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -392,19 +392,26 @@ it('can get the store', () => {
 })
 
 it('can set the store', () => {
-  const { setState, getState } = create<any>((set) => ({
+  type State = {
+    value: number
+    setState1: (v: Arg) => void
+    setState2: (v: Arg) => void
+  }
+  type Arg = Partial<State> | ((s: State) => Partial<State>)
+
+  const { setState, getState } = create<State>((set) => ({
     value: 1,
-    setState1: (v: any) => set(v),
-    setState2: (v: any) => setState(v),
+    setState1: (v: Arg) => set(v),
+    setState2: (v: Arg) => setState(v),
   }))
 
   getState().setState1({ value: 2 })
   expect(getState().value).toBe(2)
   getState().setState2({ value: 3 })
   expect(getState().value).toBe(3)
-  getState().setState1((s: any) => ({ value: ++s.value }))
+  getState().setState1((s) => ({ value: ++s.value }))
   expect(getState().value).toBe(4)
-  getState().setState2((s: any) => ({ value: ++s.value }))
+  getState().setState2((s) => ({ value: ++s.value }))
   expect(getState().value).toBe(5)
 })
 

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -296,7 +296,7 @@ it('can throw an error in selector', async () => {
   const useStore = create<State>(() => initialState)
   const { setState } = useStore
   const selector: StateSelector<State, string | void> = (s) =>
-    // @ts-ignore This function is supposed to throw an error
+    // @ts-expect-error This function is supposed to throw an error
     s.value.toUpperCase()
 
   class ErrorBoundary extends React.Component<{}, { hasError: boolean }> {
@@ -340,7 +340,7 @@ it('can throw an error in equality checker', async () => {
   const { setState } = useStore
   const selector: StateSelector<State, State> = (s) => s
   const equalityFn: EqualityChecker<State> = (a, b) =>
-    // @ts-ignore This function is supposed to throw an error
+    // @ts-expect-error This function is supposed to throw an error
     a.value.trim() === b.value?.trim()
 
   class ErrorBoundary extends React.Component<{}, { hasError: boolean }> {

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -248,7 +248,7 @@ it('can call useStore with progressively more arguments', async () => {
   type State = { value: number }
   type Props = {
     selector?: StateSelector<State, number>
-    equalityFn?: EqualityChecker<State>
+    equalityFn?: EqualityChecker<number>
   }
 
   const useStore = create<State>(() => ({ value: 0 }))

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -296,7 +296,7 @@ it('can throw an error in selector', async () => {
   const useStore = create<State>(() => initialState)
   const { setState } = useStore
   const selector: StateSelector<State, string | void> = (s) =>
-    // @ts-ignore Ignore error since the code is supposed to crash here
+    // @ts-ignore This function is supposed to throw an error
     s.value.toUpperCase()
 
   class ErrorBoundary extends React.Component<{}, { hasError: boolean }> {
@@ -340,7 +340,7 @@ it('can throw an error in equality checker', async () => {
   const { setState } = useStore
   const selector: StateSelector<State, State> = (s) => s
   const equalityFn: EqualityChecker<State> = (a, b) =>
-    // @ts-ignore Ignore error since the code is supposed to crash here
+    // @ts-ignore This function is supposed to throw an error
     a.value.trim() === b.value?.trim()
 
   class ErrorBoundary extends React.Component<{}, { hasError: boolean }> {

--- a/tests/persistAsync.test.tsx
+++ b/tests/persistAsync.test.tsx
@@ -105,7 +105,7 @@ describe('persist middleware with async configuration', () => {
       },
     }
 
-    const useStore = create<any>(
+    const useStore = create(
       persist(() => ({ count: 0 }), {
         name: 'test-storage',
         getStorage: () => storage,


### PR DESCRIPTION
Notes:
- used `@ts-ignore` twice, makes sense that way IMO ([here](https://github.com/pmndrs/zustand/pull/417/files#diff-c21e24854115b390eccde717da83f91feb2d5927a76c1485e5f0fdd0135c2afaR299) and [here](https://github.com/pmndrs/zustand/pull/417/files#diff-c21e24854115b390eccde717da83f91feb2d5927a76c1485e5f0fdd0135c2afaR343)
- There are 2 TS errors right now which I'm not sure how to resolve as the test seems to violate the type definitions. Remove the test? Ignore the error? One in line 222 and one in 259
- The remaining `any` in the file I couldn't easily remove (L387:404), and the way the test was written looked a bit strange. Should the test really be the way it is, with `getState2()` calling `getState()`which is defined in the outer scope?