### PR TITLE
docs(readme): symbol supplement in code example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -171,9 +171,9 @@ unsub1()
 useStore.destroy()
 
 // You can of course use the hook as you always would
-function Component() {
+const Component = () => {
   const paw = useStore((state) => state.paw)
-}
+  ...
 ```
 
 ### Using subscribe with selector
@@ -241,13 +241,14 @@ The subscribe function allows components to bind to a state-portion without forc
 ```jsx
 const useStore = create(set => ({ scratches: 0, ... }))
 
-function Component() {
+const Component = () => {
   // Fetch initial state
   const scratchRef = useRef(useStore.getState().scratches)
   // Connect to the store on mount, disconnect on unmount, catch state-changes in a reference
   useEffect(() => useStore.subscribe(
     state => (scratchRef.current = state.scratches)
   ), [])
+  ...
 ```
 
 ## Sick of reducers and changing nested state? Use Immer!
@@ -436,7 +437,6 @@ const Component = () => {
   const store = useContext(StoreContext)
   const slice = useStore(store, selector)
   ...
-}
 ```
 
 Alternatively, a special `createContext` is provided since v3.5,
@@ -460,7 +460,6 @@ const Component = () => {
   const state = useStore()
   const slice = useStore(selector)
   ...
-}
 ```
 
 <details>

--- a/readme.md
+++ b/readme.md
@@ -172,7 +172,8 @@ useStore.destroy()
 
 // You can of course use the hook as you always would
 function Component() {
-  const paw = useStore(state => state.paw)
+  const paw = useStore((state) => state.paw)
+}
 ```
 
 ### Using subscribe with selector


### PR DESCRIPTION
Located at _`Reading/writing state and reacting to changes outside of components`_

Supplement the ending symbol of the `Component` function 😄

---
![image](https://user-images.githubusercontent.com/63690944/178744084-c3578a1f-3f5a-45ee-b993-d78512c97ca3.png)
