### PR TITLE
docs: add note about using set() third param for logging

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -440,15 +440,14 @@ const useStore = create(devtools(redux(reducer, initialState)))
 devtools takes the store function as its first argument, optionally you can name the store or configure [serialize](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#serialize) options with a second argument.  
   
 Name store: `devtools(store, {name: "MyStore"})`, which will create a seperate instance named "MyStore" in the devtools.
-Serialize options: `devtools(store, { serialize: { options: true } })`.  
+
+Serialize options: `devtools(store, { serialize: { options: true } })`. 
   
 #### Logging Actions
 
 devtools will only log actions from each separated store unlike in a typical *combined reducers* redux store. See an approach to combining stores https://github.com/pmndrs/zustand/issues/163
 
-Because of this, actions will be logged as "anonymous" by default. To set a default log action type for all actions from your store: `devtools(store, {name: 'MyStore', anonymousActionType: 'MyStoreAction'})`
-
-Alternatively, `set` functions take a third parameter which can be used to log any action type you choose: 
+You can log a specific action type for each `set` function by passing a third parameter:
 
 ```jsx
 const createBearSlice = (set, get) => ({
@@ -459,6 +458,12 @@ const createBearSlice = (set, get) => ({
       "bear/eatFish"
     ),
 })
+```
+
+If an action type is not provided, it is defaulted to "anonymous". You can customize this default value by providing an `anonymousActionType` parameter: 
+
+```jsx
+devtools(..., { anonymousActionType: 'unknown', ... })
 ```
 
 ## React context

--- a/readme.md
+++ b/readme.md
@@ -441,7 +441,7 @@ devtools takes the store function as its first argument, optionally you can name
   
 Name store: `devtools(store, {name: "MyStore"})`, which will create a seperate instance named "MyStore" in the devtools.
 
-Serialize options: `devtools(store, { serialize: { options: true } })`. 
+Serialize options: `devtools(store, { serialize: { options: true } })`.
   
 #### Logging Actions
 

--- a/readme.md
+++ b/readme.md
@@ -442,7 +442,24 @@ devtools takes the store function as its first argument, optionally you can name
 Name store: `devtools(store, {name: "MyStore"})`, which will create a seperate instance named "MyStore" in the devtools.
 Serialize options: `devtools(store, { serialize: { options: true } })`.  
   
+#### Logging Actions
+
 devtools will only log actions from each separated store unlike in a typical *combined reducers* redux store. See an approach to combining stores https://github.com/pmndrs/zustand/issues/163
+
+Because of this, actions will be logged as "anonymous" by default. To set a default log action type for all actions from your store: `devtools(store, {name: 'MyStore', anonymousActionType: 'MyStoreAction'})`
+
+Alternatively, `set` functions take a third parameter which can be used to log any action type you choose: 
+
+```jsx
+const createBearSlice = (set, get) => ({
+  eatFish: () =>
+    set(
+      (prev) => ({ fishes: prev.fishes > 1 ? prev.fishes - 1 : 0 }),
+      false,
+      "bear/eatFish"
+    ),
+})
+```
 
 ## React context
 


### PR DESCRIPTION
Newcomers to zustand may be confused why devtools doesn't show action types by default (I was!), so I've added  a note to the readme following [this comment from @devanshj ](https://github.com/pmndrs/zustand/issues/705#issuecomment-992976936)