### PR TITLE
fix(middleware): revert devtools extension connector with try-catch

### DIFF
--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -87,16 +87,20 @@ export const devtools =
         ? { name: options }
         : options
 
-    if (typeof window === 'undefined') {
-      return fn(set, get, api)
+    let extensionConnector
+    try {
+      extensionConnector =
+        (window as any).__REDUX_DEVTOOLS_EXTENSION__ ||
+        (window as any).top.__REDUX_DEVTOOLS_EXTENSION__
+    } catch {
+      // ignored
     }
 
-    const extensionConnector =
-      (window as any).__REDUX_DEVTOOLS_EXTENSION__ ||
-      (window as any).top.__REDUX_DEVTOOLS_EXTENSION__
-
     if (!extensionConnector) {
-      if (process.env.NODE_ENV === 'development') {
+      if (
+        process.env.NODE_ENV === 'development' &&
+        typeof window !== 'undefined'
+      ) {
         console.warn(
           '[zustand devtools middleware] Please install/enable Redux devtools extension'
         )

--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -489,3 +489,14 @@ it('works in non-browser env', () => {
 
   global.window = originalWindow
 })
+
+it('works in react native env', () => {
+  const originalWindow = global.window
+  global.window = {} as any
+
+  expect(() => {
+    create(devtools(() => ({ count: 0 })))
+  }).not.toThrow()
+
+  global.window = originalWindow
+})


### PR DESCRIPTION
close #723

When I reviewed #675, I thought it's clean without try-catch.
Later, an issue is reported and we fix it with #693, but that wasn't enough.
This is to revert to pre #675, with try-catch.