### PR TITLE
better immer help

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -240,13 +240,13 @@ import produce from 'immer'
 
 const useStore = create(set => ({
   lush: { forest: { contains: { a: "bear" } } },
-  set: fn => set(produce(fn)),
+  clearForest: () => set(produce(state => {
+    state.lush.forest.contains = null
+  }))
 }))
 
-const set = useStore(state => state.set)
-set(state => {
-  state.lush.forest.contains = null
-})
+const clearForest = useStore(state => state.clearForest)
+clearForest();
 ```
 
 ## Middleware


### PR DESCRIPTION
The docs example for immer could embed the immer code in the common 'action' style setter as in the other examples. This might give a better example of the common usage of immer in zustand. Otherwise, it encourages putting the setter code in the component