### PR TITLE
match vanilla StateCreator type in middleware/subscribeWithSelector

### DIFF
--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -47,9 +47,9 @@ export type StoreApiWithDevtools<T extends State> = StoreApi<T> & {
  */
 export function devtools<
   S extends State,
-  CustomSetState extends SetState<S>,
-  CustomGetState extends GetState<S>,
-  CustomStoreApi extends StoreApi<S>
+  CustomSetState extends SetState<S> = SetState<S>,
+  CustomGetState extends GetState<S> = GetState<S>,
+  CustomStoreApi extends StoreApi<S> = StoreApi<S>
 >(
   fn: (set: NamedSet<S>, get: CustomGetState, api: CustomStoreApi) => S,
   options?: string

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -140,9 +140,9 @@ const toThenable =
 export const persist =
   <
     S extends State,
-    CustomSetState extends SetState<S>,
-    CustomGetState extends GetState<S>,
-    CustomStoreApi extends StoreApi<S>
+    CustomSetState extends SetState<S> = SetState<S>,
+    CustomGetState extends GetState<S> = GetState<S>,
+    CustomStoreApi extends StoreApi<S> = StoreApi<S>
   >(
     config: (
       set: CustomSetState,

--- a/src/middleware/subscribeWithSelector.ts
+++ b/src/middleware/subscribeWithSelector.ts
@@ -30,8 +30,8 @@ export type StoreApiWithSubscribeWithSelector<T extends State> = Omit<
 export const subscribeWithSelector =
   <
     S extends State,
-    CustomSetState = SetState<S>,
-    CustomGetState = GetState<S>,
+    CustomSetState extends SetState<S> = SetState<S>,
+    CustomGetState extends GetState<S> = GetState<S>,
     CustomStoreApi extends StoreApi<S> = StoreApi<S>
   >(
     fn: (set: CustomSetState, get: CustomGetState, api: CustomStoreApi) => S

--- a/src/middleware/subscribeWithSelector.ts
+++ b/src/middleware/subscribeWithSelector.ts
@@ -30,9 +30,9 @@ export type StoreApiWithSubscribeWithSelector<T extends State> = Omit<
 export const subscribeWithSelector =
   <
     S extends State,
-    CustomSetState extends SetState<S>,
-    CustomGetState extends GetState<S>,
-    CustomStoreApi extends StoreApi<S>
+    CustomSetState = SetState<S>,
+    CustomGetState = GetState<S>,
+    CustomStoreApi extends StoreApi<S> = StoreApi<S>
   >(
     fn: (set: CustomSetState, get: CustomGetState, api: CustomStoreApi) => S
   ) =>


### PR DESCRIPTION
Match
https://github.com/pmndrs/zustand/blob/0ba3c240078cf61792a4b13ff11d774ecca70a0a/src/vanilla.ts#L50-L52
to make subscribeWithSelector more useful with custom states.

Ran into this when trying to use subscribeWithSelector with
custom middleware that uses immer's WritableDraft on SetState