### PR TITLE
fix(types): simplify internal TakeTwo and SkipTwo types in middleware

### DIFF
--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -92,12 +92,6 @@ type TakeTwo<T> = T extends []
   ? [...a0: T, a1: undefined]
   : T extends [unknown?]
   ? [...a0: T, a1: undefined]
-  : T extends [unknown, unknown]
-  ? T
-  : T extends [unknown, unknown?]
-  ? T
-  : T extends [unknown?, unknown?]
-  ? T
   : T extends [infer A0, infer A1, ...unknown[]]
   ? [A0, A1]
   : T extends [infer A0, (infer A1)?, ...unknown[]]

--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -18,18 +18,14 @@ declare module '../vanilla' {
 }
 
 type Write<T, U> = Omit<T, keyof U> & U
-type SkipTwo<T> = T extends []
-  ? []
-  : T extends [unknown]
-  ? []
-  : T extends [unknown?]
-  ? []
-  : T extends [unknown, unknown, ...infer A]
+type SkipTwo<T> = T extends [unknown, unknown, ...infer A]
   ? A
   : T extends [unknown, unknown?, ...infer A]
   ? A
   : T extends [unknown?, unknown?, ...infer A]
   ? A
+  : T extends unknown[]
+  ? []
   : never
 
 type WithImmer<S> = Write<S, StoreImmer<S>>


### PR DESCRIPTION
should fix #1013.

my guess is `TakeTwo` is too complex.

https://tsplay.dev/mx3VBN I think we can simplify it. @devanshj can confirm?

Also, `SkipTwo` is simplified, which might solve issues with old TS.