### PR TITLE
fix(middleware): revert types of redux middleware

### DIFF
--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -48,9 +48,6 @@ type StoreDevtools<S> = S extends {
     }
   : never
 
-const isObjectWithTypeProperty = (x: unknown): x is { type: unknown } =>
-  x !== null && typeof x === 'object' && 'type' in x
-
 export interface DevtoolsOptions extends Config {
   enabled?: boolean
   anonymousActionType?: string
@@ -120,9 +117,9 @@ const devtoolsImpl: DevtoolsImpl =
       extension.send(
         nameOrAction === undefined
           ? { type: anonymousActionType || 'anonymous' }
-          : isObjectWithTypeProperty(nameOrAction)
-          ? nameOrAction
-          : { type: nameOrAction },
+          : typeof nameOrAction === 'string'
+          ? { type: nameOrAction }
+          : nameOrAction,
         get()
       )
       return r

--- a/src/middleware/redux.ts
+++ b/src/middleware/redux.ts
@@ -3,25 +3,31 @@ import { NamedSet } from './devtools'
 
 type Write<T, U> = Omit<T, keyof U> & U
 
-type ReduxState<A> = {
-  dispatch: StoreRedux<A>['dispatch']
-}
+type Action = { type: unknown }
 
-type StoreRedux<A> = {
+type StoreRedux<A extends Action> = {
   dispatch: (a: A) => A
   dispatchFromDevtools: true
 }
 
-type WithRedux<S, A> = Write<S, StoreRedux<A>>
+type ReduxState<A extends Action> = {
+  dispatch: StoreRedux<A>['dispatch']
+}
 
-type Redux = <T, A, Cms extends [StoreMutatorIdentifier, unknown][] = []>(
+type WithRedux<S, A extends Action> = Write<S, StoreRedux<A>>
+
+type Redux = <
+  T,
+  A extends Action,
+  Cms extends [StoreMutatorIdentifier, unknown][] = []
+>(
   reducer: (state: T, action: A) => T,
   initialState: T
 ) => StateCreator<Write<T, ReduxState<A>>, Cms, [['zustand/redux', A]]>
 
 declare module '../vanilla' {
   interface StoreMutators<S, A> {
-    'zustand/redux': WithRedux<S, A>
+    'zustand/redux': WithRedux<S, A & Action>
   }
 }
 
@@ -31,23 +37,16 @@ type PopArgument<T extends (...a: never[]) => unknown> = T extends (
   ? (...a: A) => R
   : never
 
-type ReduxImpl = <T, A>(
+type ReduxImpl = <T, A extends Action>(
   reducer: (state: T, action: A) => T,
   initialState: T
 ) => PopArgument<StateCreator<T & ReduxState<A>, [], []>>
-
-const isObjectWithTypeProperty = (x: unknown): x is { type: unknown } =>
-  x !== null && typeof x === 'object' && 'type' in x
 
 const reduxImpl: ReduxImpl = (reducer, initial) => (set, _get, api) => {
   type S = typeof initial
   type A = Parameters<typeof reducer>[1]
   ;(api as any).dispatch = (action: A) => {
-    ;(set as NamedSet<S>)(
-      (state: S) => reducer(state, action),
-      false,
-      isObjectWithTypeProperty(action) ? action : { type: action }
-    )
+    ;(set as NamedSet<S>)((state: S) => reducer(state, action), false, action)
     return action
   }
   ;(api as any).dispatchFromDevtools = true

--- a/src/middleware/redux.ts
+++ b/src/middleware/redux.ts
@@ -5,16 +5,16 @@ type Write<T, U> = Omit<T, keyof U> & U
 
 type Action = { type: unknown }
 
-type StoreRedux<A extends Action> = {
+type StoreRedux<A> = {
   dispatch: (a: A) => A
   dispatchFromDevtools: true
 }
 
-type ReduxState<A extends Action> = {
+type ReduxState<A> = {
   dispatch: StoreRedux<A>['dispatch']
 }
 
-type WithRedux<S, A extends Action> = Write<S, StoreRedux<A>>
+type WithRedux<S, A> = Write<S, StoreRedux<A>>
 
 type Redux = <
   T,
@@ -27,7 +27,7 @@ type Redux = <
 
 declare module '../vanilla' {
   interface StoreMutators<S, A> {
-    'zustand/redux': WithRedux<S, A & Action>
+    'zustand/redux': WithRedux<S, A>
   }
 }
 


### PR DESCRIPTION
In #1144, I made some types loosen, which includes not only `State` but also `Action` in the redux middleware. @devanshj pointed out that it can cause misusage with the combination of `redux` and `devtools` middleware.

So, I'm convinced to revert the `Action` part of the change.
