### PR TITLE
Fix failing test in persistAsync.test.tsx

### DIFF
--- a/tests/persistAsync.test.tsx
+++ b/tests/persistAsync.test.tsx
@@ -132,7 +132,7 @@ describe('persist middleware with async configuration', () => {
 
     const { findByText } = render(<Counter />)
     await findByText('count: 0')
-    expect(onRehydrateStorageSpy).toBeCalledWith({ count: 0 }, undefined)
+    expect(onRehydrateStorageSpy).toBeCalledWith(undefined, undefined)
 
     // Write something to the store
     act(() => useStore.setState({ count: 42 }))


### PR DESCRIPTION
The test started to fail on master because #436 and #437 were developed in parallel and #436 was merged before #437.

This situation is interesting for 2 reasons:

1. It shows that #436 did add a test that was missing before: It tests an async storage without an initial value.

2. This test shows that the argument of `onRehydrateStorage` not only differ when the migrate function is missing (as was assumed in #437) but when the store is empty. The reason for the difference is that `get()` (see [here](https://github.com/pmndrs/zustand/pull/437/files#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0L360)) returns `undefined` when the storage is synchronous but returns the _default store value_ when asynchronous. The reason for the difference is that in sync mode the default store value hasn't been applied yet as the current function has not returned yet.

All of that means that the change of the argument of onRehydrateStorage in  #437 is more significant, as it doesn't only affect an edge case but a happy path for async storage.