### PR TITLE
export NamedSet type for combining with immer

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -30,7 +30,7 @@ export const redux =
     return { dispatch: api.dispatch, ...initial }
   }
 
-type NamedSet<T extends State> = {
+export type NamedSet<T extends State> = {
   <K extends keyof T>(
     partial: PartialState<T, K>,
     replace?: boolean,


### PR DESCRIPTION
From PR#397, we changed the type of `PartialState`, so when combining `devtools` with `immer`, we have type error.

**Before**

```ts
export type PartialState<T extends State, K extends keyof T = keyof T> =
  | (Pick<T, K> | T)
  | ((state: T) => Pick<T, K> | T)
```

**Now**
```ts
export type PartialState<
  T extends State,
  K1 extends keyof T = keyof T,
  K2 extends keyof T = K1,
  K3 extends keyof T = K2,
  K4 extends keyof T = K3
> =
  | (Pick<T, K1> | Pick<T, K2> | Pick<T, K3> | Pick<T, K4> | T)
  | ((state: T) => Pick<T, K1> | Pick<T, K2> | Pick<T, K3> | Pick<T, K4> | T)
```

If we define `immer` like `README`

```ts
const immer = <T extends State>(
  config: StateCreator<T, (fn: (draft: Draft<T>) => void) => void>
): StateCreator<T> => (set, get, api) =>
  config((fn) => set(produce<T>(fn)), get, api)
```

it will raise error like this

![image](https://user-images.githubusercontent.com/15771072/121135554-d15dd280-c85e-11eb-9787-2b4fd60a2172.png)

So, if we export this type, we can fix this error

```ts
import produce, { Draft } from 'immer';
import { devtools } from 'zustand/middleware';
import create, { PartialState, State, StateCreator, UseStore } from 'zustand';

type NamedSet<T extends State> = {
  <K extends keyof T>(
    partial: PartialState<T, K>,
    replace?: boolean,
    name?: string,
  ): void;
};

type TImmerConfigFn<T extends State> = (fn: (draft: Draft<T>) => void) => void;
type TImmerConfig<T extends State> = StateCreator<T, TImmerConfigFn<T>>;

const immer = <T extends State>(
  config: TImmerConfig<T>,
): StateCreator<T, NamedSet<T>> => {
  return (set, get, api) => {
    return config((fn) => set(produce<T>(fn)), get, api);
  };
};

const createZustandStore = <T extends State>(
  createState: TImmerConfig<T>,
  prefix = 'project name',
): UseStore<T> => {
  return create(devtools(immer(createState), prefix));
};

export default createZustandStore;
```