### PR TITLE
fix(context): revert removing overloads in `UseContextStore`

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -11,10 +11,10 @@ import { EqualityChecker, State, StateSelector, UseBoundStore } from 'zustand'
 /**
  * @deprecated Use `typeof MyContext.useStore` instead.
  */
-export type UseContextStore<T extends State> = <U = T>(
-  selector?: StateSelector<T, U>,
-  equalityFn?: EqualityChecker<U>
-) => U
+export type UseContextStore<T extends State> = {
+  (): T
+  <U>(selector: StateSelector<T, U>, equalityFn?: EqualityChecker<U>): U
+}
 
 function createContext<
   TState extends State,

--- a/tests/context.test.tsx
+++ b/tests/context.test.tsx
@@ -157,8 +157,8 @@ it('throws error when not using provider', async () => {
 it('useCallback with useStore infers types correctly', async () => {
   const { useStore } = createContext<CounterState>()
   function _Counter() {
-    let x = useStore(useCallback((state) => state.count, []))
-    expectAreTypesEqual<typeof x, number>().toBe(true)
+    const _x = useStore(useCallback((state) => state.count, []))
+    expectAreTypesEqual<typeof _x, number>().toBe(true)
   }
 })
 

--- a/tests/context.test.tsx
+++ b/tests/context.test.tsx
@@ -1,6 +1,7 @@
 import {
   Component as ClassComponent,
   ReactNode,
+  useCallback,
   useEffect,
   useState,
 } from 'react'
@@ -151,4 +152,20 @@ it('throws error when not using provider', async () => {
     </ErrorBoundary>
   )
   await findByText('errored')
+})
+
+it('useCallback with useStore infers types correctly', async () => {
+  const { useStore } = createContext<CounterState>()
+  function _Counter() {
+    let x = useStore(useCallback((state) => state.count, []))
+    expectAreTypesEqual<typeof x, number>().toBe(true)
+  }
+})
+
+const expectAreTypesEqual = <A, B>() => ({
+  toBe: (
+    _: (<T>() => T extends B ? 1 : 0) extends <T>() => T extends A ? 1 : 0
+      ? true
+      : false
+  ) => {},
 })


### PR DESCRIPTION
Fixes #812