### PR TITLE
docs: expose `enabled` devtools options in the documentation

### DIFF
--- a/docs/recipes/recipes.mdx
+++ b/docs/recipes/recipes.mdx
@@ -379,6 +379,8 @@ import { devtools } from 'zustand/middleware'
 const useStore = create(devtools(store))
 // Usage with a redux store, it will log full action types
 const useStore = create(devtools(redux(reducer, initialState)))
+// Disabling devtools (for instance in production build)
+const useStore = create(devtools(store, { enabled: false }))
 ```
 
 devtools takes the store function as its first argument, optionally you can name the store with a second argument: `devtools(store, "MyStore")`, which will be prefixed to your actions.

--- a/readme.md
+++ b/readme.md
@@ -430,7 +430,8 @@ If an action type is not provided, it is defaulted to "anonymous". You can custo
 devtools(..., { anonymousActionType: 'unknown', ... })
 ```
 
-If you wish to disable devtools (on production for instance). You can customize this setting by providing the `enabled` parameter: 
+If you wish to disable devtools (on production for instance). You can customize this setting by providing the `enabled` parameter:
+
 ```jsx
 devtools(..., { enabled: false, ... })
 ```

--- a/readme.md
+++ b/readme.md
@@ -430,6 +430,11 @@ If an action type is not provided, it is defaulted to "anonymous". You can custo
 devtools(..., { anonymousActionType: 'unknown', ... })
 ```
 
+If you wish to disable devtools (on production for instance). You can customize this setting by providing the `enabled` parameter: 
+```jsx
+devtools(..., { enabled: false, ... })
+```
+
 ## React context
 
 The store created with `create` doesn't require context providers. In some cases, you may want to use contexts for dependency injection or if you want to initialize your store with props from a component. Because the normal store is a hook, passing it as a normal context value may violate rules of hooks.


### PR DESCRIPTION
## Summary

Document the `enabled` option for devtools middleware.

## Check List

- [x] `yarn run prettier` for formatting code and docs
