### PR TITLE
Use jest.fn() to test callbacks

### DIFF
--- a/tests/persistAsync.test.tsx
+++ b/tests/persistAsync.test.tsx
@@ -5,8 +5,6 @@ import { persist } from '../src/middleware'
 
 describe('persist middleware with async configuration', () => {
   it('can rehydrate state', async () => {
-    let postRehydrationCallbackCallCount = 0
-
     const storage = {
       getItem: async (name: string) =>
         JSON.stringify({
@@ -16,6 +14,7 @@ describe('persist middleware with async configuration', () => {
       setItem: () => {},
     }
 
+    const spy = jest.fn()
     const useStore = create(
       persist(
         () => ({
@@ -25,11 +24,7 @@ describe('persist middleware with async configuration', () => {
         {
           name: 'test-storage',
           getStorage: () => storage,
-          onRehydrateStorage: () => (state) => {
-            postRehydrationCallbackCallCount++
-            expect(state?.count).toBe(42)
-            expect(state?.name).toBe('test-storage')
-          },
+          onRehydrateStorage: () => spy,
         }
       )
     )
@@ -47,7 +42,7 @@ describe('persist middleware with async configuration', () => {
 
     await findByText('count: 0, name: empty')
     await findByText('count: 42, name: test-storage')
-    expect(postRehydrationCallbackCallCount).toBe(1)
+    expect(spy).toBeCalledWith({ count: 42, name: 'test-storage' }, undefined)
   })
 
   it('can throw rehydrate error', async () => {

--- a/tests/persistAsync.test.tsx
+++ b/tests/persistAsync.test.tsx
@@ -4,7 +4,13 @@ import create from '../src/index'
 import { persist } from '../src/middleware'
 
 describe('persist middleware with async configuration', () => {
+  const consoleError = console.error
+  afterEach(() => {
+    console.error = consoleError
+  })
+
   it('can rehydrate state', async () => {
+    const onRehydrateStorageSpy = jest.fn()
     const storage = {
       getItem: async (name: string) =>
         JSON.stringify({
@@ -14,7 +20,6 @@ describe('persist middleware with async configuration', () => {
       setItem: () => {},
     }
 
-    const spy = jest.fn()
     const useStore = create(
       persist(
         () => ({
@@ -24,7 +29,7 @@ describe('persist middleware with async configuration', () => {
         {
           name: 'test-storage',
           getStorage: () => storage,
-          onRehydrateStorage: () => spy,
+          onRehydrateStorage: () => onRehydrateStorageSpy,
         }
       )
     )
@@ -42,11 +47,14 @@ describe('persist middleware with async configuration', () => {
 
     await findByText('count: 0, name: empty')
     await findByText('count: 42, name: test-storage')
-    expect(spy).toBeCalledWith({ count: 42, name: 'test-storage' }, undefined)
+    expect(onRehydrateStorageSpy).toBeCalledWith(
+      { count: 42, name: 'test-storage' },
+      undefined
+    )
   })
 
   it('can throw rehydrate error', async () => {
-    let postRehydrationCallbackCallCount = 0
+    const onRehydrateStorageSpy = jest.fn()
 
     const storage = {
       getItem: async () => {
@@ -59,10 +67,7 @@ describe('persist middleware with async configuration', () => {
       persist(() => ({ count: 0 }), {
         name: 'test-storage',
         getStorage: () => storage,
-        onRehydrateStorage: () => (_, e) => {
-          postRehydrationCallbackCallCount++
-          expect(e?.message).toBe('getItem error')
-        },
+        onRehydrateStorage: () => onRehydrateStorageSpy,
       })
     )
 
@@ -74,30 +79,26 @@ describe('persist middleware with async configuration', () => {
     const { findByText } = render(<Counter />)
 
     await findByText('count: 0')
-    expect(postRehydrationCallbackCallCount).toBe(1)
+    expect(onRehydrateStorageSpy).toBeCalledWith(
+      undefined,
+      new Error('getItem error')
+    )
   })
 
   it('can persist state', async () => {
-    let setItemCallCount = 0
+    const setItemSpy = jest.fn()
+    const onRehydrateStorageSpy = jest.fn()
 
     const storage = {
       getItem: () => null,
-      setItem: (name: string, value: string) => {
-        setItemCallCount++
-        expect(name).toBe('test-storage')
-        expect(value).toBe(
-          JSON.stringify({
-            state: { count: 42 },
-            version: 0,
-          })
-        )
-      },
+      setItem: setItemSpy,
     }
 
     const useStore = create(
       persist(() => ({ count: 0 }), {
         name: 'test-storage',
         getStorage: () => storage,
+        onRehydrateStorage: () => onRehydrateStorageSpy,
       })
     )
 
@@ -112,12 +113,17 @@ describe('persist middleware with async configuration', () => {
     act(() => useStore.setState({ count: 42 }))
 
     await findByText('count: 42')
-    expect(setItemCallCount).toBe(1)
+    expect(setItemSpy).toBeCalledWith(
+      'test-storage',
+      JSON.stringify({ state: { count: 42 }, version: 0 })
+    )
+    expect(onRehydrateStorageSpy).toBeCalledWith(undefined, undefined)
   })
 
   it('can migrate persisted state', async () => {
-    let migrateCallCount = 0
-    let setItemCallCount = 0
+    const setItemSpy = jest.fn()
+    const onRehydrateStorageSpy = jest.fn()
+    const migrateSpy = jest.fn(() => ({ count: 99 }))
 
     const storage = {
       getItem: async () =>
@@ -125,15 +131,7 @@ describe('persist middleware with async configuration', () => {
           state: { count: 42 },
           version: 12,
         }),
-      setItem: (_: string, value: string) => {
-        setItemCallCount++
-        expect(value).toBe(
-          JSON.stringify({
-            state: { count: 99 },
-            version: 13,
-          })
-        )
-      },
+      setItem: setItemSpy,
     }
 
     const useStore = create(
@@ -141,12 +139,8 @@ describe('persist middleware with async configuration', () => {
         name: 'test-storage',
         version: 13,
         getStorage: () => storage,
-        migrate: async (state, version) => {
-          migrateCallCount++
-          expect(state.count).toBe(42)
-          expect(version).toBe(12)
-          return { count: 99 }
-        },
+        onRehydrateStorage: () => onRehydrateStorageSpy,
+        migrate: migrateSpy,
       })
     )
 
@@ -159,12 +153,20 @@ describe('persist middleware with async configuration', () => {
 
     await findByText('count: 0')
     await findByText('count: 99')
-    expect(migrateCallCount).toBe(1)
-    expect(setItemCallCount).toBe(1)
+    expect(migrateSpy).toBeCalledWith({ count: 42 }, 12)
+    expect(setItemSpy).toBeCalledWith(
+      'test-storage',
+      JSON.stringify({
+        state: { count: 99 },
+        version: 13,
+      })
+    )
+    expect(onRehydrateStorageSpy).toBeCalledWith({ count: 99 }, undefined)
   })
 
   it('can throw migrate error', async () => {
-    let postRehydrationCallbackCallCount = 0
+    console.error = jest.fn()
+    const onRehydrateStorageSpy = jest.fn()
 
     const storage = {
       getItem: async () =>
@@ -183,10 +185,7 @@ describe('persist middleware with async configuration', () => {
         migrate: () => {
           throw new Error('migrate error')
         },
-        onRehydrateStorage: () => (_, e) => {
-          postRehydrationCallbackCallCount++
-          expect(e?.message).toBe('migrate error')
-        },
+        onRehydrateStorage: () => onRehydrateStorageSpy,
       })
     )
 
@@ -198,6 +197,9 @@ describe('persist middleware with async configuration', () => {
     const { findByText } = render(<Counter />)
 
     await findByText('count: 0')
-    expect(postRehydrationCallbackCallCount).toBe(1)
+    expect(onRehydrateStorageSpy).toBeCalledWith(
+      undefined,
+      new Error('migrate error')
+    )
   })
 })

--- a/tests/persistSync.test.tsx
+++ b/tests/persistSync.test.tsx
@@ -1,12 +1,12 @@
 import create from '../src/index'
 import { persist } from '../src/middleware'
 
-const consoleError = console.error
-afterEach(() => {
-  console.error = consoleError
-})
-
 describe('persist middleware with sync configuration', () => {
+  const consoleError = console.error
+  afterEach(() => {
+    console.error = consoleError
+  })
+
   it('can rehydrate state', () => {
     const storage = {
       getItem: (name: string) =>


### PR DESCRIPTION
Using `jest.fn()` not only is more concise but more importantly is less prone to be used incorrectly.

As an example, `expect()` calls within the `onRehydrateStorage` callbacks would not make a test fail at all.

Also in `persistAsync.test.tsx` add some checks verifying that `onRehydrateStorage` was not called with an error. (In `persistSync.test.tsx` those checks had been added previously.)