### PR TITLE
fix(readme): ts example of immer middleware

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -318,10 +318,10 @@ const immer = <T extends State>(config: StateCreator<T>): StateCreator<T> =>
   (set, get, api) => config((partial, replace) => {
     const nextState =
       typeof partial === 'function'
-        ? produce(partial as (state: T) => T)
+        ? produce(partial as (state: Draft<T>) => T)
         : partial as T
     return set(nextState, replace)
-  }, get, api)
+  }, get, api);
 ```
 
 </details>

--- a/readme.md
+++ b/readme.md
@@ -321,7 +321,7 @@ const immer = <T extends State>(config: StateCreator<T>): StateCreator<T> =>
         ? produce(partial as (state: Draft<T>) => T)
         : partial as T
     return set(nextState, replace)
-  }, get, api);
+  }, get, api)
 ```
 
 </details>


### PR DESCRIPTION
immer middleware with TypeScript example was missing the Draft wrapper type