### PR TITLE
Add devtools action name to typings

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -43,7 +43,8 @@ export type SetState<T extends State> = {
     K4 extends keyof T = K3
   >(
     partial: PartialState<T, K1, K2, K3, K4>,
-    replace?: boolean
+    replace?: boolean,
+    name?: string
   ): void
 }
 export type GetState<T extends State> = () => T


### PR DESCRIPTION
When devtools is enabled, `setState` function accepts an optional third argument with a name that will be displayed as the action's type in Redux devtools. This is missing in the types and this PR adds it