### PR TITLE
Added docs page: flux inspired practice

### DIFF
--- a/docs/flux-inspired-practice.md
+++ b/docs/flux-inspired-practice.md
@@ -3,17 +3,24 @@
 Although zustand is an unopinionated library, here's one of the recommended usages.
 
 ```js
-const useStore = create((set) => ({
-  storeSliceA: ...,
-  storeSliceB: ...,
-  storeSliceC: ...,
-  dispatchX: () => set(...),
-  dispatchY: () => set(...),
+const createBearSlice = (set) => ({
+  bears: 0,
+  addBear: () => set((state) => ({ bears: state.bears + 1 })),
+})
+
+const createFishSlice = (set) => ({
+  fishes: 0,
+  addFish: () => set((state) => ({ fishes: state.fishes + 1 })),
+})
+
+const useStore = create()((...a) => ({
+  ...createBearSlice(...a),
+  ...createFishSlice(...a),
 }))
 ```
 
 - Create one single store
 - Define a store only with `set`
-- Define dispatch functions at the root level of store to update one or more store slices
+- Define dispatch functions at the root level of the store to update one or more store slices
 
 See [Splitting the store into separate slices](https://github.com/pmndrs/zustand/wiki/Splitting-the-store-into-separate-slices) to define a store with separate slices.

--- a/docs/flux-inspired-practice.md
+++ b/docs/flux-inspired-practice.md
@@ -1,6 +1,10 @@
 # Flux inspired practice
 
-Although zustand is an unopinionated library, here's one of the recommended usages.
+Although zustand is an unopinionated library, here's one of the recommended usages:
+
+  - Create one single store
+  - Define a store only with `set`
+  - Define dispatch functions at the root level of the store to update one or more store slices
 
 ```js
 const createBearSlice = (set) => ({
@@ -19,8 +23,39 @@ const useStore = create()((...a) => ({
 }))
 ```
 
-- Create one single store
-- Define a store only with `set`
-- Define dispatch functions at the root level of the store to update one or more store slices
 
-See [Splitting the store into separate slices](https://github.com/pmndrs/zustand/wiki/Splitting-the-store-into-separate-slices) to define a store with separate slices.
+See [Splitting the store into separate slices](https://github.com/pmndrs/zustand/blob/main/docs/typescript.md#interdependent-slices-pattern) for how to define a store with separate slices.
+
+## Flux like patterns / "Dispatching" actions
+If you can't live without redux-like reducers, you can define a `dispatch` function on the root level of the store like store
+
+```typescript
+const types = { increase: 'INCREASE', decrease: 'DECREASE' }
+
+const reducer = (state, { type, by = 1 }) => {
+  switch (type) {
+    case types.increase:
+      return { grumpiness: state.grumpiness + by }
+    case types.decrease:
+      return { grumpiness: state.grumpiness - by }
+  }
+}
+
+const useStore = create((set) => ({
+  grumpiness: 0,
+  dispatch: (args) => set((state) => reducer(state, args)),
+}))
+
+const dispatch = useStore((state) => state.dispatch)
+dispatch({ type: types.increase, by: 2 })
+```
+
+Or, just use our redux-middleware. It wires up your main-reducer, sets initial state, and adds a dispatch function to the state itself and the vanilla api. Try [this](https://codesandbox.io/s/amazing-kepler-swxol) example.
+
+```typescript
+import { redux } from 'zustand/middleware'
+
+const useStore = create(redux(reducer, initialState))
+```
+
+Another way to update the store could be in functions wrapping the state functions. These could also handle side-effects of actions, for example for HTTP-calls. For using Zustand in a none-reactive way see [the readme](https://github.com/pmndrs/zustand#readingwriting-state-and-reacting-to-changes-outside-of-components)

--- a/docs/flux-inspired-practice.md
+++ b/docs/flux-inspired-practice.md
@@ -1,0 +1,19 @@
+# Flux inspired practice
+
+Although zustand is an unopinionated library, here's one of the recommended usages.
+
+```js
+const useStore = create((set) => ({
+  storeSliceA: ...,
+  storeSliceB: ...,
+  storeSliceC: ...,
+  dispatchX: () => set(...),
+  dispatchY: () => set(...),
+}))
+```
+
+- Create one single store
+- Define a store only with `set`
+- Define dispatch functions at the root level of store to update one or more store slices
+
+See [Splitting the store into separate slices](https://github.com/pmndrs/zustand/wiki/Splitting-the-store-into-separate-slices) to define a store with separate slices.


### PR DESCRIPTION
Wiki port of https://github.com/pmndrs/zustand/wiki/Flux-inspired-practice

I added just a little content and a snippet out of the readme to show examples on how flux-like patterns can be applied to zustand