### PR TITLE
Export created Context value

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -99,6 +99,7 @@ function createContext<
     Provider,
     useStore,
     useStoreApi,
+    Context: ZustandContext,
   }
 }
 


### PR DESCRIPTION
This enables `zustand` context to be used in apis that expect a `Context` value, e.g. `React.useContext` or `useContextBridge` from `drei`.

Without the export it appears impossible to use `zustand/context` with `useContextBridge`.