### PR TITLE
feat(context): add `onDestroy` callback to Provider component

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -3,6 +3,7 @@ import {
   createElement,
   createContext as reactCreateContext,
   useContext,
+  useEffect,
   useMemo,
   useRef,
 } from 'react'
@@ -32,9 +33,11 @@ function createContext<
 
   const Provider = ({
     createStore,
+    onDestroy,
     children,
   }: {
     createStore: () => CustomStoreApi
+    onDestroy?: (store: CustomStoreApi) => void
     children: ReactNode
   }) => {
     const storeRef = useRef<CustomStoreApi>()
@@ -42,6 +45,16 @@ function createContext<
     if (!storeRef.current) {
       storeRef.current = createStore()
     }
+
+    useEffect(
+      () => () => {
+        if (onDestroy) {
+          // @ts-expect-error current is never undefined but typescript doesn't know that
+          onDestroy(storeRef.current)
+        }
+      },
+      []
+    )
 
     return createElement(
       ZustandContext.Provider,

--- a/tests/context.test.tsx
+++ b/tests/context.test.tsx
@@ -173,8 +173,8 @@ it('calls onDestroy callback when Provider component unmounting', async () => {
   const { findByText, unmount } = render(
     <Provider
       createStore={createStore}
-      onDestroy={(state) => {
-        onDestroyState = state.getState()
+      onDestroy={(store) => {
+        onDestroyState = store.getState()
       }}>
       <Counter />
     </Provider>


### PR DESCRIPTION
### Problem

My zustand `createStore` function create a lot of subscriptions to window.evenListeners to internal eventBus for micro-frontends. BUT I am not able to unsubscribe from them on Provider unmounting. And it leads to memory leaks in my application. 

So this PR adds the ability for housekeeping on Provider unmounting.
  
 ### Example: setting `bears` equal to 0 if the user press the `Esc` key
  
```tsx
  import create from "zustand";
  import createContext from "zustand/context";

  type BearState = {
    bears: number
    increase: () => void
  }

  // pass the type to `createContext` rather than to `create`
  const { Provider, useStore } = createContext<BearState>();

  const createStore = () => 
    create((set) => {
      // Track ESC key press for setting bears equal to 0
      const onKeyup = (e: KeyboardEvent) => {
        if (e.key === 'Escape') {
          set({ bears: 0 })
        }
      };
      window.addEventListener('keyup', onKeyup);

      return {
        bears: initialBears,
        increase: () => set((state) => ({ bears: state.bears + 1 })),
        removeListeners: () => {
          window.removeEventListener('keyup', onKeyup)
        },
      };
    });

  export default function App({ initialBears }: { initialBears: number }) {
    return (
      <Provider
        createStore={createStore}
        onDestroy={(store) => {
          const state = store.getState();

          // removes previously registered event listeners 
          // for preventing memory leaks
          state.removeListeners();
          
          console.log('Last bears value was:', state.bears);
        }}
      >
        <Button />
      </Provider>
  )
}
```