### PR TITLE
export the WithReact type

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -12,7 +12,7 @@ import createStore, {
 
 type ExtractState<S> = S extends { getState: () => infer T } ? T : never
 
-type WithReact<S extends StoreApi<State>> = S & {
+export type WithReact<S extends StoreApi<State>> = S & {
   getServerState?: () => ExtractState<S>
 }
 


### PR DESCRIPTION
Please export the `WithReact` type so we can use zustand store types in our own typed stores.
Extending from `StoreApi<State>` is not possible without `WithReact` being exported

For example:


    export type TTranslationStore<KeyIndex = any> = UseBoundStore<ITranslator<KeyIndex>>;

    export interface ITranslator<KeysIndex> extends WithReact<StoreApi<State>> {
        .....
    }

