### PR TITLE
test: Add additional test for the new dom render method on react 18

### DIFF
--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -1,6 +1,7 @@
 import {
   Component as ClassComponent,
   ReactNode,
+  version as reactVersion,
   useEffect,
   useLayoutEffect,
   useState,
@@ -144,6 +145,40 @@ it('only re-renders if selected state has changed', async () => {
 })
 
 it('re-renders with useLayoutEffect', async () => {
+  if (!/^18./.test(reactVersion)) {
+    return
+  }
+
+  const useStore = create(() => ({ state: false }))
+
+  function Component() {
+    const { state } = useStore()
+    useLayoutEffect(() => {
+      useStore.setState({ state: true })
+    }, [])
+    return <>{`${state}`}</>
+  }
+
+  /**
+   * require is using here because the following will fail on react version
+   * under 18.
+   *
+   * > `import { createRoot } from 'react-dom/client'`
+   */
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { createRoot } = require('react-dom/client')
+
+  const container = document.createElement('div')
+  const root = createRoot(container)
+
+  act(() => root.render(<Component />))
+  await waitFor(() => {
+    expect(container.innerHTML).toBe('true')
+  })
+  act(() => root.unmount())
+})
+
+it('re-renders with useLayoutEffect using legacy render method', async () => {
   const useStore = create(() => ({ state: false }))
 
   function Component() {


### PR DESCRIPTION
`ReactDOM.render` and `ReactDOM.unmountComponentAtNode` has been deprecated from react 18, added an additional test case for react version 18 new render api.

Using node require and disabled eslint on `require('react-dom/client')` because if I use `import { createRoot } from 'reac-dom/client'` the ci will fail when the react version is lower than 18.

Reference
- `ReactDOM.render` is deprecated
https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis

- `ReactDOM.unmountComponentAtNode` has been replaced with `root.unmount `
https://reactjs.org/docs/react-dom.html#unmountcomponentatnode