### PR TITLE
Fix typescript error, incompatibility with strict mode set to true

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -368,7 +368,7 @@ export type PersistOptions<
   merge?: (persistedState: any, currentState: S) => S
 }
 export type StoreApiWithPersist<S extends State> = StoreApi<S> & {
-  persist: {
+  persist?: {
     setOptions: (options: Partial<PersistOptions<S>>) => void
     clearStorage: () => void
     rehydrate: () => Promise<void>
@@ -458,7 +458,7 @@ export const persist =
 
     let hasHydrated = false
     const onHydrateCallbacks: Parameters<
-      StoreApiWithPersist<S>['persist']['onHydrate']
+      Exclude<StoreApiWithPersist<S>['persist'], undefined>['onHydrate']
     >[0][] = []
     let storage: StateStorage | undefined
 


### PR DESCRIPTION
To fix issues described here https://github.com/pmndrs/zustand/issues/638

I am just setting the `persist` option to optional (adding `?`) as seen on line 371 in `src/middleware.ts`
Also to make that possible, we need to exclude `undefined` from typing at line 461