### PR TITLE
Docs: Fix TypeScript docs for Middleware that changes the store type

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -253,7 +253,7 @@ type Foo =
 
 declare module 'zustand' {
   interface StoreMutators<S, A> {
-    foo: Write<Cast<S, object> { foo: A }>
+    foo: Write<Cast<S, object>, { foo: A }>
   }
 }
 


### PR DESCRIPTION
Fixes errors:

```
Generic type 'Write' requires 2 type argument(s).
Parsing error: '>' expected.
'>' expected.
Cannot find name 'A'.
```