### PR TITLE
fix(deps)(example): incorrect peer dependency version of three

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -18,7 +18,7 @@
     "react-spring": "^8.0.27",
     "react-three-fiber": "^4.2.20",
     "react-three-gui": "^0.1.5",
-    "three": "^0.125.0",
+    "three": "^0.120.1",
     "threejs-meshline": "^2.0.11",
     "web-vitals": "^0.2.2",
     "zustand": "^3.0.0"

--- a/examples/yarn.lock
+++ b/examples/yarn.lock
@@ -10539,10 +10539,10 @@ text-table@0.2.0, text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@^0.125.0:
-  version "0.125.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.125.0.tgz#19e922b9dc51ad0b706893aeee888de68e99850a"
-  integrity sha512-qL36qUGsPQ/Ofo/RZdXwHwM7A8wzUSAIyawtjIebJSPvounUQeneSqxI0aBY2iwKpseGy+RUtj3C5f/z4poyXw==
+three@^0.120.1:
+  version "0.120.1"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.120.1.tgz#dbd8894f8ab87c109f1602933e7c740c98137377"
+  integrity sha512-ktaCRFUR7JUZcKec+cBRz+oBex5pOVaJhrtxvFF2T7on53o9UkEux+/Nh1g/4zeb4t/pbxIFcADbn/ACu3LC1g==
 
 threejs-meshline@^2.0.11:
   version "2.0.12"


### PR DESCRIPTION
Saw a lot of warnings in the console on the demo site ([https://zustand-demo.pmnd.rs/](https://zustand-demo.pmnd.rs/)),

![lots of warning](https://user-images.githubusercontent.com/48589760/177374206-7f10d16e-f560-4fce-a9e7-42bf19d6769b.png)

the reason is because the incorrect dependency of `three`,

<img width="756" alt="incorrect deps" src="https://user-images.githubusercontent.com/48589760/177373571-c1976765-6283-4590-bbf0-05133981db08.png">

downgrade `three` to version `0.120.1` the warnings no longer exist.

Related issue: pmndrs/postprocessing#246
