### PR TITLE
chore(examples): Refactor demo code to reduce distraction from Zustand usage

### DIFF
--- a/examples/src/App.js
+++ b/examples/src/App.js
@@ -1,22 +1,9 @@
-import * as THREE from 'three'
-import React, { Suspense, useRef, useState } from 'react'
-import { Canvas, useFrame, useThree } from 'react-three-fiber'
-import { Plane, useAspect, useTextureLoader } from 'drei'
-import { EffectComposer, DepthOfField, Vignette } from 'react-postprocessing'
+import React from 'react'
 import create from 'zustand'
 import CodePreview from './components/CodePreview'
-import 'prismjs'
-import 'prismjs/components/prism-jsx.min'
-import 'prismjs/themes/prism-okaidia.css'
-import Fireflies from './components/Fireflies'
-import bgUrl from './resources/bg.jpg'
-import starsUrl from './resources/stars.png'
-import groundUrl from './resources/ground.png'
-import bearUrl from './resources/bear.png'
-import leaves1Url from './resources/leaves1.png'
-import leaves2Url from './resources/leaves2.png'
+import Backdrop from './components/Backdrop'
+import Details from './components/Details'
 import code from './resources/code'
-import './materials/layerMaterial'
 
 const useStore = create((set) => ({
   count: 1,
@@ -33,80 +20,10 @@ function Counter() {
   )
 }
 
-function Scene({ dof }) {
-  const scaleN = useAspect('cover', 1600, 1000, 0.21)
-  const scaleW = useAspect('cover', 2200, 1000, 0.21)
-  const textures = useTextureLoader([bgUrl, starsUrl, groundUrl, bearUrl, leaves1Url, leaves2Url])
-  const subject = useRef()
-  const group = useRef()
-  const layersRef = useRef([])
-  const [movementVector] = useState(() => new THREE.Vector3())
-  const [tempVector] = useState(() => new THREE.Vector3())
-  const [focusVector] = useState(() => new THREE.Vector3())
-  const layers = [
-    { texture: textures[0], z: 0, factor: 0.005, scale: scaleW },
-    { texture: textures[1], z: 10, factor: 0.005, scale: scaleW },
-    { texture: textures[2], z: 20, scale: scaleW },
-    { texture: textures[3], z: 30, ref: subject, scaleFactor: 0.83, scale: scaleN },
-    { texture: textures[4], factor: 0.03, scaleFactor: 1, z: 40, wiggle: 0.24, scale: scaleW },
-    { texture: textures[5], factor: 0.04, scaleFactor: 1.3, z: 49, wiggle: 0.3, scale: scaleW },
-  ]
-
-  useFrame((state, delta) => {
-    dof.current.target = focusVector.lerp(subject.current.position, 0.05)
-    movementVector.lerp(tempVector.set(state.mouse.x, state.mouse.y * 0.2, 0), 0.2)
-    group.current.position.x = THREE.MathUtils.lerp(group.current.position.x, state.mouse.x * 20, 0.2)
-    group.current.rotation.x = THREE.MathUtils.lerp(group.current.rotation.x, state.mouse.y / 10, 0.2)
-    group.current.rotation.y = THREE.MathUtils.lerp(group.current.rotation.y, -state.mouse.x / 2, 0.2)
-    layersRef.current[4].uniforms.time.value = layersRef.current[5].uniforms.time.value += delta
-  }, 1)
-
-  return (
-    <group ref={group}>
-      <Fireflies count={10} radius={80} colors={['orange']} />
-      {layers.map(({ scale, texture, ref, factor = 0, scaleFactor = 1, wiggle = 0, z }, i) => (
-        <Plane scale={scale} args={[1, 1, wiggle ? 10 : 1, wiggle ? 10 : 1]} position-z={z} key={i} ref={ref}>
-          <layerMaterial
-            attach="material"
-            movementVector={movementVector}
-            textr={texture}
-            factor={factor}
-            ref={(el) => (layersRef.current[i] = el)}
-            wiggle={wiggle}
-            scaleFactor={scaleFactor}
-          />
-        </Plane>
-      ))}
-    </group>
-  )
-}
-
-const Effects = React.forwardRef((props, ref) => {
-  const {
-    viewport: { width, height },
-  } = useThree()
-  return (
-    <EffectComposer multisampling={0}>
-      <DepthOfField ref={ref} bokehScale={4} focalLength={0.1} width={width / 2} height={height / 2} />
-      <Vignette />
-    </EffectComposer>
-  )
-})
-
 export default function App() {
-  const dof = useRef()
   return (
     <>
-      <Canvas
-        className="canvas-container"
-        orthographic
-        gl={{ powerPreference: 'high-performance', antialias: false, stencil: false, alpha: false, depth: false }}
-        camera={{ zoom: 5, position: [0, 0, 200], far: 300, near: 0 }}>
-        <Suspense fallback={null}>
-          <Scene dof={dof} />
-        </Suspense>
-        <Effects ref={dof} />
-      </Canvas>
+      <Backdrop />
       <div className="main">
         <div className="code">
           <div className="code-container">
@@ -114,17 +31,7 @@ export default function App() {
             <Counter />
           </div>
         </div>
-
-        <a href="https://github.com/drcmda/zustand" className="top-right" children="Github" />
-        <div className="bottom">
-          <a href="https://codesandbox.io/s/xgjtc" className="bottom-right" children="<Source />" />
-          <a
-            href="https://www.instagram.com/tina.henschel/"
-            className="bottom-left"
-            children="Illustrations @ Tina Henschel"
-          />
-        </div>
-        <span className="header-left">Zustand</span>
+        <Details />
       </div>
     </>
   )

--- a/examples/src/components/Backdrop.js
+++ b/examples/src/components/Backdrop.js
@@ -1,0 +1,21 @@
+import React, { Suspense, useRef } from 'react'
+import { Canvas } from 'react-three-fiber'
+import Effects from './Effects'
+import Scene from './Scene'
+
+export default function Backdrop() {
+  const dof = useRef()
+  return (
+    <Canvas
+      className="canvas-container"
+      orthographic
+      gl={{ powerPreference: 'high-performance', antialias: false, stencil: false, alpha: false, depth: false }}
+      camera={{ zoom: 5, position: [0, 0, 200], far: 300, near: 0 }}
+    >
+      <Suspense fallback={null}>
+        <Scene dof={dof} />
+      </Suspense>
+      <Effects ref={dof} />
+    </Canvas>
+  )
+}

--- a/examples/src/components/CodePreview.js
+++ b/examples/src/components/CodePreview.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import Highlight, { defaultProps } from 'prism-react-renderer'
-import { CopyButton } from './CopyButton'
+import CopyButton from './CopyButton'
 import 'prismjs'
 import 'prismjs/components/prism-jsx.min'
 import 'prismjs/themes/prism-okaidia.css'
 
-function CodePreview({ code, ...props }) {
+export default function CodePreview({ code, ...props }) {
   return (
     <Highlight {...defaultProps} className="language-jsx" code={code} language="jsx" theme={undefined}>
       {({ className, style, tokens, getLineProps, getTokenProps }) => (
@@ -25,4 +25,3 @@ function CodePreview({ code, ...props }) {
     </Highlight>
   )
 }
-export default CodePreview

--- a/examples/src/components/CopyButton.js
+++ b/examples/src/components/CopyButton.js
@@ -5,7 +5,7 @@ import { copyToClipboard } from '../utils/copy-to-clipboard'
 Isolated logic for the entire copy functionality instead 
 of a separate button component and with the added utility
 */
-export function CopyButton({ code, ...props }) {
+export default function CopyButton({ code, ...props }) {
   const [isCopied, setIsCopied] = useState(false)
 
   const handleCopy = () => {
@@ -31,7 +31,8 @@ export function CopyButton({ code, ...props }) {
               strokeWidth={2}
               strokeLinecap="round"
               strokeLinejoin="round"
-              {...props}>
+              {...props}
+            >
               <rect x={9} y={9} width={13} height={13} rx={2} ry={2} />
               <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
             </svg>

--- a/examples/src/components/Details.js
+++ b/examples/src/components/Details.js
@@ -3,7 +3,7 @@ import React from 'react'
 export default function () {
   return (
     <>
-      <a href="https://github.com/drcmda/zustand" className="top-right" children="Github" />
+      <a href="https://github.com/pmndrs/zustand" className="top-right" children="Github" />
       <div className="bottom">
         <a href="https://codesandbox.io/s/xgjtc" className="bottom-right" children="<Source />" />
         <a

--- a/examples/src/components/Details.js
+++ b/examples/src/components/Details.js
@@ -5,7 +5,7 @@ export default function () {
     <>
       <a href="https://github.com/pmndrs/zustand" className="top-right" children="Github" />
       <div className="bottom">
-        <a href="https://codesandbox.io/s/xgjtc" className="bottom-right" children="<Source />" />
+        <a href="https://github.com/pmndrs/zustand/tree/main/examples" className="bottom-right" children="<Source />" />
         <a
           href="https://www.instagram.com/tina.henschel/"
           className="bottom-left"

--- a/examples/src/components/Details.js
+++ b/examples/src/components/Details.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export default function () {
+  return (
+    <>
+      <a href="https://github.com/drcmda/zustand" className="top-right" children="Github" />
+      <div className="bottom">
+        <a href="https://codesandbox.io/s/xgjtc" className="bottom-right" children="<Source />" />
+        <a
+          href="https://www.instagram.com/tina.henschel/"
+          className="bottom-left"
+          children="Illustrations @ Tina Henschel"
+        />
+      </div>
+      <span className="header-left">Zustand</span>
+    </>
+  )
+}

--- a/examples/src/components/Effects.js
+++ b/examples/src/components/Effects.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { useThree } from 'react-three-fiber'
+import { EffectComposer, DepthOfField, Vignette } from 'react-postprocessing'
+
+const Effects = React.forwardRef((props, ref) => {
+  const {
+    viewport: { width, height },
+  } = useThree()
+  return (
+    <EffectComposer multisampling={0}>
+      <DepthOfField ref={ref} bokehScale={4} focalLength={0.1} width={width / 2} height={height / 2} />
+      <Vignette />
+    </EffectComposer>
+  )
+})
+
+export default Effects

--- a/examples/src/components/Scene.js
+++ b/examples/src/components/Scene.js
@@ -1,0 +1,60 @@
+import * as THREE from 'three'
+import React, { useRef, useState } from 'react'
+import { Plane, useAspect, useTextureLoader } from 'drei'
+import { useFrame } from 'react-three-fiber'
+import Fireflies from './Fireflies'
+import bgUrl from '../resources/bg.jpg'
+import starsUrl from '../resources/stars.png'
+import groundUrl from '../resources/ground.png'
+import bearUrl from '../resources/bear.png'
+import leaves1Url from '../resources/leaves1.png'
+import leaves2Url from '../resources/leaves2.png'
+import '../materials/layerMaterial'
+
+export default function Scene({ dof }) {
+  const scaleN = useAspect('cover', 1600, 1000, 0.21)
+  const scaleW = useAspect('cover', 2200, 1000, 0.21)
+  const textures = useTextureLoader([bgUrl, starsUrl, groundUrl, bearUrl, leaves1Url, leaves2Url])
+  const subject = useRef()
+  const group = useRef()
+  const layersRef = useRef([])
+  const [movementVector] = useState(() => new THREE.Vector3())
+  const [tempVector] = useState(() => new THREE.Vector3())
+  const [focusVector] = useState(() => new THREE.Vector3())
+  const layers = [
+    { texture: textures[0], z: 0, factor: 0.005, scale: scaleW },
+    { texture: textures[1], z: 10, factor: 0.005, scale: scaleW },
+    { texture: textures[2], z: 20, scale: scaleW },
+    { texture: textures[3], z: 30, ref: subject, scaleFactor: 0.83, scale: scaleN },
+    { texture: textures[4], factor: 0.03, scaleFactor: 1, z: 40, wiggle: 0.24, scale: scaleW },
+    { texture: textures[5], factor: 0.04, scaleFactor: 1.3, z: 49, wiggle: 0.3, scale: scaleW },
+  ]
+
+  useFrame((state, delta) => {
+    dof.current.target = focusVector.lerp(subject.current.position, 0.05)
+    movementVector.lerp(tempVector.set(state.mouse.x, state.mouse.y * 0.2, 0), 0.2)
+    group.current.position.x = THREE.MathUtils.lerp(group.current.position.x, state.mouse.x * 20, 0.2)
+    group.current.rotation.x = THREE.MathUtils.lerp(group.current.rotation.x, state.mouse.y / 10, 0.2)
+    group.current.rotation.y = THREE.MathUtils.lerp(group.current.rotation.y, -state.mouse.x / 2, 0.2)
+    layersRef.current[4].uniforms.time.value = layersRef.current[5].uniforms.time.value += delta
+  }, 1)
+
+  return (
+    <group ref={group}>
+      <Fireflies count={10} radius={80} colors={['orange']} />
+      {layers.map(({ scale, texture, ref, factor = 0, scaleFactor = 1, wiggle = 0, z }, i) => (
+        <Plane scale={scale} args={[1, 1, wiggle ? 10 : 1, wiggle ? 10 : 1]} position-z={z} key={i} ref={ref}>
+          <layerMaterial
+            attach="material"
+            movementVector={movementVector}
+            textr={texture}
+            factor={factor}
+            ref={(el) => (layersRef.current[i] = el)}
+            wiggle={wiggle}
+            scaleFactor={scaleFactor}
+          />
+        </Plane>
+      ))}
+    </group>
+  )
+}


### PR DESCRIPTION
Based on my comment here: https://github.com/pmndrs/zustand/issues/747#issuecomment-1010670457

This simply pulls much of the design code out into separate files, so that `App.js` has a clearer focus on declaring the store and implementing the counter.