### PR TITLE
fix: cjs build, no regenerator

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -12,6 +12,7 @@ module.exports = (api, targets) => {
           loose: true,
           modules: isTestEnv ? 'commonjs' : false,
           targets: isTestEnv ? { node: 'current' } : targets,
+          exclude: ['@babel/plugin-transform-regenerator'],
         },
       ],
     ],


### PR DESCRIPTION
#419 had an issue. we still have one generator for backward compatibility.
This PR prevents using regenerator.
The impact is only on IE11 users who still use v2 API.