### PR TITLE
refactor(types): prefer type alias

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -8,7 +8,7 @@ import {
 } from 'react'
 import { EqualityChecker, State, StateSelector, UseBoundStore } from 'zustand'
 
-export interface UseContextStore<T extends State> {
+export type UseContextStore<T extends State> = {
   (): T
   <U>(selector: StateSelector<T, U>, equalityFn?: EqualityChecker<U>): U
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -361,7 +361,7 @@ export type PersistOptions<
   merge?: (persistedState: any, currentState: S) => S
 }
 
-interface Thenable<Value> {
+type Thenable<Value> = {
   then<V>(
     onFulfilled: (value: Value) => V | Promise<V> | Thenable<V>
   ): Thenable<V>

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -14,7 +14,7 @@ export type StateSelector<T extends State, U> = (state: T) => U
 export type EqualityChecker<T> = (state: T, newState: T) => boolean
 export type StateListener<T> = (state: T, previousState: T) => void
 export type StateSliceListener<T> = (slice: T, previousSlice: T) => void
-export interface Subscribe<T extends State> {
+export type Subscribe<T extends State> = {
   (listener: StateListener<T>): () => void
   /**
    * @deprecated Please use `subscribeWithSelector` middleware
@@ -39,7 +39,7 @@ export type SetState<T extends State> = {
 }
 export type GetState<T extends State> = () => T
 export type Destroy = () => void
-export interface StoreApi<T extends State> {
+export type StoreApi<T extends State> = {
   setState: SetState<T>
   getState: GetState<T>
   subscribe: Subscribe<T>


### PR DESCRIPTION
I know this is mostly about preference, but I feel a little bad about mixing two styles for maintainability.
There are some differences between interface and type alias, like overloading, index signature and maybe others.
However, in the current code, mostly type alias is used and only some cases use interface. Hopefully making it consistent makes sense. (In this PR, to type alias.)
If this causes a real problem rather than styling preference, we can revisit. (I can think of one case, module augmentation, but wonder if anyone does it, and if it's the case, we should prefer "export function" too.)