### PR TITLE
fix(react): update reactive listener on api change

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -147,7 +147,7 @@ function create<
         listener() // state has changed before subscription
       }
       return unsubscribe
-    }, [])
+    }, [api])
 
     const sliceToReturn = hasNewStateSlice
       ? (newStateSlice as StateSlice)

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -7,8 +7,12 @@ import {
 } from 'react'
 import { act, fireEvent, render } from '@testing-library/react'
 import ReactDOM from 'react-dom'
-import create, { EqualityChecker, SetState, StateSelector, UseBoundStore } from 'zustand'
-import createStore from 'zustand/vanilla'
+import create, {
+  EqualityChecker,
+  SetState,
+  StateSelector,
+  UseBoundStore,
+} from 'zustand'
 
 const consoleError = console.error
 afterEach(() => {
@@ -145,23 +149,31 @@ it('only re-renders if selected state has changed', async () => {
 })
 
 it('still re-renders if store has changed', async () => {
-  const origStore = {useStore: create<CounterState>((set) => ({
-    count: 0,
-    inc: () => set((state) => ({ count: state.count + 1 })),
-  }))}
-  const nextStore = {useStore: create<CounterState>((set) => ({
-    count: 0,
-    inc: () => set((state) => ({ count: state.count + 1 })),
-  }))}
+  const origStore = {
+    useStore: create<CounterState>((set) => ({
+      count: 0,
+      inc: () => set((state) => ({ count: state.count + 1 })),
+    })),
+  }
+  const nextStore = {
+    useStore: create<CounterState>((set) => ({
+      count: 0,
+      inc: () => set((state) => ({ count: state.count + 1 })),
+    })),
+  }
   let counterRenderCount = 0
 
-  function Counter({store}: {store: {useStore: UseBoundStore<CounterState>}}) {
+  function Counter({
+    store,
+  }: {
+    store: { useStore: UseBoundStore<CounterState> }
+  }) {
     const count = store.useStore((state) => state.count)
     counterRenderCount++
     return <div>count: {count}</div>
   }
 
-  const { getByText, findByText, rerender } = render(
+  const { findByText, rerender } = render(
     <>
       <Counter store={origStore} />
     </>
@@ -170,7 +182,7 @@ it('still re-renders if store has changed', async () => {
   await findByText('count: 0')
 
   act(() => {
-    origStore.useStore.setState({count: 1})
+    origStore.useStore.setState({ count: 1 })
   })
 
   await findByText('count: 1')
@@ -184,7 +196,7 @@ it('still re-renders if store has changed', async () => {
   await findByText('count: 0')
 
   act(() => {
-    nextStore.useStore.setState({count: 1})
+    nextStore.useStore.setState({ count: 1 })
   })
 
   await findByText('count: 1')


### PR DESCRIPTION
- Make `useStore` reactive even if the store is swapped after the initial render (fixes #721).