### PR TITLE
fix: live demo failure

### DIFF
--- a/examples/src/components/Scene.js
+++ b/examples/src/components/Scene.js
@@ -1,8 +1,7 @@
 import * as THREE from 'three'
-import { PlaneBufferGeometry } from 'three'
 import { useRef, useState } from 'react'
 import { Plane, useAspect, useTexture } from '@react-three/drei'
-import { useFrame, extend } from '@react-three/fiber'
+import { useFrame } from '@react-three/fiber'
 import Fireflies from './Fireflies'
 import bgUrl from '../resources/bg.jpg'
 import starsUrl from '../resources/stars.png'
@@ -11,9 +10,6 @@ import bearUrl from '../resources/bear.png'
 import leaves1Url from '../resources/leaves1.png'
 import leaves2Url from '../resources/leaves2.png'
 import '../materials/layerMaterial'
-
-// PlaneBufferGeometry is needed for Plane
-extend({ PlaneBufferGeometry })
 
 export default function Scene({ dof }) {
   const scaleN = useAspect(16, 10, 1.05)

--- a/examples/src/index.js
+++ b/examples/src/index.js
@@ -1,5 +1,6 @@
+import * as THREE from 'three'
 import { createRoot } from 'react-dom/client'
-import { createRoot as createCanvasRoot, events } from '@react-three/fiber'
+import { createRoot as createCanvasRoot, events, extend } from '@react-three/fiber'
 import './styles.css'
 import App from './App'
 import Backdrop from './components/Backdrop'
@@ -7,6 +8,9 @@ import Backdrop from './components/Backdrop'
 const root = createRoot(document.getElementById('root'))
 
 root.render(<App />)
+
+// https://docs.pmnd.rs/react-three-fiber/api/canvas#custom-canvas
+extend(THREE)
 
 const backdrop = createCanvasRoot(document.getElementById('backdrop'))
 


### PR DESCRIPTION
fix #1158

The custom canvas was implemented incorrectly, I forgot to extend the THREE namespaces, take the solution from below:

https://github.com/pmndrs/react-three-fiber/discussions/2402#discussioncomment-3270482

And also remove the unnecessary extend `extend({ PlaneBufferGeometry })` in `Scene.js` since the THREE namespaces are now fully registered.