### PR TITLE
Migrate docs from wiki: auto generating selectors

### DIFF
--- a/docs/auto-generating-selectors.md
+++ b/docs/auto-generating-selectors.md
@@ -11,45 +11,44 @@ However, writing these could be tedious, but you can auto-generate them
 ## create the following function: `createSelectors`
 
 ```typescript
-import { State, StoreApi, UseBoundStore } from "zustand";
+import { State, StoreApi, UseBoundStore } from 'zustand'
 
 interface Selectors<StoreType> {
   use: {
-    [key in keyof StoreType]: () => StoreType[key];
-  };
+    [key in keyof StoreType]: () => StoreType[key]
+  }
 }
 
 export default function createSelectors<StoreType extends State>(
   store: UseBoundStore<StoreType, StoreApi<StoreType>>
 ) {
   // Casting to any to allow adding a new property
-  (store as any).use = {};
+  ;(store as any).use = {}
 
   Object.keys(store.getState()).forEach((key) => {
-    const selector = (state: StoreType) => state[key as keyof StoreType];
-    (store as any).use[key] = () => store(selector);
-  });
+    const selector = (state: StoreType) => state[key as keyof StoreType]
+    ;(store as any).use[key] = () => store(selector)
+  })
 
   return store as UseBoundStore<StoreType, StoreApi<StoreType>> &
-    Selectors<StoreType>;
+    Selectors<StoreType>
 }
-
 ```
 
 ## If you have a store like this:
 
 ```typescript
 interface BearState {
-  bears: number;
-  increase: (by: number) => void;
-  increment: () => void;
+  bears: number
+  increase: (by: number) => void
+  increment: () => void
 }
 
 const useStoreBase = create<BearState>((set) => ({
   bears: 0,
   increase: (by) => set((state) => ({ bears: state.bears + by })),
-  increment: () => set((state) => state.increase(1))
-}));
+  increment: () => set((state) => state.increase(1)),
+}))
 ```
 
 ## Apply that function to your store:
@@ -69,6 +68,7 @@ const increase = useStore.use.increment()
 ```
 
 ## Live Demo
+
 for a working example of this, see the [Code Sandbox](https://codesandbox.io/s/zustand-auto-generate-selectors-9i0ob3?file=/src/store.ts:396-408)
 
 ## 3rd-party Libraries

--- a/docs/auto-generating-selectors.md
+++ b/docs/auto-generating-selectors.md
@@ -62,8 +62,7 @@ const bears = useStore.use.bears()
 const increase = useStore.use.increase()
 ```
 
-## Libraries
+## 3rd-party Libraries
 
-- Or you can just `npm i auto-zustand-selectors-hook`
 - [auto-zustand-selectors-hook](https://github.com/Albert-Gao/auto-zustand-selectors-hook)
 - [zustood](https://github.com/udecode/zustood)

--- a/docs/auto-generating-selectors.md
+++ b/docs/auto-generating-selectors.md
@@ -74,4 +74,5 @@ for a working example of this, see the [Code Sandbox](https://codesandbox.io/s/z
 ## 3rd-party Libraries
 
 - [auto-zustand-selectors-hook](https://github.com/Albert-Gao/auto-zustand-selectors-hook)
+- [react-hooks-global-state](https://github.com/dai-shi/react-hooks-global-state)
 - [zustood](https://github.com/udecode/zustood)

--- a/docs/auto-generating-selectors.md
+++ b/docs/auto-generating-selectors.md
@@ -1,0 +1,68 @@
+# Auto Generating Selectors
+
+It is recommended to use selectors when using either the properties or actions from the store.
+
+```javascript
+const bears = useBearStore((state) => state.bears)
+```
+
+However, writing these could be tedious, but you can auto-generate them
+
+## create the following function: `createSelectors`
+
+```typescript
+import create, { StateCreator, State, StoreApi, UseStore } from 'zustand'
+
+interface Selectors<StoreType> {
+  use: {
+    [key in keyof StoreType]: () => StoreType[key]
+  }
+}
+
+function createSelectors<StoreType extends State>(store: UseStore<StoreType>) {
+  ;(store as any).use = {}
+
+  Object.keys(store.getState()).forEach((key) => {
+    const selector = (state: StoreType) => state[key as keyof StoreType]
+    ;(store as any).use[key] = () => store(selector)
+  })
+
+  return store as UseStore<StoreType> & Selectors<StoreType>
+}
+```
+
+## If you have a store like this:
+
+```typescript
+interface BearState {
+  bears: number
+  increase: (by: number) => void
+}
+
+const useStoreBase = create<BearState>((set) => ({
+  bears: 0,
+  increase: (by) => set((state) => ({ bears: state.bears + by })),
+}))
+```
+
+## Apply that function to your store:
+
+```typescript
+const useStore = createSelectors(useStoreBase)
+```
+
+## Now the selectors are auto generated:
+
+```typescript
+// get the property
+const bears = useStore.use.bears()
+
+// get the action
+const increase = useStore.use.increase()
+```
+
+## Libraries
+
+- Or you can just `npm i auto-zustand-selectors-hook`
+- [auto-zustand-selectors-hook](https://github.com/Albert-Gao/auto-zustand-selectors-hook)
+- [zustood](https://github.com/udecode/zustood)

--- a/docs/auto-generating-selectors.md
+++ b/docs/auto-generating-selectors.md
@@ -15,16 +15,17 @@ import create, { StateCreator, State, StoreApi, UseStore } from 'zustand'
 
 interface Selectors<StoreType> {
   use: {
-    [key in keyof StoreType]: () => StoreType[key]
+    [key in keyof StoreType]: () => StoreType[key];
   }
 }
 
 function createSelectors<StoreType extends State>(store: UseStore<StoreType>) {
-  ;(store as any).use = {}
+  (store as any).use = {};
 
   Object.keys(store.getState()).forEach((key) => {
-    const selector = (state: StoreType) => state[key as keyof StoreType]
-    ;(store as any).use[key] = () => store(selector)
+    const selector = (state: StoreType) => state[key as keyof StoreType];
+
+    (store as any).use[key] = () => store(selector);
   })
 
   return store as UseStore<StoreType> & Selectors<StoreType>


### PR DESCRIPTION
Like you said in #1008 you want to migrate the docs from Github's wiki to the docs folder as markdown files and I'd like to help! This one is for [Auto generating selectors](https://github.com/pmndrs/zustand/wiki/Auto-Generating-Selectors).
I will work on all the pages in my fork and open PRs if that's fine?

A few things:
-  I removed some semicolons from the wiki page in the last commit (aabaaad1b92a7b33b0aa07803856b2fb42bbdfc3). These semicolons are added back in by prettier for some reason
- The prettier and eslint scripts do not run on windows for me, but they ran fine in a ubuntu wsl.
- I did not test a lot of the code provided in the examples. Should I do so or is it save to assume that it's still valid?

Looking forward to your suggestions