### PR TITLE
Package all files into a single dist folder

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -5,7 +5,8 @@
     "react-typescript-react-ts",
     "simple-react-browserify-x9yni",
     "simple-snowpack-react-o1gmx",
-    "react-parcel-onewf"
+    "react-parcel-onewf",
+    "next-js-uo1h0"
   ],
   "node": "12"
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,5 +1,10 @@
 {
   "index.js": {
+    "bundled": 4684,
+    "minified": 1888,
+    "gzipped": 846
+  },
+  "index.mjs": {
     "bundled": 3993,
     "minified": 1614,
     "gzipped": 786,
@@ -14,6 +19,11 @@
     }
   },
   "vanilla.js": {
+    "bundled": 1800,
+    "minified": 631,
+    "gzipped": 350
+  },
+  "vanilla.mjs": {
     "bundled": 1352,
     "minified": 444,
     "gzipped": 288,
@@ -28,6 +38,11 @@
     }
   },
   "middleware.js": {
+    "bundled": 8221,
+    "minified": 3675,
+    "gzipped": 1508
+  },
+  "middleware.mjs": {
     "bundled": 6679,
     "minified": 3385,
     "gzipped": 1483,
@@ -42,6 +57,11 @@
     }
   },
   "shallow.js": {
+    "bundled": 622,
+    "minified": 401,
+    "gzipped": 251
+  },
+  "shallow.mjs": {
     "bundled": 541,
     "minified": 338,
     "gzipped": 217,
@@ -56,6 +76,11 @@
     }
   },
   "context.js": {
+    "bundled": 1857,
+    "minified": 935,
+    "gzipped": 466
+  },
+  "context.mjs": {
     "bundled": 1516,
     "minified": 840,
     "gzipped": 418,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "3.5.8",
   "description": "🐻 Bear necessities for state management in React",
   "main": "./index.js",
-  "module": "./esm/index.js",
+  "module": "./index.mjs",
   "types": "./index.d.ts",
   "files": [
     "**"
@@ -13,32 +13,32 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./index.d.ts",
-      "module": "./esm/index.js",
-      "import": "./esm/index.js",
+      "module": "./index.mjs",
+      "import": "./index.mjs",
       "default": "./index.js"
     },
     "./vanilla": {
       "types": "./vanilla.d.ts",
-      "module": "./esm/vanilla.js",
-      "import": "./esm/vanilla.js",
+      "module": "./vanilla.mjs",
+      "import": "./vanilla.mjs",
       "default": "./vanilla.js"
     },
     "./middleware": {
       "types": "./middleware.d.ts",
-      "module": "./esm/middleware.js",
-      "import": "./esm/middleware.js",
+      "module": "./middleware.mjs",
+      "import": "./middleware.mjs",
       "default": "./middleware.js"
     },
     "./shallow": {
       "types": "./shallow.d.ts",
-      "module": "./esm/shallow.js",
-      "import": "./esm/shallow.js",
+      "module": "./shallow.mjs",
+      "import": "./shallow.mjs",
       "default": "./shallow.js"
     },
     "./context": {
       "types": "./context.d.ts",
-      "module": "./esm/context.js",
-      "import": "./esm/context.js",
+      "module": "./context.mjs",
+      "import": "./context.mjs",
       "default": "./context.js"
     }
   },
@@ -60,7 +60,7 @@
     "test": "jest",
     "test:dev": "jest --watch --no-coverage",
     "test:coverage:watch": "jest --watch",
-    "copy": "shx cp -r dist/src/* dist/esm && shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\" && shx cp package.json dist/esm && shx echo '{\"type\":\"module\"}' > dist/esm/package.json && json -I -f dist/esm/package.json"
+    "copy": "shx mv dist/src/* dist && shx rm -rf dist/{src,tests} && shx cp package.json readme.md LICENSE dist && json -I -f dist/package.json -e \"this.private=false; this.devDependencies=undefined; this.optionalDependencies=undefined; this.scripts=undefined; this.prettier=undefined; this.jest=undefined; this['lint-staged']=undefined;\""
   },
   "prettier": {
     "semi": false,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "3.5.8",
   "description": "🐻 Bear necessities for state management in React",
   "main": "./index.js",
-  "module": "./index.mjs",
   "types": "./index.d.ts",
   "files": [
     "**"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,8 +27,6 @@ function getEsbuild(target) {
     minify: false,
     target,
     tsconfig: path.resolve('./tsconfig.json'),
-    allowSyntheticDefaultImports: true,
-    module: 'esnext',
   })
 }
 

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -27,6 +27,8 @@ function getEsbuild(target) {
     minify: false,
     target,
     tsconfig: path.resolve('./tsconfig.json'),
+    allowSyntheticDefaultImports: true,
+    module: 'esnext',
   })
 }
 
@@ -37,7 +39,13 @@ function createDeclarationConfig(input, output) {
       dir: output,
     },
     external,
-    plugins: [typescript({ declaration: true, outDir: output })],
+    plugins: [
+      typescript({
+        declaration: true,
+        emitDeclarationOnly: true,
+        outDir: output,
+      }),
+    ],
   }
 }
 
@@ -69,12 +77,12 @@ export default function (args) {
     c = c.slice('config-'.length)
     return [
       createCommonJSConfig(`src/${c}.ts`, `dist/${c}.js`),
-      createESMConfig(`src/${c}.ts`, `dist/esm/${c}.js`),
+      createESMConfig(`src/${c}.ts`, `dist/${c}.mjs`),
     ]
   }
   return [
     createDeclarationConfig('src/index.ts', 'dist'),
     createCommonJSConfig('src/index.ts', 'dist/index.js'),
-    createESMConfig('src/index.ts', 'dist/esm/index.js'),
+    createESMConfig('src/index.ts', 'dist/index.mjs'),
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,21 +4,12 @@
     "strict": true,
     "jsx": "preserve",
     "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
     "moduleResolution": "node",
     "baseUrl": ".",
     "paths": {
-      "zustand": [
-        "./src/index.ts"
-      ]
+      "zustand": ["./src/index.ts"]
     }
   },
-  "include": [
-    "src/**/*",
-    "tests/**/*"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
-  ]
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "esnext",
     "strict": true,
     "jsx": "preserve",
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
     "baseUrl": ".",


### PR DESCRIPTION
### Changes 
- Modify Rollup to output to a single folder
- Modify rollup typescript config
- Rename exports to point to `.mjs` in exports
- Added nextjs to the sandbox generators