### PR TITLE
Deprecations before v4

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -95,14 +95,24 @@ function createContext<
     )
   }
 
+  let didWarnAboutStoreApiDeprecation = false
+
   return {
     Provider,
     useStore,
     /**
-    * @deprecated `useStoreApi` is renamed to `useStoreRef`, `useStoreApi` will be removed in next major
-    */
-    useStoreApi,
-    useStoreRef: useStoreApi
+     * @deprecated `useStoreApi` is renamed to `useStoreRef`, `useStoreApi` will be removed in next major
+     */
+    useStoreApi: (...a: Parameters<typeof useStoreApi>) => {
+      if (!didWarnAboutStoreApiDeprecation) {
+        console.warn(
+          '`useStoreApi` is renamed to `useStoreRef`, `useStoreApi` will be removed in next major'
+        )
+        didWarnAboutStoreApiDeprecation = true
+      }
+      return useStoreApi(...a)
+    },
+    useStoreRef: useStoreApi,
   }
 }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -98,7 +98,11 @@ function createContext<
   return {
     Provider,
     useStore,
+    /**
+    * @deprecated `useStoreApi` is renamed to `useStoreRef`, `useStoreApi` will be removed in next major
+    */
     useStoreApi,
+    useStoreRef: useStoreApi
   }
 }
 

--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -69,26 +69,25 @@ export function devtools<
   CustomStoreApi extends StoreApi<S>
 >(
   fn: (set: NamedSet<S>, get: CustomGetState, api: CustomStoreApi) => S,
-  options?:
-    {
-      name?: string
-      anonymousActionType?: string
-      serialize?: {
-        options:
-          | boolean
-          | {
-              date?: boolean
-              regex?: boolean
-              undefined?: boolean
-              nan?: boolean
-              infinity?: boolean
-              error?: boolean
-              symbol?: boolean
-              map?: boolean
-              set?: boolean
-            }
-      }
+  options?: {
+    name?: string
+    anonymousActionType?: string
+    serialize?: {
+      options:
+        | boolean
+        | {
+            date?: boolean
+            regex?: boolean
+            undefined?: boolean
+            nan?: boolean
+            infinity?: boolean
+            error?: boolean
+            symbol?: boolean
+            map?: boolean
+            set?: boolean
+          }
     }
+  }
 ): (
   set: CustomSetState,
   get: CustomGetState,
@@ -136,13 +135,13 @@ export function devtools<
         dispatchFromDevtools?: boolean
       }
   ): S => {
-    let didWarnAboutNameDeprecation = false;
+    let didWarnAboutNameDeprecation = false
     if (typeof options === 'string' && !didWarnAboutNameDeprecation) {
       console.warn(
         '[zustand devtools middleware]: passing `name` as directly will be not allowed in next major' +
-        'pass the `name` in an object `{ name: ... }` instead'
+          'pass the `name` in an object `{ name: ... }` instead'
       )
-      didWarnAboutNameDeprecation = true;
+      didWarnAboutNameDeprecation = true
     }
     const devtoolsOptions =
       options === undefined

--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -41,37 +41,93 @@ export type StoreApiWithDevtools<T extends State> = StoreApi<T> & {
   devtools?: DevtoolsType
 }
 
-export const devtools =
-  <
-    S extends State,
-    CustomSetState extends SetState<S>,
-    CustomGetState extends GetState<S>,
-    CustomStoreApi extends StoreApi<S>
-  >(
-    fn: (set: NamedSet<S>, get: CustomGetState, api: CustomStoreApi) => S,
-    options?:
-      | string
-      | {
-          name?: string
-          anonymousActionType?: string
-          serialize?: {
-            options:
-              | boolean
-              | {
-                  date?: boolean
-                  regex?: boolean
-                  undefined?: boolean
-                  nan?: boolean
-                  infinity?: boolean
-                  error?: boolean
-                  symbol?: boolean
-                  map?: boolean
-                  set?: boolean
-                }
-          }
+/**
+ * @deprecated Passing `name` as directly will be not allowed in next major.
+ * Pass the `name` in an object `{ name: ... }` instead
+ */
+export function devtools<
+  S extends State,
+  CustomSetState extends SetState<S>,
+  CustomGetState extends GetState<S>,
+  CustomStoreApi extends StoreApi<S>
+>(
+  fn: (set: NamedSet<S>, get: CustomGetState, api: CustomStoreApi) => S,
+  options?: string
+): (
+  set: CustomSetState,
+  get: CustomGetState,
+  api: CustomStoreApi &
+    StoreApiWithDevtools<S> & {
+      dispatch?: unknown
+      dispatchFromDevtools?: boolean
+    }
+) => S
+export function devtools<
+  S extends State,
+  CustomSetState extends SetState<S>,
+  CustomGetState extends GetState<S>,
+  CustomStoreApi extends StoreApi<S>
+>(
+  fn: (set: NamedSet<S>, get: CustomGetState, api: CustomStoreApi) => S,
+  options?:
+    {
+      name?: string
+      anonymousActionType?: string
+      serialize?: {
+        options:
+          | boolean
+          | {
+              date?: boolean
+              regex?: boolean
+              undefined?: boolean
+              nan?: boolean
+              infinity?: boolean
+              error?: boolean
+              symbol?: boolean
+              map?: boolean
+              set?: boolean
+            }
+      }
+    }
+): (
+  set: CustomSetState,
+  get: CustomGetState,
+  api: CustomStoreApi &
+    StoreApiWithDevtools<S> & {
+      dispatch?: unknown
+      dispatchFromDevtools?: boolean
+    }
+) => S
+export function devtools<
+  S extends State,
+  CustomSetState extends SetState<S>,
+  CustomGetState extends GetState<S>,
+  CustomStoreApi extends StoreApi<S>
+>(
+  fn: (set: NamedSet<S>, get: CustomGetState, api: CustomStoreApi) => S,
+  options?:
+    | string
+    | {
+        name?: string
+        anonymousActionType?: string
+        serialize?: {
+          options:
+            | boolean
+            | {
+                date?: boolean
+                regex?: boolean
+                undefined?: boolean
+                nan?: boolean
+                infinity?: boolean
+                error?: boolean
+                symbol?: boolean
+                map?: boolean
+                set?: boolean
+              }
         }
-  ) =>
-  (
+      }
+) {
+  return (
     set: CustomSetState,
     get: CustomGetState,
     api: CustomStoreApi &
@@ -80,6 +136,14 @@ export const devtools =
         dispatchFromDevtools?: boolean
       }
   ): S => {
+    let didWarnAboutNameDeprecation = false;
+    if (typeof options === 'string' && !didWarnAboutNameDeprecation) {
+      console.warn(
+        '[zustand devtools middleware]: passing `name` as directly will be not allowed in next major' +
+        'pass the `name` in an object `{ name: ... }` instead'
+      )
+      didWarnAboutNameDeprecation = true;
+    }
     const devtoolsOptions =
       options === undefined
         ? { name: undefined, anonymousActionType: undefined }
@@ -262,6 +326,7 @@ export const devtools =
 
     return initialState
   }
+}
 
 const parseJsonThen = <T>(stringified: string, f: (parsed: T) => void) => {
   let parsed: T | undefined

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -1,6 +1,18 @@
+/**
+ * @deprecated `State` is renamed to `UnknownState`,
+ * `State` will be removed in next major
+ */
 export type State = object
+
+export type UnknownState = object;
+
 // types inspired by setState from React, see:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/6c49e45842358ba59a508e13130791989911430d/types/react/v16/index.d.ts#L489-L495
+/**
+ * @deprecated Use the builtin `Partial<T>` instead of `PartialState<T>`.
+ * Additionally turn on `--exactOptionalPropertyTypes` tsc flag.
+ * `PartialState` will be removed in next major
+ */
 export type PartialState<
   T extends State,
   K1 extends keyof T = keyof T,
@@ -10,10 +22,35 @@ export type PartialState<
 > =
   | (Pick<T, K1> | Pick<T, K2> | Pick<T, K3> | Pick<T, K4> | T)
   | ((state: T) => Pick<T, K1> | Pick<T, K2> | Pick<T, K3> | Pick<T, K4> | T)
+
+/**
+ * @deprecated Use `(t: T) => U` instead of `StateSelector<T, U>`.
+ * `StateSelector` will be removed in next major.
+ */
 export type StateSelector<T extends State, U> = (state: T) => U
+
+/**
+ * @deprecated Use `(a: T, b: T) => boolean` instead of `EqualityChecker<T>.
+ * `EqualityChecker` will be removed in next major.
+ */
 export type EqualityChecker<T> = (state: T, newState: T) => boolean
+
+/** 
+ * @deprecated Use `(state: T, prevState: T) => void` instead of `StateListener<T>`.
+ * `StateListener` will be removed in next major.
+ */
 export type StateListener<T> = (state: T, previousState: T) => void
+
+/** 
+ * @deprecated Use `(slice: T, prevSlice: T) => void` instead of `StateSliceListener<T>`.
+ * `StateSliceListener` will be removed in next major.
+ */
 export type StateSliceListener<T> = (slice: T, previousSlice: T) => void
+
+/**
+ * @deprecated Use `Store<T>['subscribe']` instead of `Subscribe<T>`.
+ * `Subscribe` will be removed in next major.
+ */
 export type Subscribe<T extends State> = {
   (listener: StateListener<T>): () => void
   /**
@@ -26,6 +63,10 @@ export type Subscribe<T extends State> = {
   ): () => void
 }
 
+/**
+ * @deprecated Use `Store<T>['setState']` instead of `SetState<T>`
+ * `SetState` will be removed in next major.
+ */
 export type SetState<T extends State> = {
   <
     K1 extends keyof T,
@@ -37,15 +78,50 @@ export type SetState<T extends State> = {
     replace?: boolean
   ): void
 }
+
+/**
+ * @deprecated Use `() => T` or `Store<T>['getState']` instead of `GetState<T>`
+ * `GetState` will be removed in next major.
+ */
 export type GetState<T extends State> = () => T
+
+/**
+ * @deprecated Use `() => void` or `Store<UnknownState>['destroy']` instead of `Destroy`.
+ * `Destroy` will be removed in next major.
+ */
 export type Destroy = () => void
+
+/**
+ * @deprecated `StoreApi<T>` has been renamed to `Store<T>`
+ * `StoreApi` will be removed in next major.
+ */
 export type StoreApi<T extends State> = {
   setState: SetState<T>
   getState: GetState<T>
   subscribe: Subscribe<T>
   destroy: Destroy
 }
+
+export type Store<T extends State> = {
+  setState: SetState<T>
+  getState: GetState<T>
+  subscribe: Subscribe<T>
+  destroy: Destroy
+}
+
+/**
+ * @deprecated `StateCreator` has been renamed to `StoreInitializer`.
+ * `StateCreator` will be removed in next major.
+ */
 export type StateCreator<
+  T extends State,
+  CustomSetState = SetState<T>,
+  CustomGetState = GetState<T>,
+  CustomStoreApi extends StoreApi<T> = StoreApi<T>
+> = (set: CustomSetState, get: CustomGetState, api: CustomStoreApi) => T
+
+
+export type StoreInitializer<
   T extends State,
   CustomSetState = SetState<T>,
   CustomGetState = GetState<T>,

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -4,7 +4,7 @@
  */
 export type State = object
 
-export type UnknownState = object;
+export type UnknownState = object
 
 // types inspired by setState from React, see:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/6c49e45842358ba59a508e13130791989911430d/types/react/v16/index.d.ts#L489-L495
@@ -35,13 +35,13 @@ export type StateSelector<T extends State, U> = (state: T) => U
  */
 export type EqualityChecker<T> = (state: T, newState: T) => boolean
 
-/** 
+/**
  * @deprecated Use `(state: T, prevState: T) => void` instead of `StateListener<T>`.
  * `StateListener` will be removed in next major.
  */
 export type StateListener<T> = (state: T, previousState: T) => void
 
-/** 
+/**
  * @deprecated Use `(slice: T, prevSlice: T) => void` instead of `StateSliceListener<T>`.
  * `StateSliceListener` will be removed in next major.
  */
@@ -119,7 +119,6 @@ export type StateCreator<
   CustomGetState = GetState<T>,
   CustomStoreApi extends StoreApi<T> = StoreApi<T>
 > = (set: CustomSetState, get: CustomGetState, api: CustomStoreApi) => T
-
 
 export type StoreInitializer<
   T extends State,


### PR DESCRIPTION
This PR is to be released as a minor which will contain deprecations that'll make the migration to the next major smoother. This is not to be merged yet, as #662 progresses this will get more commits if required, so this will be ready when #662 is ready.

I'm quite an idealist, I value correctness higher than non-breaking change, so changes are in alignment to that, they can always be negotiated later, I'm not the boss :)

Changes till now:
- **Minimizing Types**.
  - Some types are removed which can be replaced by a existing type. Eg `SetState<T>` to `Store<T>['setState']`. It's best if derived types are actually derived. A type named `SetState<T>` doesn't tell what is it's relationship to `Store<T>` or where did it came from. It's always good to only export the necessary types.
  - Some types are removed which can be inlined. Eg `EqualityChecker<T>` to `(a: T, b: T) => boolean` and `StateSelector<T, U>` to `(state: T) => U`. The beauty of types is that you can tell their implementation by simply looking at them. `StateSelector<T, U>` doesn't tell me anything about the implementation whereas a shorter `(state: T) => U` does. Types should only be extracted if the name is more telling than it's definition or the definition is too long to write, eg `Store<T>`.
  - Some types are only renamed to better names. Eg. `StateCreator` to `StoreInitializer`.
- **Removing the "api" nomenclature**.
  Calling "store" as "storeApi" is like calling "todos" as "todosArray", "Tea" as "Tea beverage", "Devansh" as "Devansh Human". Good part is that this is not visible at a lot of places in the code. When using context, there's a `useStoreApi` so that is renamed to `useStoreRef` (as `useStore` is already for reading the state).
  A more idealist and correct naming would have been calling `MyStoreContext.useStore()` as simply `MyStoreContext.use()`, and `MyStoreContext.useStoreRef()` as `MyStoreContext.useStore()`, but that's too radical change so I avoided it, let me know if you like it anyway.
- `devtools({}, name)` to `devtools({}, { name }`. Ability to pass the name directly is a rather unnecessary feature, more over expecting an object is consistent with `persist`. Good part is the documentation doesn't mention that you can directly pass the name so hopefully many users would not be using it.