### PR TITLE
perf(example): remove unnecessary imports of "prismjs"

### DIFF
--- a/examples/src/components/CodePreview.js
+++ b/examples/src/components/CodePreview.js
@@ -1,12 +1,10 @@
 import Highlight, { defaultProps } from 'prism-react-renderer'
 import CopyButton from './CopyButton'
-import 'prismjs'
-import 'prismjs/components/prism-jsx.min'
 import 'prismjs/themes/prism-okaidia.css'
 
 export default function CodePreview({ code, ...props }) {
   return (
-    <Highlight {...defaultProps} className="language-jsx" code={code} language="jsx" theme={undefined}>
+    <Highlight {...defaultProps} code={code} language="jsx" theme={undefined}>
       {({ className, style, tokens, getLineProps, getTokenProps }) => (
         // define how each line is to be rendered in the code block,
         // position is set to relative so the copy button can align to bottom right


### PR DESCRIPTION
This reduces 8.54kb of the bundle size for the example site.

<img width="542" alt="reduce" src="https://user-images.githubusercontent.com/48589760/180825180-6172fa5a-dc73-4def-95a8-c3238a7792ba.png">
 
Cannot use the new theme from `'prism-react-renderer/themes/okaidia'` although they have the same name `okaidia`, the style still looks different. Followed [the introduction](https://github.com/FormidableLabs/prism-react-renderer#faq) and used the old Prism css theme, removed unnecessary imports of "prismjs".

The output is as same as before

<img width="1190" alt="compare" src="https://user-images.githubusercontent.com/48589760/180826895-34d45add-13b3-403d-881c-7e0fb57c666b.png">


