### PR TITLE
fix(build): separate vanilla build

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "@babel/plugin-transform-typescript": "^7.16.8",
     "@babel/preset-env": "^7.16.11",
     "@redux-devtools/extension": "^3.2.2",
+    "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@rollup/plugin-replace": "^4.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import path from 'path'
+import alias from '@rollup/plugin-alias'
 import babelPlugin from '@rollup/plugin-babel'
 import resolve from '@rollup/plugin-node-resolve'
 import replace from '@rollup/plugin-replace'
@@ -57,6 +58,11 @@ function createESMConfig(input, output) {
     ],
     external,
     plugins: [
+      alias({
+        entries: {
+          './vanilla': 'zustand/vanilla',
+        },
+      }),
       resolve({ extensions }),
       replace({
         __DEV__: '(import.meta.env&&import.meta.env.MODE)!=="production"',
@@ -76,6 +82,11 @@ function createCommonJSConfig(input, output) {
     output: { file: `${output}.js`, format: 'cjs', exports: 'named' },
     external,
     plugins: [
+      alias({
+        entries: {
+          './vanilla': 'zustand/vanilla',
+        },
+      }),
       resolve({ extensions }),
       replace({
         __DEV__: 'process.env.NODE_ENV!=="production"',
@@ -100,10 +111,19 @@ function createUMDConfig(input, output, env) {
           : `zustand${c.slice(0, 1).toUpperCase()}${c.slice(1)}`,
       globals: {
         react: 'React',
+        // FIXME not yet supported
+        'use-sync-external-store/shim/with-selector':
+          'useSyncExternalStoreShimWithSelector',
+        'zustand/vanilla': 'zustandVanilla',
       },
     },
     external,
     plugins: [
+      alias({
+        entries: {
+          './vanilla': 'zustand/vanilla',
+        },
+      }),
       resolve({ extensions }),
       replace({
         __DEV__: env !== 'production' ? 'true' : 'false',
@@ -125,6 +145,11 @@ function createSystemConfig(input, output, env) {
     },
     external,
     plugins: [
+      alias({
+        entries: {
+          './vanilla': 'zustand/vanilla',
+        },
+      }),
       resolve({ extensions }),
       replace({
         __DEV__: env !== 'production' ? 'true' : 'false',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1226,6 +1226,13 @@
   dependencies:
     "@babel/runtime" "^7.17.0"
 
+"@rollup/plugin-alias@^3.1.9":
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-alias/-/plugin-alias-3.1.9.tgz#a5d267548fe48441f34be8323fb64d1d4a1b3fdf"
+  integrity sha512-QI5fsEvm9bDzt32k39wpOwZhVzRcL5ydcffUHMyLVaVaLeC70I8TJZ17F1z1eMoLu4E/UOcH9BWVkKpIKdrfiw==
+  dependencies:
+    slash "^3.0.0"
+
 "@rollup/plugin-babel@^5.3.1":
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz#04bc0608f4aa4b2e4b1aebf284344d0f68fda283"


### PR DESCRIPTION
In v4, we will allow `useStore` + vanilla store usage, it's better to avoid code duplication.
This is how we do in valtio.

(Just noticed, UMD is not supported by use-sync-external-store. Same for valtio.)