### PR TITLE
docs: remove dead link from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -370,7 +370,7 @@ const dispatch = useGrumpyStore((state) => state.dispatch)
 dispatch({ type: types.increase, by: 2 })
 ```
 
-Or, just use our redux-middleware. It wires up your main-reducer, sets initial state, and adds a dispatch function to the state itself and the vanilla api. Try [this](https://codesandbox.io/s/amazing-kepler-swxol) example.
+Or, just use our redux-middleware. It wires up your main-reducer, sets initial state, and adds a dispatch function to the state itself and the vanilla api.
 
 ```jsx
 import { redux } from 'zustand/middleware'


### PR DESCRIPTION
## Related Issues

[Fixes](https://github.com/pmndrs/zustand/issues/1300)

## Summary

Remove dead link as mentioned:
 - https://github.com/pmndrs/zustand/issues/1300
 - https://github.com/pmndrs/zustand/pull/1231#issuecomment-1229575111
 - https://github.com/pmndrs/zustand/issues/1216#issuecomment-1236031336

## Check List

- [ ] `yarn run prettier` for formatting code and docs
