### PR TITLE
Compatible set function of immer middleware proxy

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -322,7 +322,7 @@ const immer = <T extends State>config: StateCreator<T>): StateCreator<T> =>
     const nextState =
       typeof partial === 'function'
         ? produce(partial as (state: T) => T)
-        : partial as Draft<T>
+        : partial as T
     return set(nextState, replace)
   }, get, api)
 ```

--- a/readme.md
+++ b/readme.md
@@ -271,7 +271,12 @@ const log = config => (set, get, api) => config(args => {
 }, get, api)
 
 // Turn the set method into an immer proxy
-const immer = config => (set, get, api) => config(fn => set(produce(fn)), get, api)
+const immer = config => (set, get, api) => config((partial, replace) => {
+  const nextState = typeof partial === 'function'
+      ? produce(partial)
+      : produce(() => partial);
+  return set(nextState, replace)
+}, get, api)
 
 const useStore = create(
   log(

--- a/readme.md
+++ b/readme.md
@@ -274,7 +274,7 @@ const log = config => (set, get, api) => config(args => {
 const immer = config => (set, get, api) => config((partial, replace) => {
   const nextState = typeof partial === 'function'
       ? produce(partial)
-      : produce(() => partial);
+      : produce(() => partial)
   return set(nextState, replace)
 }, get, api)
 
@@ -315,19 +315,16 @@ For a TS example see the following [discussion](https://github.com/pmndrs/zustan
 
 ```ts
 import { State, StateCreator } from 'zustand'
-import produce, { Draft } from 'immer'
+import produce from 'immer'
 
-// Immer V8 or lower
-const immer = <T extends State>(
-  config: StateCreator<T, (fn: (draft: Draft<T>) => void) => void>
-): StateCreator<T> => (set, get, api) =>
-  config((fn) => set(produce(fn) as (state: T) => T), get, api)
-
-// Immer V9
-const immer = <T extends State>(
-  config: StateCreator<T, (fn: (draft: Draft<T>) => void) => void>
-): StateCreator<T> => (set, get, api) =>
-  config((fn) => set(produce<T>(fn)), get, api)
+const immer = <T extends State>config: StateCreator<T>): StateCreator<T> => 
+  (set, get, api) => config((partial, replace) => {
+    const nextState =
+      typeof partial === 'function'
+        ? produce(partial as (state: T) => T)
+        : produce(() => partial)
+    return set(nextState, replace)
+  }, get, api)
 ```
 
 </details>

--- a/readme.md
+++ b/readme.md
@@ -274,7 +274,7 @@ const log = config => (set, get, api) => config(args => {
 const immer = config => (set, get, api) => config((partial, replace) => {
   const nextState = typeof partial === 'function'
       ? produce(partial)
-      : produce(() => partial)
+      : partial
   return set(nextState, replace)
 }, get, api)
 
@@ -315,14 +315,14 @@ For a TS example see the following [discussion](https://github.com/pmndrs/zustan
 
 ```ts
 import { State, StateCreator } from 'zustand'
-import produce from 'immer'
+import produce, { Draft } from 'immer'
 
 const immer = <T extends State>config: StateCreator<T>): StateCreator<T> => 
   (set, get, api) => config((partial, replace) => {
     const nextState =
       typeof partial === 'function'
         ? produce(partial as (state: T) => T)
-        : produce(() => partial)
+        : partial as Draft<T>
     return set(nextState, replace)
   }, get, api)
 ```


### PR DESCRIPTION
Until now the immer proxy sample code supports only functions. But the original `set` of zustand also allows to provide an object. The updated immer middleware sample in this pr allows an object too. With this change the immer middleware is fully compatible with the `set` function of zustand.