### PR TITLE
fix(docs): Add how to reset state to docs/guides section

### DIFF
--- a/docs/guides/how-to-reset-state.md
+++ b/docs/guides/how-to-reset-state.md
@@ -1,0 +1,71 @@
+---
+title: How to reset state
+nav: 18
+---
+
+The following pattern can be used to reset the state to its initial value.
+
+```js
+//define types for state values and actions separately
+
+type State = {
+  salmon: number;
+  tuna: number;
+};
+
+type Actions = {
+  addSalmon: (qty: number) => void;
+  addTuna: (qty: number) => void;
+  reset: () => void
+};
+
+//define the initial state
+const initalState: State = {
+  salmon: 0;
+  tuna: 0;
+};
+
+//create store
+const useSlice = create<State & Actions>((set, get) => ({
+  ...initialState,
+
+  addSalmon: (qty: number) => {
+    set({ salmon: get().salmon + qty });
+  },
+
+  addTuna: (qty: number) => {
+    set({ tuna: get().tuna + qty });
+  },
+
+  reset: () => {
+    set({ ...initialState })
+  },
+}));
+```
+
+Resetting multiple stores at once instead of individual stores
+
+```js
+import actualCreate, { GetState, SetState, State, StateCreator, StoreApi, UseBoundStore } from 'zustand';
+
+const resetters: (() => void)[] = [];
+
+export const create: typeof actualCreate = <TState extends State>(
+  createState: StateCreator<TState, SetState<TState>, GetState<TState>, any> | StoreApi<TState>
+): UseBoundStore<TState, StoreApi<TState>> => {
+  const slice = actualCreate(createState);
+  const initialState = slice.getState();
+
+  resetters.push(() => {
+    slice.setState(initialState, true);
+  });
+
+  return slice;
+};
+
+export const resetAllSlices = () => {
+  for (const resetter of resetters) {
+    resetter();
+  }
+};
+```

--- a/docs/guides/how-to-reset-state.md
+++ b/docs/guides/how-to-reset-state.md
@@ -38,7 +38,7 @@ const useSlice = create<State & Actions>((set, get) => ({
   },
 
   reset: () => {
-    set({ ...initialState })
+    set(initialState)
   },
 }))
 ```

--- a/docs/guides/how-to-reset-state.md
+++ b/docs/guides/how-to-reset-state.md
@@ -76,4 +76,5 @@ export const resetAllSlices = () => {
 
 ## CodeSandbox Demo
 
-https://codesandbox.io/s/zustand-how-to-reset-state-demo-gtu0qe
+- Basic: https://codesandbox.io/s/zustand-how-to-reset-state-basic-demo-rrqyon
+- Advanced: https://codesandbox.io/s/zustand-how-to-reset-state-advanced-demo-gtu0qe

--- a/docs/guides/how-to-reset-state.md
+++ b/docs/guides/how-to-reset-state.md
@@ -73,3 +73,7 @@ export const resetAllSlices = () => {
   }
 }
 ```
+
+## CodeSandbox Demo
+
+https://codesandbox.io/s/zustand-how-to-reset-state-demo-gtu0qe

--- a/docs/guides/how-to-reset-state.md
+++ b/docs/guides/how-to-reset-state.md
@@ -6,8 +6,9 @@ nav: 18
 The following pattern can be used to reset the state to its initial value.
 
 ```ts
-//define types for state values and actions separately
+import create from 'zustand'
 
+// define types for state values and actions separately
 type State = {
   salmon: number
   tuna: number
@@ -19,13 +20,13 @@ type Actions = {
   reset: () => void
 }
 
-//define the initial state
-const initalState: State = {
+// define the initial state
+const initialState: State = {
   salmon: 0,
   tuna: 0,
 }
 
-//create store
+// create store
 const useSlice = create<State & Actions>((set, get) => ({
   ...initialState,
 
@@ -46,23 +47,17 @@ const useSlice = create<State & Actions>((set, get) => ({
 Resetting multiple stores at once instead of individual stores
 
 ```ts
-import actualCreate, {
-  GetState,
-  SetState,
-  State,
-  StateCreator,
-  StoreApi,
-  UseBoundStore,
-} from 'zustand'
+import _create, { StateCreator, StoreApi, UseBoundStore } from 'zustand'
 
 const resetters: (() => void)[] = []
 
-export const create: typeof actualCreate = <TState extends State>(
-  createState:
-    | StateCreator<TState, SetState<TState>, GetState<TState>, any>
-    | StoreApi<TState>
-): UseBoundStore<TState, StoreApi<TState>> => {
-  const slice = actualCreate(createState)
+export const create = <TState extends unknown>(
+  createState: StateCreator<TState> | StoreApi<TState>
+): UseBoundStore<StoreApi<TState>> => {
+  // We need to use createState as never to support StateCreator<TState> and
+  // StoreApi<TState> at the same time.
+  // We also need to re-type slice to UseBoundStore<StoreApi<TState>>
+  const slice: UseBoundStore<StoreApi<TState>> = _create(createState as never)
   const initialState = slice.getState()
 
   resetters.push(() => {

--- a/docs/guides/how-to-reset-state.md
+++ b/docs/guides/how-to-reset-state.md
@@ -5,67 +5,76 @@ nav: 18
 
 The following pattern can be used to reset the state to its initial value.
 
-```js
+```ts
 //define types for state values and actions separately
 
 type State = {
-  salmon: number;
-  tuna: number;
-};
+  salmon: number
+  tuna: number
+}
 
 type Actions = {
-  addSalmon: (qty: number) => void;
-  addTuna: (qty: number) => void;
+  addSalmon: (qty: number) => void
+  addTuna: (qty: number) => void
   reset: () => void
-};
+}
 
 //define the initial state
 const initalState: State = {
-  salmon: 0;
-  tuna: 0;
-};
+  salmon: 0,
+  tuna: 0,
+}
 
 //create store
 const useSlice = create<State & Actions>((set, get) => ({
   ...initialState,
 
   addSalmon: (qty: number) => {
-    set({ salmon: get().salmon + qty });
+    set({ salmon: get().salmon + qty })
   },
 
   addTuna: (qty: number) => {
-    set({ tuna: get().tuna + qty });
+    set({ tuna: get().tuna + qty })
   },
 
   reset: () => {
     set({ ...initialState })
   },
-}));
+}))
 ```
 
 Resetting multiple stores at once instead of individual stores
 
-```js
-import actualCreate, { GetState, SetState, State, StateCreator, StoreApi, UseBoundStore } from 'zustand';
+```ts
+import actualCreate, {
+  GetState,
+  SetState,
+  State,
+  StateCreator,
+  StoreApi,
+  UseBoundStore,
+} from 'zustand'
 
-const resetters: (() => void)[] = [];
+const resetters: (() => void)[] = []
 
 export const create: typeof actualCreate = <TState extends State>(
-  createState: StateCreator<TState, SetState<TState>, GetState<TState>, any> | StoreApi<TState>
+  createState:
+    | StateCreator<TState, SetState<TState>, GetState<TState>, any>
+    | StoreApi<TState>
 ): UseBoundStore<TState, StoreApi<TState>> => {
-  const slice = actualCreate(createState);
-  const initialState = slice.getState();
+  const slice = actualCreate(createState)
+  const initialState = slice.getState()
 
   resetters.push(() => {
-    slice.setState(initialState, true);
-  });
+    slice.setState(initialState, true)
+  })
 
-  return slice;
-};
+  return slice
+}
 
 export const resetAllSlices = () => {
   for (const resetter of resetters) {
-    resetter();
+    resetter()
   }
-};
+}
 ```


### PR DESCRIPTION
## Related Issues

Fixes #1008 

## Summary

Move how to reset state to ./docs 

## Check List

- [x] `yarn run prettier` for formatting code and docs
