### PR TITLE
fix(types): Missing exports on middleware

### DIFF
--- a/src/middleware/combine.ts
+++ b/src/middleware/combine.ts
@@ -2,7 +2,7 @@ import { State, StateCreator, StoreMutatorIdentifier } from '../vanilla'
 
 type Write<T, U> = Omit<T, keyof U> & U
 
-type Combine = <
+export type Combine = <
   T extends State,
   U extends State,
   Mps extends [StoreMutatorIdentifier, unknown][] = [],

--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -75,7 +75,7 @@ interface DevtoolsOptions {
       }
 }
 
-type Devtools = <
+export type Devtools = <
   T extends State,
   Mps extends [StoreMutatorIdentifier, unknown][] = [],
   Mcs extends [StoreMutatorIdentifier, unknown][] = []

--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -2,7 +2,7 @@
 import { Draft, produce } from 'immer'
 import { State, StateCreator, StoreMutatorIdentifier } from '../vanilla'
 
-type Immer = <
+export type Immer = <
   T extends State,
   Mps extends [StoreMutatorIdentifier, unknown][] = [],
   Mcs extends [StoreMutatorIdentifier, unknown][] = []

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -77,7 +77,7 @@ export interface PersistOptions<S, PersistedState = S> {
 
 type PersistListener<S> = (state: S) => void
 
-interface StorePersist<S extends State, Ps> {
+export interface StorePersist<S extends State, Ps> {
   persist: {
     setOptions: (options: Partial<PersistOptions<S, Ps>>) => void
     clearStorage: () => void
@@ -301,7 +301,7 @@ const persistImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
   return stateFromStorage || configResult
 }
 
-type Persist = <
+export type Persist = <
   T extends State,
   Mps extends [StoreMutatorIdentifier, unknown][] = [],
   Mcs extends [StoreMutatorIdentifier, unknown][] = [],

--- a/src/middleware/redux.ts
+++ b/src/middleware/redux.ts
@@ -4,22 +4,22 @@ import { NamedSet } from './devtools'
 type Write<T extends object, U extends object> = Omit<T, keyof U> & U
 type Cast<T, U> = T extends U ? T : U
 
-interface Action {
+export interface Action {
   type: unknown
 }
 
-interface ReduxState<A extends Action> {
+export interface ReduxState<A extends Action> {
   dispatch: StoreRedux<A>['dispatch']
 }
 
-interface StoreRedux<A extends Action> {
+export interface StoreRedux<A extends Action> {
   dispatch: (a: A) => A
   dispatchFromDevtools: true
 }
 
 type WithRedux<S, A> = Write<Cast<S, object>, StoreRedux<Cast<A, Action>>>
 
-type Redux = <
+export type Redux = <
   T extends State,
   A extends Action,
   Cms extends [StoreMutatorIdentifier, unknown][] = []

--- a/src/middleware/subscribeWithSelector.ts
+++ b/src/middleware/subscribeWithSelector.ts
@@ -6,7 +6,7 @@ import {
   Subscribe,
 } from '../vanilla'
 
-type SubscribeWithSelector = <
+export type SubscribeWithSelector = <
   T extends State,
   Mps extends [StoreMutatorIdentifier, unknown][] = [],
   Mcs extends [StoreMutatorIdentifier, unknown][] = []
@@ -32,7 +32,7 @@ declare module '../vanilla' {
   }
 }
 
-interface StoreSubscribeWithSelector<T extends State> {
+export interface StoreSubscribeWithSelector<T extends State> {
   subscribe: {
     (listener: (selectedState: T, previousSelectedState: T) => void): () => void
     <U>(


### PR DESCRIPTION
Missing exports on middleware required for generating declarations (fixes #1103).

As this requires a different `tsconfig.json` entry for the compiler to complain, I could not think of a simple way to integrate with the existing type-testing.