### PR TITLE
Allow optional REDUX DEVTOOLS "options" object

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -38,14 +38,14 @@
     }
   },
   "middleware.js": {
-    "bundled": 8221,
-    "minified": 3675,
-    "gzipped": 1508
+    "bundled": 8244,
+    "minified": 3700,
+    "gzipped": 1512
   },
   "middleware.mjs": {
-    "bundled": 6679,
-    "minified": 3385,
-    "gzipped": 1483,
+    "bundled": 6732,
+    "minified": 3424,
+    "gzipped": 1491,
     "treeshaked": {
       "rollup": {
         "code": 0,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -46,7 +46,24 @@ export type NamedSet<T extends State> = {
 export const devtools =
   <S extends State>(
     fn: (set: NamedSet<S>, get: GetState<S>, api: StoreApi<S>) => S,
-    prefix?: string
+    options?: {
+      name?: string
+      serialize?: {
+        options:
+          | boolean
+          | {
+              date?: boolean
+              regex?: boolean
+              undefined?: boolean
+              nan?: boolean
+              infinity?: boolean
+              error?: boolean
+              symbol?: boolean
+              map?: boolean
+              set?: boolean
+            }
+      }
+    }
   ) =>
   (
     set: SetState<S>,
@@ -91,8 +108,8 @@ export const devtools =
         savedSetState(state, replace)
         api.devtools.send(api.devtools.prefix + 'setState', api.getState())
       }
-      api.devtools = extension.connect({ name: prefix })
-      api.devtools.prefix = prefix ? `${prefix} > ` : ''
+      api.devtools = extension.connect({ ...options })
+      api.devtools.prefix = options?.name ? `${options.name} > ` : ''
       api.devtools.subscribe((message: any) => {
         if (message.type === 'DISPATCH' && message.state) {
           const ignoreState =
@@ -247,7 +264,7 @@ const toThenable =
           return this as Thenable<any>
         },
       }
-    } catch (e) {
+    } catch (e: any) {
       return {
         then(_onFulfilled) {
           return this as Thenable<any>

--- a/tests/middlewareTypes.test.tsx
+++ b/tests/middlewareTypes.test.tsx
@@ -43,9 +43,9 @@ interface ITestStateProps {
 it('should have correct type when creating store with devtool', () => {
   const createStoreWithDevtool = <T extends State>(
     createState: StateCreator<T>,
-    prefix = 'prefix'
+    options = { name: 'prefix' }
   ): UseStore<T> & ISelectors<T> => {
-    return createSelectorHooks(create(devtools(createState, prefix)))
+    return createSelectorHooks(create(devtools(createState, options)))
   }
 
   const testDevtoolStore = createStoreWithDevtool<ITestStateProps>(
@@ -57,7 +57,7 @@ it('should have correct type when creating store with devtool', () => {
         })
       },
     }),
-    'test'
+    { name: 'test' }
   )
 
   const TestComponent = (): JSX.Element => {
@@ -72,9 +72,9 @@ it('should have correct type when creating store with devtool', () => {
 it('should have correct type when creating store with devtool and immer', () => {
   const createStoreWithImmer = <T extends State>(
     createState: TImmerConfig<T>,
-    prefix = 'prefix'
+    options = { name: 'prefix' }
   ): UseStore<T> & ISelectors<T> => {
-    return createSelectorHooks(create(devtools(immer(createState), prefix)))
+    return createSelectorHooks(create(devtools(immer(createState), options)))
   }
 
   const testImmerStore = createStoreWithImmer<ITestStateProps>(
@@ -86,7 +86,7 @@ it('should have correct type when creating store with devtool and immer', () => 
         })
       },
     }),
-    'test'
+    { name: 'test' }
   )
 
   const TestComponent = (): JSX.Element => {
@@ -101,11 +101,11 @@ it('should have correct type when creating store with devtool and immer', () => 
 it('should have correct type when creating store with devtool and persist', () => {
   const createStoreWithPersist = <T extends State>(
     createState: StateCreator<T>,
-    prefix = 'prefix',
+    options = { name: 'prefix' },
     persistName = 'persist'
   ): UseStore<T> & ISelectors<T> => {
     return createSelectorHooks(
-      create(devtools(persist(createState, { name: persistName }), prefix))
+      create(devtools(persist(createState, { name: persistName }), options))
     )
   }
 
@@ -118,7 +118,7 @@ it('should have correct type when creating store with devtool and persist', () =
         })
       },
     }),
-    'test',
+    { name: 'test' },
     'persist'
   )
 
@@ -209,12 +209,12 @@ it('should have correct type when creating store with immer', () => {
 it('should have correct type when creating store with devtool, persist and immer', () => {
   const createStoreWithPersistAndImmer = <T extends State>(
     createState: TImmerConfig<T>,
-    prefix = 'prefix',
+    options = { name: 'prefix' },
     persistName = 'persist'
   ): UseStore<T> & ISelectors<T> => {
     return createSelectorHooks(
       create(
-        devtools(persist(immer(createState), { name: persistName }), prefix)
+        devtools(persist(immer(createState), { name: persistName }), options)
       )
     )
   }
@@ -228,7 +228,7 @@ it('should have correct type when creating store with devtool, persist and immer
         })
       },
     }),
-    'test'
+    { name: 'test' }
   )
 
   const TestComponent = (): JSX.Element => {


### PR DESCRIPTION
## Why is this change needed?
Unable to display Maps/Sets

## How does it address the issue?
optional serialize date, regex, undefined, nan, infinity,
error, symbol, map & set

## breaking change prev "prefix" option
prefix?: string -> options?: { name?: string }

https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#serialize

https://github.com/pmndrs/zustand/issues/249