### PR TITLE
Typed redux action object

### DIFF
--- a/docs/guides/flux-inspired-practice.md
+++ b/docs/guides/flux-inspired-practice.md
@@ -55,3 +55,42 @@ const useReduxStore = create(redux(reducer, initialState))
 ```
 
 Another way to update the store could be through functions wrapping the state functions. These could also handle side-effects of actions. For example, with HTTP-calls. To use Zustand in a none-reactive way, see [the readme](https://github.com/pmndrs/zustand#readingwriting-state-and-reacting-to-changes-outside-of-components).
+
+In addition to above, to leverage TypeScript to provide typings for `action` objects, you can create a _map_ type and specify it on the `action` parameter of a `reducer`. For an example:
+
+```typescript
+type FeatureEventActions = {
+    grumpiness: {
+      'increase': number;
+      'decrease': number;
+      'reset': undefined;
+    }
+    happiness: {
+      'show all': User[]
+      'level': "low" | "sort of" | "high"
+    }
+}
+
+const reducer = (state, { type, payload }: ReduxAction<FeatureEventActions>) => {
+  switch (type) {
+    case "grumpiness/increase":
+      return { ...state, grumpiness: state.grumpiness + payload }
+    case "grumpiness/decrease":
+      return { ...state, grumpiness: state.grumpiness - payload }
+    case "grumpiness/reset":
+      return { ...state, grumpiness: 0 }
+    ...
+  }
+}
+
+const dispatch = useGrumpyStore((state) => state.dispatch)
+dispatch({ type: "grumpiness/increase", payload: 10 })
+```
+
+The structure of this map type, `FeatureEventActions`, is premised on [Redux's recommendation for actions](https://redux.js.org/tutorials/fundamentals/part-3-state-actions-reducers#what-youve-learned):
+ 
+  "_The type field should be a readable string, and is usually written as 'feature/eventName'_"
+
+For this example, 'grumpiness' and 'happiness' are features with event names of 'increase' and 'show all' respectively. Each event name is typed for what will be its `payload` type. Any `action` object of `ReduxAction<FeatureEventActions>`, either as a parameter of `reducer` or `dispatch`, has its `type` property constrained to what will be parsed by TypeScript. This will dictate the `payload` type. 
+
+By leveraging typings as above eliminates the need to use any type assertions in reducers. It also enforces only valid values for properties of `action` objects that can increase productively by eliminating mistakes by any developer.

--- a/docs/guides/flux-inspired-practice.md
+++ b/docs/guides/flux-inspired-practice.md
@@ -56,7 +56,7 @@ const useReduxStore = create(redux(reducer, initialState))
 
 Another way to update the store could be through functions wrapping the state functions. These could also handle side-effects of actions. For example, with HTTP-calls. To use Zustand in a none-reactive way, see [the readme](https://github.com/pmndrs/zustand#readingwriting-state-and-reacting-to-changes-outside-of-components).
 
-In addition to above, to leverage TypeScript to provide typings for `action` objects, you can create a _map_ type and specify it on the `action` parameter of a `reducer`. For an example:
+In addition to the above, to leverage TypeScript to provide typings for `action` objects, you can create a _map_ type and specify it on the `action` parameter of a `reducer`. For example:
 
 ```typescript
 type FeatureEventActions = {
@@ -91,6 +91,6 @@ The structure of this map type, `FeatureEventActions`, is premised on [Redux's r
 
 "_The type field should be a readable string, and is usually written as 'feature/eventName'_"
 
-For this example, 'grumpiness' and 'happiness' are features with event names of 'increase' and 'show all' respectively. Each event name is typed for what will be its `payload` type. Any `action` object of `ReduxAction<FeatureEventActions>`, either as a parameter of `reducer` or `dispatch`, has its `type` property constrained to what will be parsed by TypeScript. This will dictate the `payload` type.
+For this example, 'grumpiness' and 'happiness' are features with event names of 'increase' and 'show all' respectively. Each event name is typed for what will be its `payload` type. Any `action` object of `ReduxAction<FeatureEventActions>`, either as a parameter of `reducer` or `dispatch`, has its `type` property constrained to what will be parsed by TypeScript. This will also dictate the `payload` type.
 
-By leveraging typings as above eliminates the need to use any type assertions in reducers. It also enforces only valid values for properties of `action` objects that can increase productively by eliminating mistakes by any developer.
+Leveraging typings as above eliminates the need to use any type assertions in reducers. It also enforces only valid values for properties of `action` objects that can increase productivity during development.

--- a/docs/guides/flux-inspired-practice.md
+++ b/docs/guides/flux-inspired-practice.md
@@ -88,9 +88,9 @@ dispatch({ type: "grumpiness/increase", payload: 10 })
 ```
 
 The structure of this map type, `FeatureEventActions`, is premised on [Redux's recommendation for actions](https://redux.js.org/tutorials/fundamentals/part-3-state-actions-reducers#what-youve-learned):
- 
-  "_The type field should be a readable string, and is usually written as 'feature/eventName'_"
 
-For this example, 'grumpiness' and 'happiness' are features with event names of 'increase' and 'show all' respectively. Each event name is typed for what will be its `payload` type. Any `action` object of `ReduxAction<FeatureEventActions>`, either as a parameter of `reducer` or `dispatch`, has its `type` property constrained to what will be parsed by TypeScript. This will dictate the `payload` type. 
+"_The type field should be a readable string, and is usually written as 'feature/eventName'_"
+
+For this example, 'grumpiness' and 'happiness' are features with event names of 'increase' and 'show all' respectively. Each event name is typed for what will be its `payload` type. Any `action` object of `ReduxAction<FeatureEventActions>`, either as a parameter of `reducer` or `dispatch`, has its `type` property constrained to what will be parsed by TypeScript. This will dictate the `payload` type.
 
 By leveraging typings as above eliminates the need to use any type assertions in reducers. It also enforces only valid values for properties of `action` objects that can increase productively by eliminating mistakes by any developer.

--- a/src/middleware/redux.ts
+++ b/src/middleware/redux.ts
@@ -1,80 +1,36 @@
 import type { StateCreator, StoreMutatorIdentifier } from '../vanilla'
 import type { NamedSet } from './devtools'
 
-type FeatureEventMap = Record<string, EventName>
-type Separator = '/'
-type EventName = Record<string, unknown>
-
-// Credit given [here](https://stackoverflow.com/a/50375286/648789).
-// prettier-ignore
-type UnionToIntersection<U> =
-  (U extends any ? (k: U) => void : never) extends ((k: infer I) => void)
-    ? I
-    : never;
-
-type PayloadOptionalIfUndefined<A> = A extends {
-  type: infer T
-  payload: undefined
-}
-  ? { type: T; payload?: undefined }
-  : A
-
-type ActionsIndex<
-  Type extends FeatureEventMap,
-  FeatureKey extends keyof Type = ''
-> = FeatureKey extends keyof Type
-  ? {
-      [EventKey in keyof Type[FeatureKey] as `${string &
-        FeatureKey}${Separator}${string &
-        EventKey}`]: Type[FeatureKey][EventKey]
-    }
-  : ActionsIndex<Type, keyof Type>
-
-type ActionsIntersect<Type extends FeatureEventMap> = UnionToIntersection<
-  ActionsIndex<Type>
->
-
-/**
- * To enforce typings for an `action` parameter of a `reducer` or `dispatch`.
- *
- * By doing so, conditional expressions evalutating the `type` property of `action` type, will have the `payload` type
- * infered in the block scope of condition.
- *
- * For more information, see '[Flux like patterns / "dispatching" actions](https://github.com/pmndrs/zustand/blob/main/docs/guides/flux-inspired-practice.md)' section of docs.
- *
- * Credit given [here](https://stackoverflow.com/questions/73792053/typescript-argument-type-from-a-previous-argument-value).
- */
-export type ReduxAction<Type extends FeatureEventMap> = {
-  [FeatureEvent in keyof ActionsIntersect<Type>]: {
-    type: FeatureEvent
-    payload: ActionsIntersect<Type>[FeatureEvent]
-  }
-}[keyof ActionsIntersect<Type>]
-
 type Write<T, U> = Omit<T, keyof U> & U
 
 type Action = { type: unknown }
 
-type StoreRedux<A> = {
-  dispatch: (a: PayloadOptionalIfUndefined<A>) => A
-
+type StoreRedux<AIn, AOut> = {
+  dispatch: (a: AIn) => AOut
   dispatchFromDevtools: true
 }
 
-type ReduxState<A> = {
-  dispatch: StoreRedux<A>['dispatch']
+type ReduxState<AIn, AOut> = {
+  dispatch: StoreRedux<AIn, AOut>['dispatch']
 }
 
-type WithRedux<S, A> = Write<S, StoreRedux<A>>
+type WithRedux<S, A> = A extends [unknown, unknown]
+  ? Write<S, StoreRedux<A[0], A[1]>>
+  : never
 
 type Redux = <
   T,
-  A extends Action,
+  AIn extends Action,
+  AOut = AIn,
   Cms extends [StoreMutatorIdentifier, unknown][] = []
 >(
-  reducer: (state: T, action: A) => T,
+  reducer: (state: T, action: AIn) => T,
   initialState: T
-) => StateCreator<Write<T, ReduxState<A>>, Cms, [['zustand/redux', A]]>
+) => StateCreator<
+  Write<T, ReduxState<AIn, AOut>>,
+  Cms,
+  [['zustand/redux', [AIn, AOut]]]
+>
 
 declare module '../vanilla' {
   interface StoreMutators<S, A> {
@@ -88,10 +44,10 @@ type PopArgument<T extends (...a: never[]) => unknown> = T extends (
   ? (...a: A) => R
   : never
 
-type ReduxImpl = <T, A extends Action>(
-  reducer: (state: T, action: A) => T,
+type ReduxImpl = <T, AIn extends Action, AOut = AIn>(
+  reducer: (state: T, action: AIn) => T,
   initialState: T
-) => PopArgument<StateCreator<T & ReduxState<A>, [], []>>
+) => PopArgument<StateCreator<T & ReduxState<AIn, AOut>, [], []>>
 
 const reduxImpl: ReduxImpl = (reducer, initial) => (set, _get, api) => {
   type S = typeof initial

--- a/src/middleware/redux.ts
+++ b/src/middleware/redux.ts
@@ -5,32 +5,25 @@ type Write<T, U> = Omit<T, keyof U> & U
 
 type Action = { type: unknown }
 
-type StoreRedux<AIn, AOut> = {
-  dispatch: (a: AIn) => AOut
+type StoreRedux<A> = {
+  dispatch: (a: A) => A
   dispatchFromDevtools: true
 }
 
-type ReduxState<AIn, AOut> = {
-  dispatch: StoreRedux<AIn, AOut>['dispatch']
+type ReduxState<A> = {
+  dispatch: StoreRedux<A>['dispatch']
 }
 
-type WithRedux<S, A> = A extends [unknown, unknown]
-  ? Write<S, StoreRedux<A[0], A[1]>>
-  : never
+type WithRedux<S, A> = Write<S, StoreRedux<A>>
 
 type Redux = <
   T,
-  AIn extends Action,
-  AOut = AIn,
+  A extends Action,
   Cms extends [StoreMutatorIdentifier, unknown][] = []
 >(
-  reducer: (state: T, action: AIn) => T,
+  reducer: (state: T, action: A) => T,
   initialState: T
-) => StateCreator<
-  Write<T, ReduxState<AIn, AOut>>,
-  Cms,
-  [['zustand/redux', [AIn, AOut]]]
->
+) => StateCreator<Write<T, ReduxState<A>>, Cms, [['zustand/redux', A]]>
 
 declare module '../vanilla' {
   interface StoreMutators<S, A> {
@@ -44,10 +37,10 @@ type PopArgument<T extends (...a: never[]) => unknown> = T extends (
   ? (...a: A) => R
   : never
 
-type ReduxImpl = <T, AIn extends Action, AOut = AIn>(
-  reducer: (state: T, action: AIn) => T,
+type ReduxImpl = <T, A extends Action>(
+  reducer: (state: T, action: A) => T,
   initialState: T
-) => PopArgument<StateCreator<T & ReduxState<AIn, AOut>, [], []>>
+) => PopArgument<StateCreator<T & ReduxState<A>, [], []>>
 
 const reduxImpl: ReduxImpl = (reducer, initial) => (set, _get, api) => {
   type S = typeof initial

--- a/src/middleware/redux.ts
+++ b/src/middleware/redux.ts
@@ -3,27 +3,44 @@ import type { NamedSet } from './devtools'
 
 type Write<T, U> = Omit<T, keyof U> & U
 
-type Action = { type: unknown }
+type LitObjAction = {
+  type: unknown
+} & Partial<{ [key: string]: unknown }>
+type TupleAction = [unknown, unknown?]
+type Action = LitObjAction | TupleAction
+type Tupleize<T> = T extends LitObjAction
+  ? [T]
+  : T extends TupleAction
+  ? T
+  : never
 
-type StoreRedux<A> = {
-  dispatch: (a: A) => A
+type StoreRedux<AIn, AOut> = {
+  dispatch: (...a: Tupleize<AIn>) => AOut
+
   dispatchFromDevtools: true
 }
 
-type ReduxState<A> = {
-  dispatch: StoreRedux<A>['dispatch']
+type ReduxState<AIn, AOut> = {
+  dispatch: StoreRedux<AIn, AOut>['dispatch']
 }
 
-type WithRedux<S, A> = Write<S, StoreRedux<A>>
+type WithRedux<S, A> = A extends [unknown, unknown]
+  ? Write<S, StoreRedux<A[0], A[1]>>
+  : never
 
 type Redux = <
   T,
-  A extends Action,
+  AIn extends Action,
+  AOut = AIn,
   Cms extends [StoreMutatorIdentifier, unknown][] = []
 >(
-  reducer: (state: T, action: A) => T,
+  reducer: (state: T, action: Required<AIn>) => T,
   initialState: T
-) => StateCreator<Write<T, ReduxState<A>>, Cms, [['zustand/redux', A]]>
+) => StateCreator<
+  Write<T, ReduxState<AIn, AOut>>,
+  Cms,
+  [['zustand/redux', [AIn, AOut]]]
+>
 
 declare module '../vanilla' {
   interface StoreMutators<S, A> {
@@ -37,20 +54,36 @@ type PopArgument<T extends (...a: never[]) => unknown> = T extends (
   ? (...a: A) => R
   : never
 
-type ReduxImpl = <T, A extends Action>(
-  reducer: (state: T, action: A) => T,
+type ReduxImpl = <T, AIn extends Action, AOut = AIn>(
+  reducer: (state: T, action: Required<AIn>) => T,
   initialState: T
-) => PopArgument<StateCreator<T & ReduxState<A>, [], []>>
+) => PopArgument<StateCreator<T & ReduxState<AIn, AOut>, [], []>>
 
 const reduxImpl: ReduxImpl = (reducer, initial) => (set, _get, api) => {
   type S = typeof initial
-  type A = Parameters<typeof reducer>[1]
-  ;(api as any).dispatch = (action: A) => {
-    ;(set as NamedSet<S>)((state: S) => reducer(state, action), false, action)
-    return action
+  ;(api as any).dispatch = <A>(...action: Tupleize<A>) => {
+    let actionOut: any = action
+
+    const isLitObjAction = (arg: any): arg is [LitObjAction] =>
+      Array.isArray(arg) && arg.length === 1 && arg[0] instanceof Object
+
+    if (isLitObjAction(action)) {
+      actionOut = action.pop()
+    }
+
+    ;(set as NamedSet<S>)(
+      (state: S) => reducer(state, actionOut),
+      false,
+      actionOut
+    )
+
+    return actionOut
   }
   ;(api as any).dispatchFromDevtools = true
 
-  return { dispatch: (...a) => (api as any).dispatch(...a), ...initial }
+  return {
+    dispatch: <A>(...a: Tupleize<A>) => (api as any).dispatch(...a),
+    ...initial,
+  }
 }
 export const redux = reduxImpl as Redux

--- a/src/middleware/redux.ts
+++ b/src/middleware/redux.ts
@@ -12,11 +12,12 @@ type UnionToIntersection<U> =
     ? I
     : never;
 
-type PayloadOptionalIfUndefined<TA> = TA extends ActionTypes<infer A>
-  ? A extends { type: infer T; payload: undefined }
-    ? { type: T; payload?: undefined }
-    : TA
-  : TA
+type PayloadOptionalIfUndefined<A> = A extends {
+  type: infer T
+  payload: undefined
+}
+  ? { type: T; payload?: undefined }
+  : A
 
 type ActionsIndex<
   Type extends FeatureEventMap,
@@ -54,10 +55,8 @@ type Write<T, U> = Omit<T, keyof U> & U
 
 type Action = { type: unknown }
 
-type ActionTypes<A> = A extends ReduxAction<infer T> ? ReduxAction<T> : A
-
 type StoreRedux<A> = {
-  dispatch: (a: PayloadOptionalIfUndefined<ActionTypes<A>>) => ActionTypes<A>
+  dispatch: (a: PayloadOptionalIfUndefined<A>) => A
 
   dispatchFromDevtools: true
 }
@@ -73,7 +72,7 @@ type Redux = <
   A extends Action,
   Cms extends [StoreMutatorIdentifier, unknown][] = []
 >(
-  reducer: (state: T, action: ActionTypes<A>) => T,
+  reducer: (state: T, action: A) => T,
   initialState: T
 ) => StateCreator<Write<T, ReduxState<A>>, Cms, [['zustand/redux', A]]>
 
@@ -90,7 +89,7 @@ type PopArgument<T extends (...a: never[]) => unknown> = T extends (
   : never
 
 type ReduxImpl = <T, A extends Action>(
-  reducer: (state: T, action: ActionTypes<A>) => T,
+  reducer: (state: T, action: A) => T,
   initialState: T
 ) => PopArgument<StateCreator<T & ReduxState<A>, [], []>>
 

--- a/tests/middlewareTypes.test.tsx
+++ b/tests/middlewareTypes.test.tsx
@@ -138,6 +138,9 @@ describe('counter state spec (single middleware)', () => {
       })
 
       useBoundStore.dispatch({ type: 'grumpiness/reset' })
+
+      // if desired, it still works the same as the line above
+      useBoundStore.dispatch({ type: 'grumpiness/reset', payload: undefined })
     }
     TestComponent
   })

--- a/tests/middlewareTypes.test.tsx
+++ b/tests/middlewareTypes.test.tsx
@@ -154,8 +154,7 @@ describe('counter state spec (single middleware)', () => {
     const useBoundStore = create(
       redux<
         State,
-        PayloadOptionalIfUndefined<ReduxAction<FeatureEventActions>>,
-        ReduxAction<FeatureEventActions>
+        PayloadOptionalIfUndefined<ReduxAction<FeatureEventActions>>
       >(
         // @ts-expect-error incorrect payload type for the 'grumpiness/reset' case.
         (state: State, { type, payload }: ReduxAction<FeatureEventActions>) => {

--- a/tests/middlewareTypes.test.tsx
+++ b/tests/middlewareTypes.test.tsx
@@ -108,7 +108,7 @@ describe('counter state spec (single middleware)', () => {
     }
 
     const useBoundStore = create(
-      redux<State, ReduxAction<FeatureEventActions>>(
+      redux(
         // @ts-expect-error incorrect payload type for the 'grumpiness/reset' case.
         (state: State, { type, payload }: ReduxAction<FeatureEventActions>) => {
           switch (type) {


### PR DESCRIPTION
This PR introduces one exported TypeScript type (`ReduxAction`) that developers can use for using redux middleware. It requires one type parameter in the same shape as `FeatureEventActions`.

As mentioned in the modified doc of this PR:

"By leveraging typings as above eliminates the need to use any type assertions in reducers. It also enforces only valid values for properties of `action` objects that can increase productivity by eliminating mistakes by any developer."  

## Summary

It would be redundant to have a summary here since the modified doc and test files can be read clearly. At least I believe so.

## Check List

- [X] `yarn run prettier` for formatting code and docs
