### PR TITLE
refactor(tests): cleaner tests

### DIFF
--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -8,6 +8,11 @@ import { act, fireEvent, render } from '@testing-library/react'
 import ReactDOM from 'react-dom'
 import create, { EqualityChecker, SetState, StateSelector } from 'zustand'
 
+const consoleError = console.error
+afterEach(() => {
+  console.error = consoleError
+})
+
 it('creates a store hook and api object', () => {
   let params
   const result = create((...args) => {
@@ -275,7 +280,7 @@ it('can call useStore with progressively more arguments', async () => {
 
 it('can throw an error in selector', async () => {
   console.error = jest.fn()
-  type State = { value?: string }
+  type State = { value: string | number }
 
   const initialState: State = { value: 'foo' }
   const useStore = create<State>(() => initialState)
@@ -309,16 +314,15 @@ it('can throw an error in selector', async () => {
   )
   await findByText('no error')
 
-  delete initialState.value
   act(() => {
-    setState({})
+    setState({ value: 123 })
   })
   await findByText('errored')
 })
 
 it('can throw an error in equality checker', async () => {
   console.error = jest.fn()
-  type State = { value?: string }
+  type State = { value: string | number }
 
   const initialState: State = { value: 'foo' }
   const useStore = create(() => initialState)
@@ -326,7 +330,7 @@ it('can throw an error in equality checker', async () => {
   const selector: StateSelector<State, State> = (s) => s
   const equalityFn: EqualityChecker<State> = (a, b) =>
     // @ts-expect-error This function is supposed to throw an error
-    a.value.trim() === b.value?.trim()
+    a.value.trim() === b.value.trim()
 
   class ErrorBoundary extends ClassComponent<{}, { hasError: boolean }> {
     constructor(props: {}) {
@@ -353,9 +357,8 @@ it('can throw an error in equality checker', async () => {
   )
   await findByText('no error')
 
-  delete initialState.value
   act(() => {
-    setState({})
+    setState({ value: 123 })
   })
   await findByText('errored')
 })

--- a/tests/context.test.tsx
+++ b/tests/context.test.tsx
@@ -3,6 +3,11 @@ import { render } from '@testing-library/react'
 import create from 'zustand'
 import createContext from 'zustand/context'
 
+const consoleError = console.error
+afterEach(() => {
+  console.error = consoleError
+})
+
 type CounterState = {
   count: number
   inc: () => void


### PR DESCRIPTION
Let's fix `delete initialState.value` which wasn't very nice.