### PR TITLE
fix(types): use TS interfaces only for public api

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -47,7 +47,6 @@
     "@typescript-eslint/no-use-before-define": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/consistent-type-definitions": ["error", "interface"],
     "jest/consistent-test-it": [
       "error",
       { "fn": "it", "withinDescribe": "it" }

--- a/src/context.ts
+++ b/src/context.ts
@@ -14,7 +14,7 @@ import {
   useStore,
 } from 'zustand'
 
-interface UseContextStore<S extends StoreApi<State>> {
+type UseContextStore<S extends StoreApi<State>> = {
   (): ExtractState<S>
   <U>(
     selector: StateSelector<ExtractState<S>, U>,

--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -16,7 +16,7 @@ declare module '../vanilla' {
 }
 
 // FIXME https://github.com/reduxjs/redux-devtools/issues/1097
-interface Message {
+type Message = {
   type: string
   payload?: any
   state?: any
@@ -56,7 +56,7 @@ type StoreDevtools<S> = S extends {
     }
   : never
 
-interface DevtoolsOptions {
+export interface DevtoolsOptions {
   enabled?: boolean
   anonymousActionType?: string
   name?: string

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -11,7 +11,7 @@ export interface StateStorage {
   removeItem: (name: string) => void | Promise<void>
 }
 
-interface StorageValue<S> {
+type StorageValue<S> = {
   state: S
   version?: number
 }
@@ -77,7 +77,7 @@ export interface PersistOptions<S, PersistedState = S> {
 
 type PersistListener<S> = (state: S) => void
 
-interface StorePersist<S extends State, Ps> {
+type StorePersist<S extends State, Ps> = {
   persist: {
     setOptions: (options: Partial<PersistOptions<S, Ps>>) => void
     clearStorage: () => void
@@ -89,7 +89,7 @@ interface StorePersist<S extends State, Ps> {
   }
 }
 
-interface Thenable<Value> {
+type Thenable<Value> = {
   then<V>(
     onFulfilled: (value: Value) => V | Promise<V> | Thenable<V>
   ): Thenable<V>

--- a/src/middleware/redux.ts
+++ b/src/middleware/redux.ts
@@ -4,15 +4,15 @@ import { NamedSet } from './devtools'
 type Write<T extends object, U extends object> = Omit<T, keyof U> & U
 type Cast<T, U> = T extends U ? T : U
 
-interface Action {
+type Action = {
   type: unknown
 }
 
-interface ReduxState<A extends Action> {
+type ReduxState<A extends Action> = {
   dispatch: StoreRedux<A>['dispatch']
 }
 
-interface StoreRedux<A extends Action> {
+type StoreRedux<A extends Action> = {
   dispatch: (a: A) => A
   dispatchFromDevtools: true
 }

--- a/src/middleware/subscribeWithSelector.ts
+++ b/src/middleware/subscribeWithSelector.ts
@@ -32,7 +32,7 @@ declare module '../vanilla' {
   }
 }
 
-interface StoreSubscribeWithSelector<T extends State> {
+type StoreSubscribeWithSelector<T extends State> = {
   subscribe: {
     (listener: (selectedState: T, previousSelectedState: T) => void): () => void
     <U>(

--- a/src/react.ts
+++ b/src/react.ts
@@ -56,7 +56,7 @@ export type UseBoundStore<S extends WithReact<StoreApi<State>>> = {
   ): U
 } & S
 
-interface Create {
+type Create = {
   <T extends State, Mos extends [StoreMutatorIdentifier, unknown][] = []>(
     initializer: StateCreator<T, [], Mos>
   ): UseBoundStore<Mutate<StoreApi<T>, Mos>>

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -30,7 +30,7 @@ export type StateSliceListener<T> = (slice: T, previousSlice: T) => void
 /**
  * @deprecated Use `(listener: (state: T) => void) => void` instead of `Subscribe<T>`.
  */
-export interface Subscribe<T extends State> {
+export type Subscribe<T extends State> = {
   (listener: (state: T, previousState: T) => void): () => void
 }
 
@@ -87,7 +87,7 @@ export type Mutate<S, Ms> = Ms extends []
 
 type Get<T, K, F = never> = K extends keyof T ? T[K] : F
 
-interface CreateStore {
+type CreateStore = {
   <T extends State, Mos extends [StoreMutatorIdentifier, unknown][] = []>(
     initializer: StateCreator<T, [], Mos>
   ): Mutate<StoreApi<T>, Mos>

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -37,7 +37,7 @@ it('creates a store hook and api object', () => {
   `)
 })
 
-interface CounterState {
+type CounterState = {
   count: number
   inc: () => void
 }
@@ -185,13 +185,8 @@ it('can batch updates', async () => {
 })
 
 it('can update the selector', async () => {
-  interface State {
-    one: string
-    two: string
-  }
-  interface Props {
-    selector: StateSelector<State, string>
-  }
+  type State = { one: string; two: string }
+  type Props = { selector: StateSelector<State, string> }
   const useStore = create<State>(() => ({
     one: 'one',
     two: 'two',
@@ -209,12 +204,8 @@ it('can update the selector', async () => {
 })
 
 it('can update the equality checker', async () => {
-  interface State {
-    value: number
-  }
-  interface Props {
-    equalityFn: EqualityChecker<State>
-  }
+  type State = { value: number }
+  type Props = { equalityFn: EqualityChecker<State> }
   const useStore = create<State>(() => ({ value: 0 }))
   const { setState } = useStore
   const selector: StateSelector<State, State> = (s) => s
@@ -247,10 +238,8 @@ it('can update the equality checker', async () => {
 })
 
 it('can call useStore with progressively more arguments', async () => {
-  interface State {
-    value: number
-  }
-  interface Props {
+  type State = { value: number }
+  type Props = {
     selector?: StateSelector<State, number>
     equalityFn?: EqualityChecker<number>
   }
@@ -294,9 +283,7 @@ it('can call useStore with progressively more arguments', async () => {
 
 it('can throw an error in selector', async () => {
   console.error = jest.fn()
-  interface State {
-    value: string | number
-  }
+  type State = { value: string | number }
 
   const initialState: State = { value: 'foo' }
   const useStore = create<State>(() => initialState)
@@ -341,9 +328,7 @@ it('can throw an error in selector', async () => {
 
 it('can throw an error in equality checker', async () => {
   console.error = jest.fn()
-  interface State {
-    value: string | number
-  }
+  type State = { value: string | number }
 
   const initialState: State = { value: 'foo' }
   const useStore = create(() => initialState)
@@ -388,7 +373,7 @@ it('can throw an error in equality checker', async () => {
 })
 
 it('can get the store', () => {
-  interface State {
+  type State = {
     value: number
     getState1: () => State
     getState2: () => State
@@ -404,7 +389,7 @@ it('can get the store', () => {
 })
 
 it('can set the store', () => {
-  interface State {
+  type State = {
     value: number
     setState1: SetState<State>
     setState2: SetState<State>
@@ -453,10 +438,7 @@ it('can destroy the store', () => {
 })
 
 it('only calls selectors when necessary', async () => {
-  interface State {
-    a: number
-    b: number
-  }
+  type State = { a: number; b: number }
   const useStore = create<State>(() => ({ a: 0, b: 0 }))
   const { setState } = useStore
   let inlineSelectorCallCount = 0
@@ -492,12 +474,10 @@ it('only calls selectors when necessary', async () => {
 })
 
 it('ensures parent components subscribe before children', async () => {
-  interface State {
+  type State = {
     children: { [key: string]: { text: string } }
   }
-  interface Props {
-    id: string
-  }
+  type Props = { id: string }
   const useStore = create<State>(() => ({
     children: {
       '1': { text: 'child 1' },

--- a/tests/context.test.tsx
+++ b/tests/context.test.tsx
@@ -15,7 +15,7 @@ afterEach(() => {
   console.error = consoleError
 })
 
-interface CounterState {
+type CounterState = {
   count: number
   inc: () => void
 }

--- a/tests/middlewareTypes.test.tsx
+++ b/tests/middlewareTypes.test.tsx
@@ -9,7 +9,7 @@ import {
 import { immer } from 'zustand/middleware/immer'
 import createVanilla from 'zustand/vanilla'
 
-interface CounterState {
+type CounterState = {
   count: number
   inc: () => void
 }
@@ -597,7 +597,7 @@ describe('more complex state spec with subscribeWithSelector', () => {
   })
 
   it('#631', () => {
-    interface MyState {
+    type MyState = {
       foo: number | null
     }
     const useStore = create<MyState>()(
@@ -622,7 +622,7 @@ describe('more complex state spec with subscribeWithSelector', () => {
   })
 
   it('#650', () => {
-    interface MyState {
+    type MyState = {
       token: string | undefined
       authenticated: boolean
       authenticate: (username: string, password: string) => Promise<void>

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -14,7 +14,7 @@ import create, {
 } from 'zustand'
 
 it('can use exposed types', () => {
-  interface ExampleState {
+  type ExampleState = {
     num: number
     numGet: () => number
     numGetState: () => number
@@ -111,9 +111,7 @@ type AssertEqual<Type, Expected> = Type extends Expected
   : never
 
 it('should have correct (partial) types for setState', () => {
-  interface Count {
-    count: number
-  }
+  type Count = { count: number }
 
   const store = create<Count>((set) => ({
     count: 0,
@@ -139,7 +137,7 @@ it('should have correct (partial) types for setState', () => {
 })
 
 it('should allow for different partial keys to be returnable from setState', () => {
-  interface State {
+  type State = {
     count: number
     something: string
   }


### PR DESCRIPTION
This mostly reverts #1012. 
`@typescript-eslint/consistent-type-definitions` rule doesn't work for library code.

So, our new ground rule is:
- prefer interface for public api (always with `export`)
- otherwise, prefer type alias

close #1100 
close #1103 
close #1113 

---
jotai and valtio should follow this too.