### PR TITLE
Update slices pattern links in readme and flux guide

### DIFF
--- a/docs/guides/flux-inspired-practice.md
+++ b/docs/guides/flux-inspired-practice.md
@@ -19,7 +19,7 @@ const useBoundStore = create((set) => ({
 }))
 ```
 
-See [Splitting the store into separate slices](./typescript.md#slices-pattern) for how to define a store with separate slices.
+See [Splitting the store into separate slices](./slices-pattern.md) for how to define a store with separate slices.
 
 ## Flux like patterns / "dispatching" actions
 

--- a/readme.md
+++ b/readme.md
@@ -496,7 +496,7 @@ A more complete TypeScript guide is [here](docs/guides/typescript.md).
 
 ## Best practices
 
-- You may wonder how to organize your code for better maintenance: [Splitting the store into separate slices](./docs/guides/typescript.md#slices-pattern).
+- You may wonder how to organize your code for better maintenance: [Splitting the store into separate slices](./docs/guides/slices-pattern.md).
 - Recommended usage for this unopinionated library: [Flux inspired practice](./docs/guides/flux-inspired-practice.md).
 - [Calling actions outside a React event handler in pre React 18](./docs/guides/event-handler-in-pre-react-18.md).
 - [Testing](./docs/guides/testing.mdx)


### PR DESCRIPTION
Link readme and flux guide to the dedicated slices pattern guide instead of the slices pattern section from typescript guide, now that #1344 is in.

Readme and flux guide were the only documents linking to the typescript section, so all links that needed updating and updated with this PR.