### PR TITLE
Fix argument of onRehydrateStorage for missing migrate function

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -357,7 +357,7 @@ export const persist =
         }
       })
       .then(() => {
-        postRehydrationCallback?.(get(), undefined)
+        postRehydrationCallback?.(stateFromStorageInSync, undefined)
       })
       .catch((e: Error) => {
         postRehydrationCallback?.(undefined, e)

--- a/tests/persistAsync.test.tsx
+++ b/tests/persistAsync.test.tsx
@@ -194,7 +194,7 @@ describe('persist middleware with async configuration', () => {
 
     await findByText('count: 0')
     expect(console.error).toHaveBeenCalled()
-    expect(onRehydrateStorageSpy).toBeCalledWith({ count: 0 }, undefined)
+    expect(onRehydrateStorageSpy).toBeCalledWith(undefined, undefined)
   })
 
   it('can throw migrate error', async () => {


### PR DESCRIPTION
When the state loaded from the storage would need to be migrated but the persist configuration doesn't contain a migrate function `onRehydrateStorage` would be called with the initial state. Now it is called with the state loaded from the storage, which in this case is assumed to be undefined.