### PR TITLE
fix(docs): comparison

### DIFF
--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -222,8 +222,8 @@ const Component = () => {
 
 ### State Model
 
-There is a major difference between Zustand and Valtio. Zustand is based on the
-immutable state model, while Valtio is based on the mutable state model.
+There is a major differences between Zustand and Valtio. Zustand is based on
+the immutable state model, while Valtio is based on the mutable state model.
 
 ```ts
 import create from 'zustand'

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -14,7 +14,7 @@ differences between these two libraries.
 There are no big difference between Zustand and Redux. Both are base on
 immutable state model.
 
-```tsx
+```ts
 import create from 'zustand'
 
 type State = {
@@ -40,7 +40,7 @@ const Component = () => {
 }
 ```
 
-```tsx
+```ts
 import create from 'zustand'
 
 type State = {
@@ -80,7 +80,7 @@ const Component = () => {
 }
 ```
 
-```tsx
+```ts
 import { createStore } from 'redux'
 import { useSelector, useDispatch } from 'react-redux'
 
@@ -146,7 +146,7 @@ The other difference between Valtio and Zustand is, Valtio made render
 optimizations through property access. But, with Zustand you need to do manual
 render optimizations through selectors.
 
-```tsx
+```ts
 import create from 'zustand'
 
 const useStore = create(() => ({
@@ -159,7 +159,7 @@ const Component = () => {
 }
 ```
 
-```tsx
+```ts
 import { proxy, useSnapshot } from 'valtio'
 
 const state = proxy({

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -40,7 +40,7 @@ const Component = () => {
 }
 ```
 
-```ts
+```tsx
 import create from 'zustand'
 
 type State = {
@@ -80,7 +80,7 @@ const Component = () => {
 }
 ```
 
-```ts
+```tsx
 import { createStore } from 'redux'
 import { useSelector, useDispatch } from 'react-redux'
 
@@ -146,7 +146,7 @@ The other difference between Valtio and Zustand is, Valtio made render
 optimizations through property access. But, with Zustand you need to do manual
 render optimizations through selectors.
 
-```ts
+```tsx
 import create from 'zustand'
 
 const useStore = create(() => ({
@@ -159,7 +159,7 @@ const Component = () => {
 }
 ```
 
-```ts
+```tsx
 import { proxy, useSnapshot } from 'valtio'
 
 const state = proxy({

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -12,7 +12,7 @@ differences between these two libraries.
 ### State Model
 
 There are no big difference between Zustand and Redux. Both are base on
-immutable state model.
+immutable state model. Also, Redux needs to wrap you app in context providers.
 
 ```ts
 import create from 'zustand'
@@ -291,8 +291,9 @@ differences between these two libraries.
 
 ### State Model
 
-The major difference is the same as Zustand and Jotai. Also, Recoil depends on
-atom string keys instead of atom object referential identities.
+The major difference is the same as Zustand and Jotai is: Recoil depends on
+atom string keys instead of atom object referential identities. Also, Recoil
+needs to wrap your app in a context provider.
 
 ```ts
 import create from 'zustand'

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -291,6 +291,9 @@ differences between these two libraries.
 
 ### State Model
 
+The major difference is the same as Zustand and Jotai. Also, Recoil depends on
+atom string keys instead of atom object referential identities.
+
 ```ts
 import create from 'zustand'
 
@@ -315,6 +318,10 @@ const count = atom({
 ```
 
 ### Render Optimization
+
+The other difference between Zustand and Recoil is: Recoil makes render
+optimizations through atom dependency. But, with Zustand you need to do manual
+render optimizations through selectors.
 
 ```ts
 import create from 'zustand'

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -4,14 +4,18 @@ description:
 nav: 2
 ---
 
-## Redux
+Zustand is one of many state management libraries for React. On this page we
+will discuss Zustand in comparison to some of these libraries, including Redux,
+Valtio, Jotai, and Recoil.
 
-Zustand and Redux are state management libraries for React. Here are some
-differences between these two libraries.
+Each library has its own strengths and weaknesses, and we will compare key
+differences and similarities between each.
+
+## Redux
 
 ### State Model
 
-There are no big difference between Zustand and Redux. Both are base on
+There are no big differences between Zustand and Redux. Both are based on
 immutable state model. Also, Redux needs to wrap you app in context providers.
 
 ```ts
@@ -94,10 +98,32 @@ const countReducer = (state: State, action: Action) => {
 const countStore = createStore(countReducer)
 ```
 
+```ts
+import { createSlice, configureStore } from '@reduxjs/toolkit'
+
+const countSlice = createSlice({
+  name: 'count',
+  initialState: { value: 0 },
+  reducers: {
+    incremented: (state, qty: number) => {
+      // Redux Toolkit does not mutate the state, it use Immer library behind
+      // scenes allow us to have something called "draft state".
+      state.value += qty
+    },
+    decremented: (state, qty: number) => {
+      state.value -= qty
+    },
+  },
+})
+
+const countStore = configureStore({ reducer: countSlice.reducer })
+```
+
 ### Render Optimization
 
-There are no difference between Zustand and Redux. In both you need to do manual
-render optimizations through selectors.
+When it comes to render optimizations within your app, there are no major
+differences in approach between Zustand and Redux. In both libraries it is
+recommended that you manually apply render optimizations by using selectors.
 
 ```ts
 import create from 'zustand'
@@ -158,10 +184,41 @@ const Component = () => {
 }
 ```
 
-## Valtio
+```ts
+import { useSelector } from 'react-redux'
+import type { TypedUseSelectorHook } from 'react-redux'
+import { createSlice, configureStore } from '@reduxjs/toolkit'
 
-Zustand and Valtio are state management libraries for React. Here are some
-differences between these two libraries.
+const countSlice = createSlice({
+  name: 'count',
+  initialState: { value: 0 },
+  reducers: {
+    incremented: (state, qty: number) => {
+      // Redux Toolkit does not mutate the state, it use Immer library behind
+      // scenes allow us to have something called "draft state".
+      state.value += qty
+    },
+    decremented: (state, qty: number) => {
+      state.value -= qty
+    },
+  },
+})
+
+const countStore = configureStore({ reducer: countSlice.reducer })
+
+const useAppSelector: TypedUseSelectorHook<typeof countStore.getState> =
+  useSelector
+
+const useAppDispatch: () => typeof countStore.dispatch = useDispatch
+
+const Component = () => {
+  const count = useAppSelector((state) => state.count.value)
+  const dispatch = useAppDispatch()
+  // ...
+}
+```
+
+## Valtio
 
 ### State Model
 
@@ -186,9 +243,9 @@ state.obj.count += 1
 
 ### Render Optimization
 
-The other difference between Zustand and Valtio is: Valtio makes render
-optimizations through property access. But, with Zustand you need to do manual
-render optimizations through selectors.
+The other difference between Zustand and Valtio is Valtio makes render
+optimizations through property access. While Zustand it is recommended that you
+manually apply render optimizations by using selectors.
 
 ```ts
 import create from 'zustand'
@@ -218,14 +275,13 @@ const Component = () => {
 
 ## Jotai
 
-Zustand and Jotai are state management libraries for React. Here are some
-differences between these two libraries.
-
 ### State Model
 
-There is a major difference between Zustand and Jotai. Zustand is a single
-store, while Jotai consits of primitive atoms and allows composing them
-together.
+There are two major difference between Zustand and Jotai. The first one is
+Zustand is a single store, while Jotai consists of primitive atoms and allows
+composing them together. The last one is Zustand store is global in memory, but
+Jotai atoms are not (are difinitions that do not hold values) and that's why
+you can use it outside React.
 
 ```ts
 import create from 'zustand'
@@ -285,9 +341,6 @@ const Component = () => {
 ```
 
 ## Recoil
-
-Zustand and Recoil are state management libraries for React. Here are some
-differences between these two libraries.
 
 ### State Model
 

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -33,9 +33,7 @@ const useCountStore = create<State & Actions>((set) => ({
 }))
 
 const Component = () => {
-  const count = useCountStore((state) => state.count)
-  const increment = useCountStore((state) => state.increment)
-  const decrement = useCountStore((state) => state.decrement)
+  const store = useCountStore()
   // ...
 }
 ```
@@ -74,8 +72,71 @@ const useCountStore = create<State & Actions>((set) => ({
 }))
 
 const Component = () => {
+  const store = useCountStore()
+  // ...
+}
+```
+
+```ts
+import { createStore } from 'redux'
+import { useSelector, useDispatch } from 'react-redux'
+
+type State = {
+  count: number
+}
+
+type Action = {
+  type: 'increment' | 'decrement'
+  qty: number
+}
+
+const countReducer = (state: State, action: Action) => {
+  switch (action.type) {
+    case 'increment':
+      return { count: state.count + action.qty }
+    case 'decrement':
+      return { count: state.count - action.qty }
+    default:
+      return state
+  }
+}
+
+const countStore = createStore(countReducer)
+
+const Component = () => {
+  const count = useSelector((state) => state)
+  const dispatch = useDispatch()
+  // ...
+}
+```
+
+### Render Optimization
+
+There are no difference between Zustand and Redux. In both you need to do manual
+render optimizations through selectors.
+
+```ts
+import create from 'zustand'
+
+type State = {
+  count: number
+}
+
+type Actions = {
+  increment: (qty: number) => void
+  decrement: (qty: number) => void
+}
+
+const useCountStore = create<State & Actions>((set) => ({
+  count: 0,
+  increment: (qty: number) => set((state) => ({ count: state.count + qty })),
+  decrement: (qty: number) => set((state) => ({ count: state.count - qty })),
+}))
+
+const Component = () => {
   const count = useCountStore((state) => state.count)
-  const dispatch = useCountStore((state) => state.dispatch)
+  const increment = useCountStore((state) => state.increment)
+  const decrement = useCountStore((state) => state.decrement)
   // ...
 }
 ```
@@ -112,8 +173,6 @@ const Component = () => {
   // ...
 }
 ```
-
-### Render Optimization
 
 ## Valtio
 

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -31,11 +31,6 @@ const useCountStore = create<State & Actions>((set) => ({
   increment: (qty: number) => set((state) => ({ count: state.count + qty })),
   decrement: (qty: number) => set((state) => ({ count: state.count - qty })),
 }))
-
-const Component = () => {
-  const store = useCountStore()
-  // ...
-}
 ```
 
 ```ts
@@ -70,11 +65,6 @@ const useCountStore = create<State & Actions>((set) => ({
   count: 0,
   dispatch: (action: Action) => set((state) => countReducer(state, action)),
 }))
-
-const Component = () => {
-  const store = useCountStore()
-  // ...
-}
 ```
 
 ```ts
@@ -102,12 +92,6 @@ const countReducer = (state: State, action: Action) => {
 }
 
 const countStore = createStore(countReducer)
-
-const Component = () => {
-  const count = useSelector((state) => state)
-  const dispatch = useDispatch()
-  // ...
-}
 ```
 
 ### Render Optimization
@@ -189,6 +173,7 @@ The contract in the immutable state model is that objects cannot be changed once
 import create from 'zustand'
 
 const store = create(() => ({ obj: { count: 0 } }))
+
 store.setState((prev) => ({ obj: { count: prev.obj.count + 1 } })
 ```
 
@@ -196,24 +181,25 @@ store.setState((prev) => ({ obj: { count: prev.obj.count + 1 } })
 import { proxy } from 'valtio'
 
 const state = proxy({ obj: { count: 0 } })
+
 state.obj.count += 1
 ```
 
 ### Render Optimization
 
-The other difference between Valtio and Zustand is, Valtio made render
+The other difference between Zustand and Valtio is: Valtio makes render
 optimizations through property access. But, with Zustand you need to do manual
 render optimizations through selectors.
 
 ```ts
 import create from 'zustand'
 
-const useStore = create(() => ({
+const useCountStore = create(() => ({
   count: 0,
 }))
 
 const Component = () => {
-  const count = useStore((state) => state.count)
+  const count = useCountStore((state) => state.count)
   // ...
 }
 ```
@@ -233,12 +219,134 @@ const Component = () => {
 
 ## Jotai
 
+Zustand and Jotai are state management libraries for React. Here are some
+differences between these two libraries.
+
 ### State Model
 
+There is a major difference between Zustand and Jotai. Zustand is a single
+store, while Jotai consits of primitive atoms and allows composing them
+together.
+
+```ts
+import create from 'zustand'
+
+type State = {
+  count: number
+}
+
+const useCountStore = create<State>((set) => ({
+  count: 0,
+  updateCount: (countCallback: (count: State['count']) => State['count']) =>
+    set((state) => ({ count: countCallback(state.count) })),
+}))
+```
+
+```ts
+import { atom } from 'jotai'
+
+const countAtom = atom<number>(0)
+```
+
 ### Render Optimization
+
+The other difference between Zustand and Jotai is: Jotai makes render
+optimizations through atom dependency. But, with Zustand you need to do manual
+render optimizations through selectors.
+
+```ts
+import create from 'zustand'
+
+type State = {
+  count: number
+}
+
+const useCountStore = create<State>((set) => ({
+  count: 0,
+  updateCount: (countCallback: (count: State['count']) => State['count']) =>
+    set((state) => ({ count: countCallback(state.count) })),
+}))
+
+const Component = () => {
+  const count = useCountStore((state) => state.count)
+  const updateCount = useCountStore((state) => state.updateCount)
+  // ...
+}
+```
+
+```ts
+import { atom, useAtom } from 'jotai'
+
+const countAtom = atom<number>(0)
+
+const Component = () => {
+  const [count, updateCount] = useAtom(countAtom)
+  // ...
+}
+```
 
 ## Recoil
 
+Zustand and Recoil are state management libraries for React. Here are some
+differences between these two libraries.
+
 ### State Model
 
+```ts
+import create from 'zustand'
+
+type State = {
+  count: number
+}
+
+const useCountStore = create<State>((set) => ({
+  count: 0,
+  setCount: (countCallback: (count: State['count']) => State['count']) =>
+    set((state) => ({ count: countCallback(state.count) })),
+}))
+```
+
+```ts
+import { atom } from 'recoil'
+
+const count = atom({
+  key: 'count',
+  default: 0,
+})
+```
+
 ### Render Optimization
+
+```ts
+import create from 'zustand'
+
+type State = {
+  count: number
+}
+
+const useCountStore = create<State>((set) => ({
+  count: 0,
+  setCount: (countCallback: (count: State['count']) => State['count']) =>
+    set((state) => ({ count: countCallback(state.count) })),
+}))
+
+const Component = () => {
+  const count = useCountStore((state) => state.count)
+  const setCount = useCountStore((state) => state.setCount)
+  // ...
+}
+```
+
+```ts
+import { atom, useRecoilState } from 'recoil'
+
+const countAtom = atom({
+  key: 'count',
+  default: 0,
+})
+
+const Component = () => {
+  const [count, setCount] = useRecoilState(countAtom)
+  // ...
+}
+```

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -6,7 +6,13 @@ nav: 2
 
 ## Redux
 
+Zustand and Redux are state management libraries for React. Here are some
+differences between these two libraries.
+
 ### State Model
+
+There are no big difference between Zustand and Redux. Both are base on
+immutable state model.
 
 ```tsx
 import create from 'zustand'
@@ -25,6 +31,13 @@ const useCountStore = create<State & Actions>((set) => ({
   increment: (qty: number) => set((state) => ({ count: state.count + qty })),
   decrement: (qty: number) => set((state) => ({ count: state.count - qty })),
 }))
+
+const Component = () => {
+  const count = useCountStore((state) => state.count)
+  const increment = useCountStore((state) => state.increment)
+  const decrement = useCountStore((state) => state.decrement)
+  // ...
+}
 ```
 
 ```ts
@@ -59,10 +72,45 @@ const useCountStore = create<State & Actions>((set) => ({
   count: 0,
   dispatch: (action: Action) => set((state) => countReducer(state, action)),
 }))
+
+const Component = () => {
+  const count = useCountStore((state) => state.count)
+  const dispatch = useCountStore((state) => state.dispatch)
+  // ...
+}
 ```
 
 ```ts
+import { createStore } from 'redux'
+import { useSelector, useDispatch } from 'react-redux'
 
+type State = {
+  count: number
+}
+
+type Action = {
+  type: 'increment' | 'decrement'
+  qty: number
+}
+
+const countReducer = (state: State, action: Action) => {
+  switch (action.type) {
+    case 'increment':
+      return { count: state.count + action.qty }
+    case 'decrement':
+      return { count: state.count - action.qty }
+    default:
+      return state
+  }
+}
+
+const countStore = createStore(countReducer)
+
+const Component = () => {
+  const count = useSelector((state) => state.count)
+  const dispatch = useDispatch()
+  // ...
+}
 ```
 
 ### Render Optimization
@@ -102,12 +150,11 @@ render optimizations through selectors.
 import create from 'zustand'
 
 const useStore = create(() => ({
-  count1: 0,
-  count2: 1,
+  count: 0,
 }))
 
 const Component = () => {
-  const count1 = useStore((state) => state.count1)
+  const count = useStore((state) => state.count)
   // ...
 }
 ```
@@ -116,16 +163,23 @@ const Component = () => {
 import { proxy, useSnapshot } from 'valtio'
 
 const state = proxy({
-  count1: 0,
-  count2: 0,
+  count: 0,
 })
 
 const Component = () => {
-  const { count1 } = useSnapshot(state)
+  const { count } = useSnapshot(state)
   // ...
 }
 ```
 
 ## Jotai
 
+### State Model
+
+### Render Optimization
+
 ## Recoil
+
+### State Model
+
+### Render Optimization

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -167,7 +167,6 @@ differences between these two libraries.
 
 There is a major difference between Zustand and Valtio. Zustand is based on the
 immutable state model, while Valtio is based on the mutable state model.
-The contract in the immutable state model is that objects cannot be changed once created
 
 ```ts
 import create from 'zustand'

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -4,11 +4,134 @@ description:
 nav: 2
 ---
 
-⚠️ This doc is still under construction. https://github.com/pmndrs/zustand/discussions/1033
+## Redux
 
-## Why zustand over react-redux?
+In some use cases, the developer experience can be similar in Zustand and Redux.
+Both are based on one-way data flow. In one-way data flow, we dispatch action,
+which represents a command to update a state, and after the state is updated
+with action, the new state is propagated to where it's needed.
 
-- Simple and un-opinionated
-- Makes hooks the primary means of consuming state
-- Doesn't wrap your app in context providers
-- [Can inform components transiently (without causing render)](recipes#transient-updates-for-often-occurring-state-changes)
+On the other hand, they differ in how to update states. Redux is based on
+reducers. While updating states with reducers is a strict method, it leads to
+more predictability. Zustand takes a flexible approach and it doesn't
+necessarily use reducers to update states.
+
+```tsx
+import create from 'zustand'
+
+type State = {
+  count: number
+}
+
+type Actions = {
+  increment: (qty: number) => void
+  decrement: (qty: number) => void
+}
+
+const useCountStore = create<State & Actions>((set) => ({
+  count: 0,
+  increment: (qty: number) => set((state) => ({ count: state.count + qty })),
+  decrement: (qty: number) => set((state) => ({ count: state.count - qty })),
+}))
+```
+
+```ts
+import create from 'zustand'
+
+type State = {
+  count: number
+}
+
+type Actions = {
+  increment: (qty: number) => void
+  decrement: (qty: number) => void
+}
+
+type Action = {
+  type: keyof Actions
+  qty: number
+}
+
+const countReducer = (state: State, action: Action) => {
+  switch (action.type) {
+    case 'increment':
+      return { count: state.count + action.qty }
+    case 'decrement':
+      return { count: state.count - action.qty }
+    default:
+      return state
+  }
+}
+
+const useCountStore = create<State & Actions>((set) => ({
+  count: 0,
+  dispatch: (action: Action) => set((state) => countReducer(state, action)),
+}))
+```
+
+```ts
+
+```
+
+## Valtio
+
+Zustand and Valtio are state management libraries for React. Here are some
+differences between these two libraries.
+
+### State Model
+
+There is a major difference between Zustand and Valtio. Zustand is based on the
+immutable state model, while Valtio is based on the mutable state model.
+The contract in the immutable state model is that objects cannot be changed once created
+
+```ts
+import create from 'zustand'
+
+const store = create(() => ({ obj: { count: 0 } }))
+store.setState((prev) => ({ obj: { count: prev.obj.count + 1 } })
+```
+
+```ts
+import { proxy } from 'valtio'
+
+const state = proxy({ obj: { count: 0 } })
+state.obj.count += 1
+```
+
+### Render Optimization
+
+The other difference between Valtio and Zustand is, Valtio made render
+optimizations through property access. But, with Zustand you need to do manual
+render optimizations through selectors.
+
+```ts
+import create from 'zustand'
+
+const useStore = create(() => ({
+  count1: 0,
+  count2: 1,
+}))
+
+const Component = () => {
+  const count1 = useStore((state) => state.count1)
+  // ...
+}
+```
+
+```ts
+import { proxy, useSnapshot } from 'valtio'
+
+const state = proxy({
+  count1: 0,
+  count2: 0,
+})
+
+const Component = () => {
+  const { count1 } = useSnapshot(state)
+  // ...
+}
+```
+
+## Jotai
+
+## Recoil

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -222,7 +222,7 @@ const Component = () => {
 
 ### State Model
 
-There is a major differences between Zustand and Valtio. Zustand is based on
+There is a major difference between Zustand and Valtio. Zustand is based on
 the immutable state model, while Valtio is based on the mutable state model.
 
 ```ts
@@ -277,11 +277,11 @@ const Component = () => {
 
 ### State Model
 
-There are two major difference between Zustand and Jotai. The first one is
+There are two major differences between Zustand and Jotai. The first one is
 Zustand is a single store, while Jotai consists of primitive atoms and allows
 composing them together. The last one is Zustand store is global in memory, but
 Jotai atoms are not (are difinitions that do not hold values) and that's why
-you can not use it outside React.
+you can use it outside React.
 
 ```ts
 import create from 'zustand'

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -280,7 +280,7 @@ const Component = () => {
 There are two major differences between Zustand and Jotai. The first one is
 Zustand is a single store, while Jotai consists of primitive atoms and allows
 composing them together. The last one is Zustand store is global in memory, but
-Jotai atoms are not (are difinitions that do not hold values) and that's why
+Jotai atoms are not (are definitions that do not hold values) and that's why
 you can use it outside React.
 
 ```ts

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -6,15 +6,7 @@ nav: 2
 
 ## Redux
 
-In some use cases, the developer experience can be similar in Zustand and Redux.
-Both are based on one-way data flow. In one-way data flow, we dispatch action,
-which represents a command to update a state, and after the state is updated
-with action, the new state is propagated to where it's needed.
-
-On the other hand, they differ in how to update states. Redux is based on
-reducers. While updating states with reducers is a strict method, it leads to
-more predictability. Zustand takes a flexible approach and it doesn't
-necessarily use reducers to update states.
+### State Model
 
 ```tsx
 import create from 'zustand'
@@ -72,6 +64,8 @@ const useCountStore = create<State & Actions>((set) => ({
 ```ts
 
 ```
+
+### Render Optimization
 
 ## Valtio
 


### PR DESCRIPTION
## Related Issues

Fixes #1008 

## Summary

- Move difference between zustand and valtio to ./docs
- Updating zustand vs redux
- Adding other comparisons

## Check List

- [x] `yarn run prettier` for formatting code and docs
