### PR TITLE
fix typo in typescript.md

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -12,7 +12,7 @@ interface BearState {
   increase: (by: number) => void
 }
 
-const useBearStore = create<BearState>()((set) => ({
+const useBoundStore = create<BearState>()((set) => ({
   bears: 0,
   increase: (by) => set((state) => ({ bears: state.bears + by })),
 }))
@@ -380,7 +380,7 @@ const createFishSlice: StateCreator<
   addFish: () => set((state) => ({ fishes: state.fishes + 1 })),
 })
 
-const useBearStore = create<BearSlice & FishSlice>()((...a) => ({
+const useBoundStore = create<BearSlice & FishSlice>()((...a) => ({
   ...createBearSlice(...a),
   ...createFishSlice(...a),
 }))

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -59,7 +59,7 @@ The thing is Zustand is lying in it's type, the simplest way to prove it by show
 ```ts
 import create from 'zustand/vanilla'
 
-const useBoundStore = create<{ foo: number }>()((_, get) => ({
+const useBearStore = create<{ foo: number }>()((_, get) => ({
   foo: get().foo,
 }))
 ```
@@ -133,9 +133,9 @@ const useBearStore = create(
 
   <br/>
 
-We achieve the inference by lying a little in the types of `set`, `get` and `store` that you receive as parameters. The lie is that they're typed in a way as if the state is the first parameter only when in fact the state is the shallow-merge (`{ ...a, ...b }`) of both first parameter and the second parameter's return. So for example `get` from the second parameter has type `() => { bears: number }` and that's a lie as it should be `() => { bears: number, increase: (by: number) => void }`. And `useBoundStore` still has the correct type, ie for example `useBoundStore.getState` is typed as `() => { bears: number, increase: (by: number) => void }`.
+We achieve the inference by lying a little in the types of `set`, `get` and `store` that you receive as parameters. The lie is that they're typed in a way as if the state is the first parameter only when in fact the state is the shallow-merge (`{ ...a, ...b }`) of both first parameter and the second parameter's return. So for example `get` from the second parameter has type `() => { bears: number }` and that's a lie as it should be `() => { bears: number, increase: (by: number) => void }`. And `useBearStore` still has the correct type, ie for example `useBearStore.getState` is typed as `() => { bears: number, increase: (by: number) => void }`.
 
-It's not a lie lie because `{ bears: number }` is still a subtype `{ bears: number, increase: (by: number) => void }`, so in most cases there won't be a problem. Just you have to be careful while using replace. For eg `set({ bears: 0 }, true)` would compile but will be unsound as it'll delete the `increase` function. (If you set from "outside" ie `useBoundStore.setState({ bears: 0 }, true)` then it won't compile because the "outside" store knows that `increase` is missing.) Another instance where you should be careful you're doing `Object.keys`, `Object.keys(get())` will return `["bears", "increase"]` and not `["bears"]` (the return type of `get` can make you fall for this).
+It's not a lie lie because `{ bears: number }` is still a subtype `{ bears: number, increase: (by: number) => void }`, so in most cases there won't be a problem. Just you have to be careful while using replace. For eg `set({ bears: 0 }, true)` would compile but will be unsound as it'll delete the `increase` function. (If you set from "outside" ie `useBearStore.setState({ bears: 0 }, true)` then it won't compile because the "outside" store knows that `increase` is missing.) Another instance where you should be careful you're doing `Object.keys`, `Object.keys(get())` will return `["bears", "increase"]` and not `["bears"]` (the return type of `get` can make you fall for this).
 
 So `combine` trades-off a little type-safety for the convenience of not having to write a type for state. Hence you should use `combine` accordingly, usually it's not a big deal and it's okay to use it.
 
@@ -380,7 +380,7 @@ const createFishSlice: StateCreator<
   addFish: () => set((state) => ({ fishes: state.fishes + 1 })),
 })
 
-const useBoundStore = create<BearSlice & FishSlice>()((...a) => ({
+const useBearStore = create<BearSlice & FishSlice>()((...a) => ({
   ...createBearSlice(...a),
   ...createFishSlice(...a),
 }))

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -12,7 +12,7 @@ interface BearState {
   increase: (by: number) => void
 }
 
-const useBoundStore = create<BearState>()((set) => ({
+const useBearStore = create<BearState>()((set) => ({
   bears: 0,
   increase: (by) => set((state) => ({ bears: state.bears + by })),
 }))
@@ -59,7 +59,7 @@ The thing is Zustand is lying in it's type, the simplest way to prove it by show
 ```ts
 import create from 'zustand/vanilla'
 
-const useBearStore = create<{ foo: number }>()((_, get) => ({
+const useBoundStore = create<{ foo: number }>()((_, get) => ({
   foo: get().foo,
 }))
 ```


### PR DESCRIPTION
Not sure if `useBoundStore` had some special meaning in other places, but there were incorrect references to it in the `combine` comment that didn't match the example. (I just replaced it with `useBearStore` everywhere assuming it was a typo.)