### PR TITLE
Added a createImmerStore function 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -252,6 +252,22 @@ const clearForest = useStore(state => state.clearForest)
 clearForest();
 ```
 
+or use our `createImmerStore` so you can skip wrapping functions in produce:
+
+```jsx
+import { createImmerStore } from "zustand/middleware/immer"
+
+const useStore = createImmerStore(set => ({
+  lush: { forest: { contains: { a: "bear" } } },
+  clearForest: () => set((state => {
+    state.lush.forest.contains = null
+  })
+}))
+
+const clearForest = useStore(state => state.clearForest)
+clearForest();
+```
+
 [Alternatively, there are some other solutions.](https://github.com/pmndrs/zustand/wiki/Updating-nested-state-object-values)
 
 ## Middleware

--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -74,11 +74,11 @@ const immerImpl: ImmerImpl = (initializer) => (set, get, store) => {
   return initializer(store.setState, get, store)
 }
 
+export const immer = immerImpl as unknown as Immer
+
 export function createImmerStore<
   T extends State,
   Mos extends [StoreMutatorIdentifier, unknown][] = []
 >(initializer: StateCreator<T, [...Mos, ["zustand/immer", never]]>) {
   return create<T, Mos>(immer<T, Mos>(initializer) as any);
 }
-
-export const immer = immerImpl as unknown as Immer

--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/named
 import { Draft, produce } from 'immer'
-import { State, StateCreator, StoreMutatorIdentifier } from '../vanilla'
+import create, { State, StateCreator, StoreMutatorIdentifier } from '../vanilla'
 
 type Immer = <
   T extends State,
@@ -72,6 +72,13 @@ const immerImpl: ImmerImpl = (initializer) => (set, get, store) => {
   }
 
   return initializer(store.setState, get, store)
+}
+
+export function createImmerStore<
+  T extends State,
+  Mos extends [StoreMutatorIdentifier, unknown][] = []
+>(initializer: StateCreator<T, [...Mos, ["zustand/immer", never]]>) {
+  return create<T, Mos>(immer<T, Mos>(initializer) as any);
 }
 
 export const immer = immerImpl as unknown as Immer


### PR DESCRIPTION
This function joins the create and immer function calls shown in this example into one function. Its a small adjustment, but one that just feels cleaner. Would love to hear any feedback!

Before:
```
import create from "zustand"
import { immer } from "zustand/middleware/immer"

const useStore = create(immer((set) => ({
  bees: 0,
  addBees: (by) => set((state) => { state.bees += by }),
})))
```

After:
```
import create from "zustand"
import { createImmerStore } from "zustand/middleware/immer"

const useStore = createImmerStore((set) => ({
  bees: 0,
  addBees: (by) => set((state) => { state.bees += by }),
}))
```

