### PR TITLE
Fix Persist in TypeScript Usage on readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -461,10 +461,15 @@ interface BearState {
 
 const useBearStore = create<BearState>()(
   devtools(
-    persist((set) => ({
-      bears: 0,
-      increase: (by) => set((state) => ({ bears: state.bears + by })),
-    }))
+    persist(
+      (set) => ({
+        bears: 0,
+        increase: (by) => set((state) => ({ bears: state.bears + by })),
+      }),
+      {
+        name: 'bear-storage'
+      }
+    )
   )
 )
 ```

--- a/readme.md
+++ b/readme.md
@@ -467,7 +467,7 @@ const useBearStore = create<BearState>()(
         increase: (by) => set((state) => ({ bears: state.bears + by })),
       }),
       {
-        name: 'bear-storage'
+        name: 'bear-storage',
       }
     )
   )


### PR DESCRIPTION
Persist middleware requires the name option to keep storage unique.

See https://github.com/pmndrs/zustand/blob/main/docs/persisting-store-data.md#name

This change adds the 'name' option to the Typescript Usage example to update it.
Additionally, the persist example already has this required option.