### PR TITLE
feat(persist): add a merge function option

### DIFF
--- a/tests/persistSync.test.tsx
+++ b/tests/persistSync.test.tsx
@@ -239,4 +239,42 @@ describe('persist middleware with sync configuration', () => {
     expect(useStore.getState()).toEqual(expectedState)
     expect(onRehydrateStorageSpy).toBeCalledWith(expectedState, undefined)
   })
+
+  it('can custom merge the stored state', () => {
+    const storage = {
+      getItem: () =>
+        JSON.stringify({
+          state: {
+            count: 1,
+            actions: {},
+          },
+          version: 0,
+        }),
+      setItem: () => {},
+    }
+
+    const unstorableMethod = () => {}
+
+    const useStore = create(
+      persist(() => ({ count: 0, actions: { unstorableMethod } }), {
+        name: 'test-storage',
+        getStorage: () => storage,
+        merge: (persistedState, currentState) => {
+          delete persistedState.actions
+
+          return {
+            ...currentState,
+            ...persistedState,
+          }
+        },
+      })
+    )
+
+    expect(useStore.getState()).toEqual({
+      count: 1,
+      actions: {
+        unstorableMethod,
+      },
+    })
+  })
 })


### PR DESCRIPTION
Follow up of #459 

This pr adds a new `merge` option for `persist` which can be used to do custom hydration merges.