### PR TITLE
refactor(types): prefer using import type

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,12 +1,13 @@
 import {
-  ReactNode,
   createElement,
   createContext as reactCreateContext,
   useContext,
   useMemo,
   useRef,
 } from 'react'
-import { StoreApi, useStore } from 'zustand'
+import type { ReactNode } from 'react'
+import { useStore } from 'zustand'
+import type { StoreApi } from 'zustand'
 
 type UseContextStore<S extends StoreApi<unknown>> = {
   (): ExtractState<S>

--- a/src/middleware/combine.ts
+++ b/src/middleware/combine.ts
@@ -1,4 +1,4 @@
-import { StateCreator, StoreMutatorIdentifier } from '../vanilla'
+import type { StateCreator, StoreMutatorIdentifier } from '../vanilla'
 
 type Write<T, U> = Omit<T, keyof U> & U
 

--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -1,5 +1,5 @@
 import type {} from '@redux-devtools/extension'
-import { StateCreator, StoreApi, StoreMutatorIdentifier } from '../vanilla'
+import type { StateCreator, StoreApi, StoreMutatorIdentifier } from '../vanilla'
 
 // Copy types to avoid import type { Config } from '@redux-devtools/extension'
 // https://github.com/pmndrs/zustand/issues/1205

--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -1,6 +1,6 @@
-// eslint-disable-next-line import/named
-import { Draft, produce } from 'immer'
-import { StateCreator, StoreMutatorIdentifier } from '../vanilla'
+import { produce } from 'immer'
+import type { Draft } from 'immer'
+import type { StateCreator, StoreMutatorIdentifier } from '../vanilla'
 
 type Immer = <
   T,

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -1,4 +1,4 @@
-import { StateCreator, StoreApi, StoreMutatorIdentifier } from '../vanilla'
+import type { StateCreator, StoreApi, StoreMutatorIdentifier } from '../vanilla'
 
 export interface StateStorage {
   getItem: (name: string) => string | null | Promise<string | null>

--- a/src/middleware/redux.ts
+++ b/src/middleware/redux.ts
@@ -1,5 +1,5 @@
-import { StateCreator, StoreMutatorIdentifier } from '../vanilla'
-import { NamedSet } from './devtools'
+import type { StateCreator, StoreMutatorIdentifier } from '../vanilla'
+import type { NamedSet } from './devtools'
 
 type Write<T, U> = Omit<T, keyof U> & U
 

--- a/src/middleware/subscribeWithSelector.ts
+++ b/src/middleware/subscribeWithSelector.ts
@@ -1,4 +1,4 @@
-import { StateCreator, StoreMutatorIdentifier } from '../vanilla'
+import type { StateCreator, StoreMutatorIdentifier } from '../vanilla'
 
 type SubscribeWithSelector = <
   T,

--- a/src/react.ts
+++ b/src/react.ts
@@ -4,7 +4,8 @@ import { useDebugValue } from 'react'
 // See: https://github.com/pmndrs/valtio/issues/452
 // The following is a workaround until ESM is supported.
 import useSyncExternalStoreExports from 'use-sync-external-store/shim/with-selector'
-import createStore, {
+import createStore from './vanilla'
+import type {
   Mutate,
   StateCreator,
   StoreApi,


### PR DESCRIPTION
Since we have downlevel-dts, we can use `import type` statement.
This is not a big deal, but it makes the code consistent with that in [jotai](https://github.com/pmndrs/jotai) and [valtio](https://github.com/pmndrs/valtio).