### PR TITLE
update persist merge and migrate types

### DIFF
--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -62,12 +62,15 @@ export interface PersistOptions<S, PersistedState = S> {
    * A function to perform persisted state migration.
    * This function will be called when persisted state versions mismatch with the one specified here.
    */
-  migrate?: (persistedState: unknown, version: number) => S | Promise<S>
+  migrate?: (
+    persistedState: Partial<PersistedState>,
+    version: number
+  ) => S | Promise<S>
   /**
    * A function to perform custom hydration merges when combining the stored state with the current one.
    * By default, this function does a shallow merge.
    */
-  merge?: (persistedState: unknown, currentState: S) => S
+  merge?: (persistedState: Partial<PersistedState>, currentState: S) => S
 }
 
 type PersistListener<S> = (state: S) => void


### PR DESCRIPTION
Hi @dai-shi, @devanshj, and @AnatoleLucet,

Thank you for the hard work on v4 of zustand. I have a question and proposal about the persist middleware option types.

Currently, the `merge` and `migrate` callback options are both access `persistedState` in the callback and are typed as `unknown`. However, we know that the `persistedState` is the type `PersistedState` in this context. Since the type is a contract and we cannot know for sure the state returned from the storage engine will perfectly match the structure of `PersistedState`, I've opted to wrap it in `Partial` so the user of the persist middleware will check to make sure the fields exist before access.

What do you think of this proposal? Is there a better way to leverage typescript when using the persist middleware `merge` and `migrate` options? Thank you for your time.