### PR TITLE
Revert Provider initialStore types

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -19,7 +19,7 @@ function createContext<TState extends State>() {
     createStore,
     children,
   }: {
-    initialStore?: UseStore<TState>
+    initialStore?: UseStore<TState> /** @deprecated */
     createStore: () => UseStore<TState>
     children: ReactNode
   }) => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -19,7 +19,10 @@ function createContext<TState extends State>() {
     createStore,
     children,
   }: {
-    initialStore?: UseStore<TState> /** @deprecated */
+    /**
+     * @deprecated
+     */
+    initialStore?: UseStore<TState>
     createStore: () => UseStore<TState>
     children: ReactNode
   }) => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -15,11 +15,11 @@ function createContext<TState extends State>() {
   )
 
   const Provider = ({
-    // @ts-expect-error deprecated
     initialStore,
     createStore,
     children,
   }: {
+    initialStore?: UseStore<TState>
     createStore: () => UseStore<TState>
     children: ReactNode
   }) => {


### PR DESCRIPTION
### Description
Recent depracation of `initialStore` prop in `Provider` component causes broken declaration files to be generated. This causes TS compilation error when not using `skipLibCheck: true`.

```
node_modules/zustand/context.d.ts:5:18 - error TS2339: Property 'initialStore' does not exist
 on type '{ createStore: () => UseStore<TState>; children: ReactNode; }'.

5     Provider: ({ initialStore, createStore, children, }: {
                   ~~~~~~~~~~~~
```

You can see this error reported in the `context.d.ts` file after building the package.
```ts
// master version
import { ReactNode } from 'react';
import { UseStore } from 'zustand';
import { EqualityChecker, State, StateSelector } from './vanilla';
declare function createContext<TState extends State>(): {
    Provider: ({ initialStore, createStore, children, }: {
        createStore: () => UseStore<TState>;
        children: ReactNode;
    }) => import("react").FunctionComponentElement<import("react").ProviderProps<UseStore<TState> | undefined>>;
    useStore: <StateSlice>(selector?: StateSelector<TState, StateSlice> | undefined, equalityFn?: EqualityChecker<StateSlice>) => StateSlice;
    useStoreApi: () => {
        getState: import("zustand").GetState<TState>;
        setState: import("zustand").SetState<TState>;
        subscribe: import("zustand").Subscribe<TState>;
        destroy: import("zustand").Destroy;
    };
};
export default createContext;
```
