### PR TITLE
feat(persist): add nested paths support for whitelist/blacklist

### DIFF
--- a/tests/persistSync.test.tsx
+++ b/tests/persistSync.test.tsx
@@ -239,4 +239,66 @@ describe('persist middleware with sync configuration', () => {
     expect(useStore.getState()).toEqual(expectedState)
     expect(onRehydrateStorageSpy).toBeCalledWith(expectedState, undefined)
   })
+
+  it('can backlist / whitelist nested fields', () => {
+    const setItemSpy = jest.fn()
+
+    const storage = {
+      getItem: () => '',
+      setItem: setItemSpy,
+    }
+
+    const useStore = create(
+      persist(
+        () => ({
+          object: {
+            first: '0',
+            second: '1',
+            third: '2',
+          },
+          array: [
+            {
+              value: '0',
+            },
+            {
+              value: '1',
+            },
+            {
+              value: '2',
+            },
+          ],
+        }),
+        {
+          name: 'test-storage',
+          getStorage: () => storage,
+          blacklist: ['object.first', 'array.0.value'],
+          whitelist: [
+            'object.first',
+            'object.third',
+            'array.0.value',
+            'array.2',
+          ],
+        }
+      )
+    )
+
+    useStore.setState({})
+    expect(setItemSpy).toBeCalledWith(
+      'test-storage',
+      JSON.stringify({
+        state: {
+          object: {
+            third: '2',
+          },
+          array: [
+            {},
+            {
+              value: '2',
+            },
+          ],
+        },
+        version: 0,
+      })
+    )
+  })
 })


### PR DESCRIPTION
Follow up of #459 

This is an initial implementation of nested paths for `persist`'s whitelist and blacklist options. See the tests for an example.

I still need to work a bit on type checks, but the logic is pretty much there. Some bits could be improved, and some vars renamed though. I'd like some feedbacks on this if any :slightly_smiling_face: 