### PR TITLE
docs(typescript): supplement the missing `)` symbol in the `combine` code example

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -123,7 +123,7 @@ import { combine } from "zustand/middleware"
 
 const useStore = create(combine({ bears: 0 }, (set) => ({
   increase: (by: number) => set((state) => ({ bears: state.bears + by })),
-}))
+})))
 ```
 
 <details>

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -118,12 +118,14 @@ And now `T` gets inferred and you get to annotate `E` too. Zustand has the same 
 Alternatively you can also use `combine` which infers the state instead of you having to type it...
 
 ```ts
-import create from "zustand"
-import { combine } from "zustand/middleware"
+import create from 'zustand'
+import { combine } from 'zustand/middleware'
 
-const useStore = create(combine({ bears: 0 }, (set) => ({
-  increase: (by: number) => set((state) => ({ bears: state.bears + by })),
-})))
+const useStore = create(
+  combine({ bears: 0 }, (set) => ({
+    increase: (by: number) => set((state) => ({ bears: state.bears + by })),
+  }))
+)
 ```
 
 <details>


### PR DESCRIPTION
There is a problem in the `combine` code example in `typescript.md`, and a ` )` symbol is missing at the end.

![image](https://user-images.githubusercontent.com/63690944/178712822-c974f9dd-8419-4f07-8799-3fd06a0a3e1e.png)

---

This is an online example: ↓
> https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAYygUwIY2XAZlCI4BEAXgK4DOMqAdgCYEBQokscA3ongEbBWYC+2XPmLlKtAPQhgNGgBtkAd1QoG9BBCoU45ZAGUY0TAF5EKdMgAU6kN14X2nNFDIAuOAAY4fADRwLZZBgASjgjAD4-Vno4OB4kNAC3C04ATzcqEhtkKBDwuACYC39KDFyI+zhHZVd8kuQAOirnOABqSpSvIKDvej4uoA
