### PR TITLE
feat(middleware): add onFinishHydration to persist api

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react'
 import {
   EqualityChecker,
   GetState,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import {
   EqualityChecker,
   GetState,
@@ -367,13 +368,15 @@ export type PersistOptions<
    */
   merge?: (persistedState: any, currentState: S) => S
 }
+type PersistListener<S> = (state: S) => void
 export type StoreApiWithPersist<S extends State> = StoreApi<S> & {
   persist: {
     setOptions: (options: Partial<PersistOptions<S>>) => void
     clearStorage: () => void
     rehydrate: () => Promise<void>
     hasHydrated: () => boolean
-    onHydrate: (fn: (state: S) => void) => void
+    onHydrate: (fn: PersistListener<S>) => () => void
+    onFinishHydration: (fn: PersistListener<S>) => () => void
   }
 }
 
@@ -457,9 +460,8 @@ export const persist =
     }
 
     let hasHydrated = false
-    const onHydrateCallbacks: Parameters<
-      StoreApiWithPersist<S>['persist']['onHydrate']
-    >[0][] = []
+    const hydrationListeners = new Set<PersistListener<S>>()
+    const finishHydrationListeners = new Set<PersistListener<S>>()
     let storage: StateStorage | undefined
 
     try {
@@ -539,6 +541,7 @@ export const persist =
       if (!storage) return
 
       hasHydrated = false
+      hydrationListeners.forEach((cb) => cb(get()))
 
       const postRehydrationCallback =
         options.onRehydrateStorage?.(get()) || undefined
@@ -579,7 +582,7 @@ export const persist =
         .then(() => {
           postRehydrationCallback?.(stateFromStorage, undefined)
           hasHydrated = true
-          onHydrateCallbacks.forEach((cb) => cb(stateFromStorage as S))
+          finishHydrationListeners.forEach((cb) => cb(stateFromStorage as S))
         })
         .catch((e: Error) => {
           postRehydrationCallback?.(undefined, e)
@@ -603,7 +606,18 @@ export const persist =
       rehydrate: () => hydrate() as Promise<void>,
       hasHydrated: () => hasHydrated,
       onHydrate: (cb) => {
-        onHydrateCallbacks.push(cb)
+        hydrationListeners.add(cb)
+
+        return () => {
+          hydrationListeners.delete(cb)
+        }
+      },
+      onFinishHydration: (cb) => {
+        finishHydrationListeners.add(cb)
+
+        return () => {
+          finishHydrationListeners.delete(cb)
+        }
       },
     }
 

--- a/tests/persistAsync.test.tsx
+++ b/tests/persistAsync.test.tsx
@@ -451,7 +451,7 @@ describe('persist middleware with async configuration', () => {
       })
     )
     expect(useStore.persist.hasHydrated()).toBe(false)
-    await new Promise((resolve) => useStore.persist.onHydrate(resolve))
+    await new Promise((resolve) => useStore.persist.onFinishHydration(resolve))
     expect(useStore.persist.hasHydrated()).toBe(true)
 
     await useStore.persist.rehydrate()

--- a/tests/persistSync.test.tsx
+++ b/tests/persistSync.test.tsx
@@ -1,3 +1,4 @@
+import { render } from '@testing-library/react'
 import create from 'zustand'
 import { persist } from 'zustand/middleware'
 
@@ -479,11 +480,14 @@ describe('persist middleware with sync configuration', () => {
     expect(useStore.persist.hasHydrated()).toBe(true)
   })
 
-  it('can wait for hydration through the api', async () => {
-    const storageValue = '{"state":{"count":1},"version":0}'
+  it('can wait for rehydration through the api', async () => {
+    const storageValue1 = '{"state":{"count":1},"version":0}'
+    const storageValue2 = '{"state":{"count":2},"version":0}'
 
     const onHydrateSpy1 = jest.fn()
     const onHydrateSpy2 = jest.fn()
+    const onFinishHydrationSpy1 = jest.fn()
+    const onFinishHydrationSpy2 = jest.fn()
 
     const storage = {
       getItem: () => '',
@@ -498,12 +502,29 @@ describe('persist middleware with sync configuration', () => {
       })
     )
 
-    useStore.persist.onHydrate(onHydrateSpy1)
+    const hydrateUnsub1 = useStore.persist.onHydrate(onHydrateSpy1)
     useStore.persist.onHydrate(onHydrateSpy2)
 
-    storage.getItem = () => storageValue
+    const finishHydrationUnsub1 = useStore.persist.onFinishHydration(
+      onFinishHydrationSpy1
+    )
+    useStore.persist.onFinishHydration(onFinishHydrationSpy2)
+
+    storage.getItem = () => storageValue1
     await useStore.persist.rehydrate()
-    expect(onHydrateSpy1).toBeCalledWith({ count: 1 })
+    expect(onHydrateSpy1).toBeCalledWith({ count: 0 })
+    expect(onHydrateSpy2).toBeCalledWith({ count: 0 })
+    expect(onFinishHydrationSpy1).toBeCalledWith({ count: 1 })
+    expect(onFinishHydrationSpy2).toBeCalledWith({ count: 1 })
+
+    hydrateUnsub1()
+    finishHydrationUnsub1()
+
+    storage.getItem = () => storageValue2
+    await useStore.persist.rehydrate()
+    expect(onHydrateSpy1).not.toBeCalledTimes(2)
     expect(onHydrateSpy2).toBeCalledWith({ count: 1 })
+    expect(onFinishHydrationSpy1).not.toBeCalledTimes(2)
+    expect(onFinishHydrationSpy2).toBeCalledWith({ count: 2 })
   })
 })

--- a/tests/persistSync.test.tsx
+++ b/tests/persistSync.test.tsx
@@ -1,4 +1,3 @@
-import { render } from '@testing-library/react'
 import create from 'zustand'
 import { persist } from 'zustand/middleware'
 


### PR DESCRIPTION
I noticed in #644 that I kind of misnamed `useStore.persist.onHydrate` :grimacing: 
By the name `onHydrate` we would most likely expect the callback to be called when hydration starts, while in reality it's called when hydration is finished.
I fixed this by actually calling `onHydrate`'s callback when hydration starts, and adding a new `onFinishHydration` method to the persist api.

This pr also adds a new `useStore.persist.useHydration()` hook to make it easier to (mainly?) know if hydration is finished.