### PR TITLE
Mark more methods bivariant

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -19,7 +19,7 @@ export type SetState<T extends State> = {
     replace?: boolean | undefined
   ): void
 }['_']
-export type BivariantStateComputer<T> = {
+type BivariantStateComputer<T> = {
   _(state: T): T | Partial<T>
 }['_']
 export type GetState<T extends State> = () => T

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -15,12 +15,9 @@ export interface Subscribe<T extends State> {
 
 export type SetState<T extends State> = {
   _(
-    partial: T | Partial<T> | BivariantStateComputer<T>,
+    partial: T | Partial<T> | { _(state: T): T | Partial<T> }['_'],
     replace?: boolean | undefined
   ): void
-}['_']
-type BivariantStateComputer<T> = {
-  _(state: T): T | Partial<T>
 }['_']
 export type GetState<T extends State> = () => T
 export type Destroy = () => void

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -9,9 +9,9 @@ export type StateListener<T> = (state: T, previousState: T) => void
  * @deprecated Use `StateListener<T>` instead of `StateSliceListener<T>`.
  */
 export type StateSliceListener<T> = (slice: T, previousSlice: T) => void
-export type Subscribe<T extends State> = {
-  _(listener: StateListener<T>): () => void
-}['_']
+export interface Subscribe<T extends State> {
+  (listener: StateListener<T>): () => void
+}
 
 export type SetState<T extends State> = {
   _(

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -9,15 +9,18 @@ export type StateListener<T> = (state: T, previousState: T) => void
  * @deprecated Use `StateListener<T>` instead of `StateSliceListener<T>`.
  */
 export type StateSliceListener<T> = (slice: T, previousSlice: T) => void
-export interface Subscribe<T extends State> {
-  (listener: StateListener<T>): () => void
-}
+export type Subscribe<T extends State> = {
+  _(listener: StateListener<T>): () => void
+}['_']
 
 export type SetState<T extends State> = {
   _(
-    partial: T | Partial<T> | ((state: T) => T | Partial<T>),
+    partial: T | Partial<T> | BivariantStateComputer<T>,
     replace?: boolean | undefined
   ): void
+}['_']
+export type BivariantStateComputer<T> = {
+  _(state: T): T | Partial<T>
 }['_']
 export type GetState<T extends State> = () => T
 export type Destroy = () => void


### PR DESCRIPTION
Fixes some upcoming build breaks in TypeScript 4.8. I'm not entirely sure the true root cause, but it looks like we're computing the correct variance of more of these types, leading to a (correct) error issued in covariant use sites like this:
```ts
export function useStore<TState extends State, StateSlice>(
  api: WithReact<StoreApi<TState>>, // <- correctly marked as constraint violation
```