### PR TITLE
Add `trace` property to devtools options

### DIFF
--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -1,5 +1,39 @@
 import { GetState, PartialState, SetState, State, StoreApi } from '../vanilla'
 
+type DevtoolsOptions = {
+  name?: string
+  anonymousActionType?: string
+  serialize?: {
+    options:
+      | boolean
+      | {
+          date?: boolean
+          regex?: boolean
+          undefined?: boolean
+          nan?: boolean
+          infinity?: boolean
+          error?: boolean
+          symbol?: boolean
+          map?: boolean
+          set?: boolean
+        }
+  }
+  features?: {
+    pause?: boolean
+    lock?: boolean
+    persist?: boolean
+    export?: boolean | 'custom'
+    import?: boolean | 'custom'
+    jump?: boolean
+    skip?: boolean
+    reorder?: boolean
+    dispatch?: boolean
+    test?: boolean
+  }
+  trace?: boolean | (() => string)
+  traceLimit?: number
+}
+
 type DevtoolsType = {
   /**
    * @deprecated along with `api.devtools`, `api.devtools.prefix` is deprecated.
@@ -69,25 +103,7 @@ export function devtools<
   CustomStoreApi extends StoreApi<S>
 >(
   fn: (set: NamedSet<S>, get: CustomGetState, api: CustomStoreApi) => S,
-  options?: {
-    name?: string
-    anonymousActionType?: string
-    serialize?: {
-      options:
-        | boolean
-        | {
-            date?: boolean
-            regex?: boolean
-            undefined?: boolean
-            nan?: boolean
-            infinity?: boolean
-            error?: boolean
-            symbol?: boolean
-            map?: boolean
-            set?: boolean
-          }
-    }
-  }
+  options?: DevtoolsOptions
 ): (
   set: CustomSetState,
   get: CustomGetState,
@@ -104,27 +120,7 @@ export function devtools<
   CustomStoreApi extends StoreApi<S>
 >(
   fn: (set: NamedSet<S>, get: CustomGetState, api: CustomStoreApi) => S,
-  options?:
-    | string
-    | {
-        name?: string
-        anonymousActionType?: string
-        serialize?: {
-          options:
-            | boolean
-            | {
-                date?: boolean
-                regex?: boolean
-                undefined?: boolean
-                nan?: boolean
-                infinity?: boolean
-                error?: boolean
-                symbol?: boolean
-                map?: boolean
-                set?: boolean
-              }
-        }
-      }
+  options?: string | DevtoolsOptions
 ) {
   return (
     set: CustomSetState,


### PR DESCRIPTION
Relates to #716

From my testing, redux dev tools trace feature is already working without any changes on Zustand's side. All that's necessary is to type the option so that Typescript will allow it to be passed.

There is at least one caveat, and that is that if you try to use a callback for trace, it does not correctly get passed the action as an argument. This functionality exists so you can either customize the trace, or to conditionally trace on some actions like in the example below.
```
trace: (action) => {
  if (shouldTrace(action)) {
    return new Error().trace;
  }
},
```

In this example, `action` will always come back as `undefined`. I intend to look into this and will put up another PR when I can with the necessary fixes. However as an initial step, I'm putting up this PR to type the field, because much of the functionality is already working.

Edit: I've also gone ahead and added `traceLimit` and `features`, as I've tested both of those as working. I'll type out more features in the future as I test them.