### PR TITLE
docs: Clarify that listeners added with `subscribe` are called synchronously

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -175,7 +175,7 @@ const useStore = create(() => ({ paw: true, snout: true, fur: true }))
 
 // Getting non-reactive fresh state
 const paw = useStore.getState().paw
-// Listening to all changes, fires on every change
+// Listening to all changes, fires synchronously on every change
 const unsub1 = useStore.subscribe(console.log)
 // Listening to selected changes, in this case when "paw" changes
 const unsub2 = useStore.subscribe(console.log, state => state.paw)


### PR DESCRIPTION
My team has just had a little discussion about this. I thought it would be useful to get this added to the docs, if I've understood your code correctly.