### PR TITLE
fix(middleware): simplify middleware types and allow explicit typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "semi": false,
     "trailingComma": "es5",
     "singleQuote": true,
-    "jsxBracketSameLine": true,
+    "bracketSameLine": true,
     "tabWidth": 2,
     "printWidth": 80
   },

--- a/tests/context.test.tsx
+++ b/tests/context.test.tsx
@@ -1,8 +1,11 @@
 import { Component as ClassComponent, useEffect, useState } from 'react'
 import { render } from '@testing-library/react'
-import create from 'zustand'
+import create, { SetState, GetState } from 'zustand'
 import createContext from 'zustand/context'
-import { subscribeWithSelector } from 'zustand/middleware'
+import {
+  subscribeWithSelector,
+  StoreApiWithSubscribeWithSelector,
+} from 'zustand/middleware'
 
 const consoleError = console.error
 afterEach(() => {
@@ -65,8 +68,13 @@ it('uses context store with selectors', async () => {
 
 it('uses context store api', async () => {
   const createStore = () =>
-    create(
-      subscribeWithSelector<CounterState>((set) => ({
+    create<
+      CounterState,
+      SetState<CounterState>,
+      GetState<CounterState>,
+      StoreApiWithSubscribeWithSelector<CounterState>
+    >(
+      subscribeWithSelector((set) => ({
         count: 0,
         inc: () => set((state) => ({ count: state.count + 1 })),
       }))

--- a/tests/context.test.tsx
+++ b/tests/context.test.tsx
@@ -1,10 +1,10 @@
 import { Component as ClassComponent, useEffect, useState } from 'react'
 import { render } from '@testing-library/react'
-import create, { SetState, GetState } from 'zustand'
+import create, { GetState, SetState } from 'zustand'
 import createContext from 'zustand/context'
 import {
-  subscribeWithSelector,
   StoreApiWithSubscribeWithSelector,
+  subscribeWithSelector,
 } from 'zustand/middleware'
 
 const consoleError = console.error

--- a/tests/middlewareTypes.test.tsx
+++ b/tests/middlewareTypes.test.tsx
@@ -1,12 +1,6 @@
 import { produce } from 'immer'
 import type { Draft } from 'immer'
-import create, {
-  GetState,
-  SetState,
-  State,
-  StateCreator,
-  UseBoundStore,
-} from 'zustand'
+import create, { GetState, SetState, State, StateCreator } from 'zustand'
 import {
   StoreApiWithSubscribeWithSelector,
   combine,
@@ -21,12 +15,6 @@ type TImmerConfigFn<T extends State> = (
   replace?: boolean
 ) => void
 type TImmerConfig<T extends State> = StateCreator<T, TImmerConfigFn<T>>
-
-interface ISelectors<T> {
-  use: {
-    [key in keyof T]: () => T[key]
-  }
-}
 
 const immer =
   <T extends State>(config: TImmerConfig<T>): StateCreator<T> =>
@@ -43,305 +31,55 @@ const immer =
       api
     )
 
-const createSelectorHooks = <
-  T extends State,
-  TUseBoundStore extends UseBoundStore<T> = UseBoundStore<T>
->(
-  store: TUseBoundStore
-) => {
-  const storeAsSelectors = store as unknown as ISelectors<T>
-  storeAsSelectors.use = {} as ISelectors<T>['use']
-
-  Object.keys(store.getState()).forEach((key) => {
-    const storeKey = key as keyof T
-    const selector = (state: T) => state[storeKey]
-
-    storeAsSelectors.use[storeKey] = () => store(selector)
-  })
-
-  return store as TUseBoundStore & ISelectors<T>
+type CounterState = {
+  count: number
+  inc: () => void
 }
 
-interface ITestStateProps {
-  testKey: string
-  setTestKey: (testKey: string) => void
-}
-
-it('should have correct type when creating store with devtool', () => {
-  const createStoreWithDevtool = <T extends State>(
-    createState: StateCreator<T>,
-    options = { name: 'prefix' }
-  ): UseBoundStore<T> & ISelectors<T> => {
-    return createSelectorHooks(create(devtools(createState, options)))
-  }
-
-  const testDevtoolStore = createStoreWithDevtool<ITestStateProps>(
-    (set) => ({
-      testKey: 'test',
-      setTestKey: (testKey: string) => {
-        set((state) => {
-          state.testKey = testKey
-        })
-      },
-    }),
-    { name: 'test' }
-  )
-
-  const TestComponent = (): JSX.Element => {
-    testDevtoolStore.use.testKey()
-    testDevtoolStore.use.setTestKey()
-
-    return <></>
-  }
-  TestComponent
-})
-
-it('should have correct type when creating store with devtool and immer', () => {
-  const createStoreWithImmer = <T extends State>(
-    createState: TImmerConfig<T>,
-    options = { name: 'prefix' }
-  ): UseBoundStore<T> & ISelectors<T> => {
-    return createSelectorHooks(create(devtools(immer(createState), options)))
-  }
-
-  const testImmerStore = createStoreWithImmer<ITestStateProps>(
-    (set) => ({
-      testKey: 'test',
-      setTestKey: (testKey: string) => {
-        set((state) => {
-          state.testKey = testKey
-        })
-      },
-    }),
-    { name: 'test' }
-  )
-
-  const TestComponent = (): JSX.Element => {
-    testImmerStore.use.testKey()
-    testImmerStore.use.setTestKey()
-
-    return <></>
-  }
-  TestComponent
-})
-
-it('should have correct type when creating store with devtool and persist', () => {
-  const createStoreWithPersist = <T extends State>(
-    createState: StateCreator<T>,
-    options = { name: 'prefix' },
-    persistName = 'persist'
-  ): UseBoundStore<T> & ISelectors<T> => {
-    return createSelectorHooks(
-      create(devtools(persist(createState, { name: persistName }), options))
-    )
-  }
-
-  const testPersistStore = createStoreWithPersist<ITestStateProps>(
-    (set) => ({
-      testKey: 'test',
-      setTestKey: (testKey: string) => {
-        set((state) => {
-          state.testKey = testKey
-        })
-      },
-    }),
-    { name: 'test' },
-    'persist'
-  )
-
-  const TestComponent = (): JSX.Element => {
-    testPersistStore.use.testKey()
-    testPersistStore.use.setTestKey()
-
-    return <></>
-  }
-  TestComponent
-})
-
-it('should have correct type when creating store without middleware', () => {
-  const testStore = create<ITestStateProps>((set) => ({
-    testKey: 'test',
-    setTestKey: (testKey: string) => {
-      set((state) => {
-        state.testKey = testKey
-      })
-    },
-  }))
-
-  const TestComponent = (): JSX.Element => {
-    testStore((state) => state.testKey)
-    testStore((state) => state.setTestKey)
-
-    return <></>
-  }
-  TestComponent
-})
-
-it('should have correct type when creating store with persist', () => {
-  const createStoreWithPersist = <T extends State>(
-    createState: StateCreator<T>,
-    persistName = 'persist'
-  ): UseBoundStore<T> & ISelectors<T> => {
-    return createSelectorHooks(
-      create(persist(createState, { name: persistName }))
-    )
-  }
-
-  const testPersistStore = createStoreWithPersist<ITestStateProps>(
-    (set) => ({
-      testKey: 'test',
-      setTestKey: (testKey: string) => {
-        set((state) => {
-          state.testKey = testKey
-        })
-      },
-    }),
-    'persist'
-  )
-
-  const TestComponent = (): JSX.Element => {
-    testPersistStore.use.testKey()
-    testPersistStore.use.setTestKey()
-
-    return <></>
-  }
-  TestComponent
-})
-
-it('should have correct type when creating store with immer', () => {
-  const createStoreWithImmer = <T extends State>(
-    createState: TImmerConfig<T>
-  ): UseBoundStore<T> & ISelectors<T> => {
-    return createSelectorHooks(create(immer(createState)))
-  }
-
-  const testImmerStore = createStoreWithImmer<ITestStateProps>((set) => ({
-    testKey: 'test',
-    setTestKey: (testKey: string) => {
-      set((state) => {
-        state.testKey = testKey
-      })
-    },
-  }))
-
-  const TestComponent = (): JSX.Element => {
-    testImmerStore.use.testKey()
-    testImmerStore.use.setTestKey()
-
-    return <></>
-  }
-  TestComponent
-})
-
-it('should have correct type when creating store with devtool, persist and immer', () => {
-  const createStoreWithPersistAndImmer = <T extends State>(
-    createState: TImmerConfig<T>,
-    options = { name: 'prefix' },
-    persistName = 'persist'
-  ): UseBoundStore<T> & ISelectors<T> => {
-    return createSelectorHooks(
-      create(
-        devtools(persist(immer(createState), { name: persistName }), options)
-      )
-    )
-  }
-
-  const testPersistImmerStore = createStoreWithPersistAndImmer<ITestStateProps>(
-    (set) => ({
-      testKey: 'test',
-      setTestKey: (testKey: string) => {
-        set((state) => {
-          state.testKey = testKey
-        })
-      },
-    }),
-    { name: 'test' }
-  )
-
-  const TestComponent = (): JSX.Element => {
-    testPersistImmerStore.use.testKey()
-    testPersistImmerStore.use.setTestKey()
-
-    return <></>
-  }
-  TestComponent
-})
-
-it('should have correct type when creating store with devtools', () => {
-  const useStore = create<ITestStateProps>(
-    devtools((set) => ({
-      testKey: 'test',
-      setTestKey: (testKey: string) => {
-        set((state) => ({
-          testKey: state.testKey + testKey,
-        }))
-      },
+describe('counter state spec (no middleware)', () => {
+  it('no middleware', () => {
+    const useStore = create<CounterState>((set, get) => ({
+      count: 0,
+      inc: () => set({ count: get().count + 1 }, false),
     }))
-  )
-
-  const TestComponent = (): JSX.Element => {
-    useStore().testKey
-    useStore().setTestKey('')
-    useStore.getState().testKey
-    useStore.getState().setTestKey('')
-
-    return <></>
-  }
-  TestComponent
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.inc)()
+      useStore().count * 2
+      useStore().inc()
+      useStore.getState().count * 2
+      useStore.getState().inc()
+      return <></>
+    }
+    TestComponent
+  })
 })
 
-it('should have correct type when creating store with redux', () => {
-  const useStore = create(
-    redux<{ count: number }, { type: 'INC' }>(
-      (state, action) => {
-        switch (action.type) {
-          case 'INC':
-            return { ...state, count: state.count + 1 }
-          default:
-            return state
-        }
-      },
-      { count: 0 }
-    )
-  )
-
-  const TestComponent = (): JSX.Element => {
-    useStore().dispatch({ type: 'INC' })
-    useStore.dispatch({ type: 'INC' })
-
-    return <></>
-  }
-  TestComponent
-})
-
-it('should combine devtools and immer', () => {
-  const useStore = create<ITestStateProps>(
-    devtools(
-      immer((set) => ({
-        testKey: 'test',
-        setTestKey: (testKey: string) => {
+describe('counter state spec (single middleware)', () => {
+  it('immer', () => {
+    const useStore = create<CounterState>(
+      immer((set, get) => ({
+        count: 0,
+        inc: () =>
           set((state) => {
-            state.testKey = testKey
-          })
-        },
+            state.count = get().count + 1
+          }),
       }))
     )
-  )
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.inc)()
+      useStore().count * 2
+      useStore().inc()
+      useStore.getState().count * 2
+      useStore.getState().inc()
+      return <></>
+    }
+    TestComponent
+  })
 
-  const TestComponent = (): JSX.Element => {
-    useStore().testKey
-    useStore().setTestKey('')
-    useStore.getState().testKey
-    useStore.getState().setTestKey('')
-
-    return <></>
-  }
-  TestComponent
-})
-
-it('should combine devtools and redux', () => {
-  const useStore = create(
-    devtools(
+  it('redux', () => {
+    const useStore = create(
       redux<{ count: number }, { type: 'INC' }>(
         (state, action) => {
           switch (action.type) {
@@ -354,134 +92,270 @@ it('should combine devtools and redux', () => {
         { count: 0 }
       )
     )
-  )
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.dispatch)({ type: 'INC' })
+      useStore().dispatch({ type: 'INC' })
+      useStore.dispatch({ type: 'INC' })
+      return <></>
+    }
+    TestComponent
+  })
 
-  const TestComponent = (): JSX.Element => {
-    useStore().dispatch({ type: 'INC' })
-    useStore.dispatch({ type: 'INC' })
-
-    return <></>
-  }
-  TestComponent
-})
-
-it('should combine devtools and combine', () => {
-  const useStore = create(
-    devtools(
-      combine({ count: 1 }, (set, get) => ({
-        inc: () => set({ count: get().count + 1 }, false, 'inc'),
-      }))
+  it('devtools', () => {
+    const useStore = create<CounterState>(
+      devtools(
+        (set, get) => ({
+          count: 0,
+          inc: () => set({ count: get().count + 1 }, false, 'inc'),
+        }),
+        { name: 'prefix' }
+      )
     )
-  )
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.inc)()
+      useStore().count * 2
+      useStore().inc()
+      useStore.getState().count * 2
+      useStore.getState().inc()
+      return <></>
+    }
+    TestComponent
+  })
 
-  const TestComponent = (): JSX.Element => {
-    useStore().count
-    useStore().inc()
-    useStore.getState().count
-    useStore.getState().inc()
+  it('subscribeWithSelector', () => {
+    const useStore = create<
+      CounterState,
+      SetState<CounterState>,
+      GetState<CounterState>,
+      StoreApiWithSubscribeWithSelector<CounterState>
+    >(
+      devtools(
+        subscribeWithSelector((set, get) => ({
+          count: 1,
+          inc: () => set({ count: get().count + 1 }, false, 'inc'),
+        })),
+        { name: 'prefix' }
+      )
+    )
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.inc)()
+      useStore().count * 2
+      useStore().inc()
+      useStore.getState().count * 2
+      useStore.getState().inc()
+      useStore.subscribe(
+        (state) => state.count,
+        (count) => console.log(count * 2)
+      )
+      return <></>
+    }
+    TestComponent
+  })
 
-    return <></>
-  }
-  TestComponent
-})
-
-it('should combine subscribeWithSelector and combine', () => {
-  const useStore = create(
-    subscribeWithSelector(
+  it('combine', () => {
+    const useStore = create(
       combine({ count: 1 }, (set, get) => ({
         inc: () => set({ count: get().count + 1 }, false),
       }))
     )
-  )
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.inc)()
+      useStore().count * 2
+      useStore().inc()
+      useStore.getState().count * 2
+      useStore.getState().inc()
+      return <></>
+    }
+    TestComponent
+  })
 
-  const TestComponent = (): JSX.Element => {
-    useStore().count
-    useStore().inc()
-    useStore.getState().count
-    useStore.getState().inc()
-    useStore.subscribe(
-      (state) => state.count,
-      (count) => console.log(count * 2)
+  it('persist', () => {
+    const useStore = create<CounterState>(
+      persist(
+        (set, get) => ({
+          count: 1,
+          inc: () => set({ count: get().count + 1 }, false),
+        }),
+        { name: 'prefix' }
+      )
     )
-
-    return <></>
-  }
-  TestComponent
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.inc)()
+      useStore().count * 2
+      useStore().inc()
+      useStore.getState().count * 2
+      useStore.getState().inc()
+      return <></>
+    }
+    TestComponent
+  })
 })
 
-it('should combine devtools and subscribeWithSelector', () => {
-  type MyState = {
-    count: number
-    inc: () => void
-  }
-  const useStore = create<
-    MyState,
-    SetState<MyState>,
-    GetState<MyState>,
-    StoreApiWithSubscribeWithSelector<MyState>
-  >(
-    devtools(
-      subscribeWithSelector((set, get) => ({
-        count: 1,
-        inc: () => set({ count: get().count + 1 }, false, 'inc'),
-      }))
+describe('counter state spec (double middleware)', () => {
+  it('devtools & immer', () => {
+    const useStore = create<CounterState>(
+      devtools(
+        immer((set, get) => ({
+          count: 0,
+          inc: () =>
+            set((state) => {
+              state.count = get().count + 1
+            }),
+        })),
+        { name: 'prefix' }
+      )
     )
-  )
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.inc)()
+      useStore().count * 2
+      useStore().inc()
+      useStore.getState().count * 2
+      useStore.getState().inc()
+      return <></>
+    }
+    TestComponent
+  })
 
-  const TestComponent = (): JSX.Element => {
-    useStore().count
-    useStore().inc()
-    useStore.getState().count
-    useStore.getState().inc()
-    useStore.subscribe(
-      (state) => state.count,
-      (count) => console.log(count * 2)
+  it('devtools & redux', () => {
+    const useStore = create(
+      devtools(
+        redux<{ count: number }, { type: 'INC' }>(
+          (state, action) => {
+            switch (action.type) {
+              case 'INC':
+                return { ...state, count: state.count + 1 }
+              default:
+                return state
+            }
+          },
+          { count: 0 }
+        ),
+        { name: 'prefix' }
+      )
     )
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.dispatch)({ type: 'INC' })
+      useStore().dispatch({ type: 'INC' })
+      useStore.dispatch({ type: 'INC' })
+      return <></>
+    }
+    TestComponent
+  })
 
-    return <></>
-  }
-  TestComponent
-})
-
-it('should combine devtools, subscribeWithSelector and combine', () => {
-  const useStore = create(
-    devtools(
-      subscribeWithSelector(
+  it('devtools & combine', () => {
+    const useStore = create(
+      devtools(
         combine({ count: 1 }, (set, get) => ({
           inc: () => set({ count: get().count + 1 }, false, 'inc'),
+        })),
+        { name: 'prefix' }
+      )
+    )
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.inc)()
+      useStore().count * 2
+      useStore().inc()
+      useStore.getState().count * 2
+      useStore.getState().inc()
+      return <></>
+    }
+    TestComponent
+  })
+
+  it('subscribeWithSelector & combine', () => {
+    const useStore = create(
+      subscribeWithSelector(
+        combine({ count: 1 }, (set, get) => ({
+          inc: () => set({ count: get().count + 1 }, false),
         }))
       )
     )
-  )
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.inc)()
+      useStore().count * 2
+      useStore().inc()
+      useStore.getState().count * 2
+      useStore.getState().inc()
+      useStore.subscribe(
+        (state) => state.count,
+        (count) => console.log(count * 2)
+      )
+      return <></>
+    }
+    TestComponent
+  })
 
-  const TestComponent = (): JSX.Element => {
-    useStore().count
-    useStore().inc()
-    useStore.getState().count
-    useStore.getState().inc()
-    useStore.subscribe(
-      (state) => state.count,
-      (count) => console.log(count * 2)
+  it('devtools & subscribeWithSelector', () => {
+    const useStore = create<
+      CounterState,
+      SetState<CounterState>,
+      GetState<CounterState>,
+      StoreApiWithSubscribeWithSelector<CounterState>
+    >(
+      devtools(
+        subscribeWithSelector((set, get) => ({
+          count: 1,
+          inc: () => set({ count: get().count + 1 }, false, 'inc'),
+        })),
+        { name: 'prefix' }
+      )
     )
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.inc)()
+      useStore().count * 2
+      useStore().inc()
+      useStore.getState().count * 2
+      useStore.getState().inc()
+      useStore.subscribe(
+        (state) => state.count,
+        (count) => console.log(count * 2)
+      )
+      return <></>
+    }
+    TestComponent
+  })
 
-    return <></>
-  }
-  TestComponent
+  it('devtools & persist', () => {
+    const useStore = create<CounterState>(
+      devtools(
+        persist(
+          (set, get) => ({
+            count: 1,
+            inc: () =>
+              set({ count: get().count + 1 }, false /* TODO , 'inc' */),
+          }),
+          { name: 'count' }
+        ),
+        { name: 'prefix' }
+      )
+    )
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.inc)()
+      useStore().count * 2
+      useStore().inc()
+      useStore.getState().count * 2
+      useStore.getState().inc()
+      return <></>
+    }
+    TestComponent
+  })
 })
 
-it('should combine devtools, subscribeWithSelector, persist and immer (#616)', () => {
-  type MyState = {
-    count: number
-    inc: () => void
-  }
-  const useStore = create<
-    MyState,
-    SetState<MyState>,
-    GetState<MyState>,
-    StoreApiWithSubscribeWithSelector<MyState>
-  >(
-    devtools(
-      subscribeWithSelector(
+describe('counter state spec (triple middleware)', () => {
+  it('devtools & persist & immer', () => {
+    const useStore = create<CounterState>(
+      devtools(
         persist(
           immer((set, get) => ({
             count: 0,
@@ -490,23 +364,124 @@ it('should combine devtools, subscribeWithSelector, persist and immer (#616)', (
                 state.count = get().count + 1
               }),
           })),
-          { name: 'name' }
-        )
+          { name: 'count' }
+        ),
+        { name: 'prefix' }
       )
     )
-  )
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.inc)()
+      useStore().count * 2
+      useStore().inc()
+      useStore.getState().count * 2
+      useStore.getState().inc()
+      return <></>
+    }
+    TestComponent
+  })
 
-  const TestComponent = (): JSX.Element => {
-    useStore().count
-    useStore().inc()
-    useStore.getState().count
-    useStore.getState().inc()
-    useStore.subscribe(
-      (state) => state.count,
-      (count) => console.log(count * 2)
+  it('devtools & subscribeWithSelector & combine', () => {
+    const useStore = create(
+      devtools(
+        subscribeWithSelector(
+          combine({ count: 1 }, (set, get) => ({
+            inc: () => set({ count: get().count + 1 }, false, 'inc'),
+          }))
+        ),
+        { name: 'prefix' }
+      )
     )
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.inc)()
+      useStore().count * 2
+      useStore().inc()
+      useStore.getState().count * 2
+      useStore.getState().inc()
+      useStore.subscribe(
+        (state) => state.count,
+        (count) => console.log(count * 2)
+      )
+      return <></>
+    }
+    TestComponent
+  })
 
-    return <></>
-  }
-  TestComponent
+  it('devtools & subscribeWithSelector & persist', () => {
+    const useStore = create<
+      CounterState,
+      SetState<CounterState>,
+      GetState<CounterState>,
+      StoreApiWithSubscribeWithSelector<CounterState>
+    >(
+      devtools(
+        subscribeWithSelector(
+          persist(
+            (set, get) => ({
+              count: 0,
+              inc: () => set({ count: get().count + 1 }, false),
+            }),
+            { name: 'count' }
+          )
+        ),
+        { name: 'prefix' }
+      )
+    )
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.inc)()
+      useStore().count * 2
+      useStore().inc()
+      useStore.getState().count * 2
+      useStore.getState().inc()
+      useStore.subscribe(
+        (state) => state.count,
+        (count) => console.log(count * 2)
+      )
+      return <></>
+    }
+    TestComponent
+  })
+})
+
+describe('counter state spec (quadruple middleware)', () => {
+  it('devtools & subscribeWithSelector & persist & immer (#616)', () => {
+    const useStore = create<
+      CounterState,
+      SetState<CounterState>,
+      GetState<CounterState>,
+      StoreApiWithSubscribeWithSelector<CounterState>
+    >(
+      devtools(
+        subscribeWithSelector(
+          persist(
+            immer((set, get) => ({
+              count: 0,
+              inc: () =>
+                set((state) => {
+                  state.count = get().count + 1
+                }),
+            })),
+            { name: 'count' }
+          )
+        ),
+        { name: 'prefix' }
+      )
+    )
+    const TestComponent = () => {
+      useStore((s) => s.count) * 2
+      useStore((s) => s.inc)()
+      useStore().count * 2
+      useStore().inc()
+      useStore.getState().count * 2
+      useStore.getState().inc()
+      useStore.subscribe(
+        (state) => state.count,
+        (count) => console.log(count * 2)
+      )
+      return <></>
+    }
+    TestComponent
+  })
 })

--- a/tests/middlewareTypes.test.tsx
+++ b/tests/middlewareTypes.test.tsx
@@ -464,3 +464,39 @@ it('should combine devtools, subscribeWithSelector and combine', () => {
   }
   TestComponent
 })
+
+it('should combine devtools, subscribeWithSelector, persist and immer (#616)', () => {
+  const useStore = create(
+    devtools(
+      subscribeWithSelector(
+        persist(
+          immer<{
+            count: number
+            inc: () => void
+          }>((set, get) => ({
+            count: 0,
+            inc: () =>
+              set((state) => {
+                state.count = get().count + 1
+              }),
+          })),
+          { name: 'name' }
+        )
+      )
+    )
+  )
+
+  const TestComponent = (): JSX.Element => {
+    useStore().count
+    useStore().inc()
+    useStore.getState().count
+    useStore.getState().inc()
+    useStore.subscribe(
+      (state) => state.count,
+      (count) => console.log(count * 2)
+    )
+
+    return <></>
+  }
+  TestComponent
+})

--- a/tests/middlewareTypes.test.tsx
+++ b/tests/middlewareTypes.test.tsx
@@ -1,8 +1,14 @@
 import { produce } from 'immer'
 import type { Draft } from 'immer'
-import create, { State, StateCreator, UseBoundStore } from 'zustand'
+import create, {
+  GetState,
+  SetState,
+  State,
+  StateCreator,
+  UseBoundStore,
+} from 'zustand'
 import {
-  NamedSet,
+  StoreApiWithSubscribeWithSelector,
   combine,
   devtools,
   persist,
@@ -384,8 +390,6 @@ it('should combine subscribeWithSelector and combine', () => {
     subscribeWithSelector(
       combine({ count: 1 }, (set, get) => ({
         inc: () => set({ count: get().count + 1 }, false),
-        // FIXME hope this to fail // @ts-expect-error
-        incInvalid: () => set({ count: get().count + 1 }, false, 'inc'),
       }))
     )
   )
@@ -406,18 +410,18 @@ it('should combine subscribeWithSelector and combine', () => {
 })
 
 it('should combine devtools and subscribeWithSelector', () => {
-  const useStore = create(
+  type MyState = {
+    count: number
+    inc: () => void
+  }
+  const useStore = create<
+    MyState,
+    SetState<MyState>,
+    GetState<MyState>,
+    StoreApiWithSubscribeWithSelector<MyState>
+  >(
     devtools(
-      subscribeWithSelector<
-        {
-          count: number
-          inc: () => void
-        },
-        NamedSet<{
-          count: number
-          inc: () => void
-        }>
-      >((set, get) => ({
+      subscribeWithSelector((set, get) => ({
         count: 1,
         inc: () => set({ count: get().count + 1 }, false, 'inc'),
       }))
@@ -466,14 +470,20 @@ it('should combine devtools, subscribeWithSelector and combine', () => {
 })
 
 it('should combine devtools, subscribeWithSelector, persist and immer (#616)', () => {
-  const useStore = create(
+  type MyState = {
+    count: number
+    inc: () => void
+  }
+  const useStore = create<
+    MyState,
+    SetState<MyState>,
+    GetState<MyState>,
+    StoreApiWithSubscribeWithSelector<MyState>
+  >(
     devtools(
       subscribeWithSelector(
         persist(
-          immer<{
-            count: number
-            inc: () => void
-          }>((set, get) => ({
+          immer((set, get) => ({
             count: 0,
             inc: () =>
               set((state) => {


### PR DESCRIPTION
As discussed in #616, I reverted some typing in #601, which was tricky and doesn't help to infer types for everything. This exports custom store types from middleware, so that users can manually type with middleware. Also added more tests for middleware typing.