### PR TITLE
fix(types): assume `getState` and `setState` will always exist on the store

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -26,8 +26,8 @@ export type StateCreator<
   Mos extends [StoreMutatorIdentifier, unknown][] = [],
   U = T
 > = ((
-  setState: Get<Mutate<StoreApi<T>, Mis>, 'setState', undefined>,
-  getState: Get<Mutate<StoreApi<T>, Mis>, 'getState', undefined>,
+  setState: Get<Mutate<StoreApi<T>, Mis>, 'setState', never>,
+  getState: Get<Mutate<StoreApi<T>, Mis>, 'getState', never>,
   store: Mutate<StoreApi<T>, Mis>,
   $$storeMutations: Mis
 ) => U) & { $$storeMutators?: Mos }

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -12,7 +12,7 @@ export interface StoreApi<T> {
   destroy: () => void
 }
 
-type Get<T, K, F = never> = K extends keyof T ? T[K] : F
+type Get<T, K, F> = K extends keyof T ? T[K] : F
 
 export type Mutate<S, Ms> = Ms extends []
   ? S

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -1,4 +1,5 @@
-import create, { StateCreator, StoreApi, UseBoundStore } from 'zustand'
+import create, { StateCreator, StoreApi, StoreMutatorIdentifier, UseBoundStore } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 it('can use exposed types', () => {
   type ExampleState = {
@@ -187,4 +188,21 @@ it('state is covariant', () => {
     foo: string
     baz: string
   }> = store
+})
+
+it("StateCreator<T, [StoreMutatorIdentfier, unknown][]> is StateCreator<T, []>", () => {
+  interface State
+    { count: number
+    , increment: () => void
+    }
+
+  const foo: <M extends [StoreMutatorIdentifier, unknown][]>() => StateCreator<State, M> =
+    () => (set, get) => ({
+      count: 0,
+      increment: () => {
+        set({ count: get().count + 1 })
+      }
+    })
+
+  create<State>()(persist(foo()))
 })

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -1,4 +1,9 @@
-import create, { StateCreator, StoreApi, StoreMutatorIdentifier, UseBoundStore } from 'zustand'
+import create, {
+  StateCreator,
+  StoreApi,
+  StoreMutatorIdentifier,
+  UseBoundStore,
+} from 'zustand'
 import { persist } from 'zustand/middleware'
 
 it('can use exposed types', () => {
@@ -190,19 +195,21 @@ it('state is covariant', () => {
   }> = store
 })
 
-it("StateCreator<T, [StoreMutatorIdentfier, unknown][]> is StateCreator<T, []>", () => {
-  interface State
-    { count: number
-    , increment: () => void
-    }
+it('StateCreator<T, [StoreMutatorIdentfier, unknown][]> is StateCreator<T, []>', () => {
+  interface State {
+    count: number
+    increment: () => void
+  }
 
-  const foo: <M extends [StoreMutatorIdentifier, unknown][]>() => StateCreator<State, M> =
-    () => (set, get) => ({
-      count: 0,
-      increment: () => {
-        set({ count: get().count + 1 })
-      }
-    })
+  const foo: <M extends [StoreMutatorIdentifier, unknown][]>() => StateCreator<
+    State,
+    M
+  > = () => (set, get) => ({
+    count: 0,
+    increment: () => {
+      set({ count: get().count + 1 })
+    },
+  })
 
   create<State>()(persist(foo()))
 })


### PR DESCRIPTION
Fixes #1368. Implements the option 2 mentioned in the issue.