### PR TITLE
fix(context): Export UseContextStore interface

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -9,7 +9,7 @@ import {
 import { EqualityChecker, UseStore } from 'zustand'
 import { State, StateSelector } from './vanilla'
 
-export interface UseStoreData<T extends State> {
+export interface UseContextStore<T extends State> {
   (): T
   <U>(selector: StateSelector<T, U>, equalityFn?: EqualityChecker<U>): U
 }
@@ -52,7 +52,7 @@ function createContext<TState extends State>() {
     )
   }
 
-  const useStore: UseStoreData<TState> = <StateSlice>(
+  const useStore: UseContextStore<TState> = <StateSlice>(
     selector?: StateSelector<TState, StateSlice>,
     equalityFn = Object.is
   ) => {

--- a/src/context.ts
+++ b/src/context.ts
@@ -9,7 +9,7 @@ import {
 import { EqualityChecker, UseStore } from 'zustand'
 import { State, StateSelector } from './vanilla'
 
-interface UseStoreData<T extends State> {
+export interface UseStoreData<T extends State> {
   (): T
   <U>(selector: StateSelector<T, U>, equalityFn?: EqualityChecker<U>): U
 }


### PR DESCRIPTION
The changes from #484 cause an error when building declaration files from code using the `createContext` API. This was an oversight and the interface has to be exported or the declaration files cannot be emitted properly. I suppose TypeScript is not able to infer an interface that only contains call signatures with it not being exported.


```
error TS4023: Exported variable 'useStore'
 has or is using name 'UseStoreData' from external module ".../node_modules/zustand/context" but cannot be named.
```

Exporting the interface fixes this error (tested it locally). I'll also change the name of the interface if needed.