### PR TITLE
Change tests for subscribe() to use jest.fn()

### DIFF
--- a/tests/subscribe.test.tsx
+++ b/tests/subscribe.test.tsx
@@ -2,128 +2,112 @@ import create from '../src/index'
 
 describe('subscribe()', () => {
   it('should not be called if new state identity is the same', () => {
+    const spy = jest.fn()
     const initialState = { value: 1, other: 'a' }
     const { setState, subscribe } = create(() => initialState)
 
-    subscribe(() => {
-      throw new Error('subscriber called when new state identity is the same')
-    })
+    subscribe(spy)
     setState(initialState)
+    expect(spy).not.toHaveBeenCalled()
   })
 
   it('should be called if new state identity is different', () => {
+    const spy = jest.fn()
     const initialState = { value: 1, other: 'a' }
     const { setState, getState, subscribe } = create(() => initialState)
 
-    subscribe((newState: { value: number; other: string } | null) => {
-      expect(newState && newState.value).toBe(1)
-    })
-    setState(initialState)
+    subscribe(spy)
+    setState({ ...getState() })
+    expect(spy).toHaveBeenCalledWith(initialState, initialState)
   })
 
   it('should not be called when state slice is the same', () => {
+    const spy = jest.fn()
     const initialState = { value: 1, other: 'a' }
     const { setState, subscribe } = create(() => initialState)
 
-    subscribe(
-      () => {
-        throw new Error('subscriber called when new state is the same')
-      },
-      (s) => s.value
-    )
+    subscribe(spy, (s) => s.value)
     setState({ other: 'b' })
+    expect(spy).not.toHaveBeenCalled()
   })
 
   it('should be called when state slice changes', () => {
+    const spy = jest.fn()
     const initialState = { value: 1, other: 'a' }
     const { setState, subscribe } = create(() => initialState)
-    const listener = jest.fn()
 
-    subscribe(listener, (s) => s.value)
+    subscribe(spy, (s) => s.value)
     setState({ value: initialState.value + 1 })
-    expect(listener).toHaveBeenCalledTimes(1)
-    expect(listener).toHaveBeenCalledWith(
-      initialState.value + 1,
-      initialState.value
-    )
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(initialState.value + 1, initialState.value)
   })
 
   it('should not be called when equality checker returns true', () => {
+    const spy = jest.fn()
     const initialState = { value: 1, other: 'a' }
     const { setState, subscribe } = create(() => initialState)
 
-    subscribe(
-      () => {
-        throw new Error('subscriber called when equality checker returned true')
-      },
-      undefined,
-      () => true
-    )
+    subscribe(spy, undefined, () => true)
     setState({ value: initialState.value + 2 })
+    expect(spy).not.toHaveBeenCalled()
   })
 
   it('should be called when equality checker returns false', () => {
+    const spy = jest.fn()
     const initialState = { value: 1, other: 'a' }
     const { setState, subscribe } = create(() => initialState)
-    const listener = jest.fn()
 
     subscribe(
-      listener,
+      spy,
       (s) => s.value,
       () => false
     )
     setState({ value: initialState.value + 2 })
-    expect(listener).toHaveBeenCalledTimes(1)
-    expect(listener).toHaveBeenCalledWith(
-      initialState.value + 2,
-      initialState.value
-    )
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(initialState.value + 2, initialState.value)
   })
 
   it('should unsubscribe correctly', () => {
+    const spy = jest.fn()
     const initialState = { value: 1, other: 'a' }
     const { setState, subscribe } = create(() => initialState)
-    const listener = jest.fn()
 
-    const unsub = subscribe(listener, (s) => s.value)
+    const unsub = subscribe(spy, (s) => s.value)
 
     setState({ value: initialState.value + 1 })
     unsub()
     setState({ value: initialState.value + 2 })
 
-    expect(listener).toHaveBeenCalledTimes(1)
-    expect(listener).toHaveBeenCalledWith(
-      initialState.value + 1,
-      initialState.value
-    )
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(initialState.value + 1, initialState.value)
   })
 
   it('should keep consistent behavior with equality check', () => {
+    const spy = jest.fn()
     const initialState = { value: 1, other: 'a' }
     const { getState, setState, subscribe } = create(() => initialState)
-    const listener = jest.fn()
 
     const isRoughEqual = (x: number, y: number) => Math.abs(x - y) < 1
     setState({ value: 0 })
-    listener.mockReset()
-    const listener2 = jest.fn()
+    spy.mockReset()
+    const spy2 = jest.fn()
     let prevValue = getState().value
     const unsub = subscribe((s) => {
       if (isRoughEqual(prevValue, s.value)) {
         // skip assuming values are equal
         return
       }
-      listener(s.value, prevValue)
+      spy(s.value, prevValue)
       prevValue = s.value
     })
-    const unsub2 = subscribe(listener2, (s) => s.value, isRoughEqual)
+    const unsub2 = subscribe(spy2, (s) => s.value, isRoughEqual)
     setState({ value: 0.5 })
     setState({ value: 1 })
     unsub()
     unsub2()
-    expect(listener).toHaveBeenCalledTimes(1)
-    expect(listener).toHaveBeenCalledWith(1, 0)
-    expect(listener2).toHaveBeenCalledTimes(1)
-    expect(listener2).toHaveBeenCalledWith(1, 0)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(1, 0)
+    expect(spy2).toHaveBeenCalledTimes(1)
+    expect(spy2).toHaveBeenCalledWith(1, 0)
   })
 })


### PR DESCRIPTION
This commit also fixes the test  `should be called if new state identity is different` which was broken by 4632b74 (and unfortunately didn't fail).