### PR TITLE
fix: import use-sync-external-store in esm

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -1,5 +1,5 @@
 import { useDebugValue } from 'react'
-import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector'
+import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector.js'
 import createStore, {
   EqualityChecker,
   GetState,


### PR DESCRIPTION
Imports `use-sync-external-store/shim/with-selector.js` (with a `.js` suffix) so that it is correctly resolved by esm bundlers like nextjs.
Fixes https://github.com/NoahZinsmeister/web3-react/issues/379, which is broken using [4.0.0-beta.1](https://www.npmjs.com/package/zustand/v/4.0.0-beta.1).