### PR TITLE
Remove devtools prefixing from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -439,7 +439,7 @@ const useStore = create(devtools(redux(reducer, initialState)))
 
 devtools takes the store function as its first argument, optionally you can name the store or configure [serialize](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#serialize) options with a second argument.  
   
-Name store: `devtools(store, {name: "MyStore"})`, which will be prefixed to your actions.  
+Name store: `devtools(store, {name: "MyStore"})`, which will create a seperate instance named "MyStore" in the devtools.
 Serialize options: `devtools(store, { serialize: { options: true } })`.  
   
 devtools will only log actions from each separated store unlike in a typical *combined reducers* redux store. See an approach to combining stores https://github.com/pmndrs/zustand/issues/163


### PR DESCRIPTION
In accordance with #675 