### PR TITLE
types: add `UnknownBecauseOfGenericMutators`

### DIFF
--- a/src/middleware/redux.ts
+++ b/src/middleware/redux.ts
@@ -53,4 +53,4 @@ const reduxImpl: ReduxImpl = (reducer, initial) => (set, _get, api) => {
 
   return { dispatch: (...a) => (api as any).dispatch(...a), ...initial }
 }
-export const redux = reduxImpl as Redux
+export const redux = reduxImpl as unknown as Redux

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -26,9 +26,9 @@ export type StateCreator<
   Mos extends [StoreMutatorIdentifier, unknown][] = [],
   U = T
 > = ((
-  setState: Get<Mutate<StoreApi<T>, Mis>, 'setState', undefined>,
-  getState: Get<Mutate<StoreApi<T>, Mis>, 'getState', undefined>,
-  store: Mutate<StoreApi<T>, Mis>,
+  setState: number extends Mis['length'] ? UnknownBecauseOfGenericMutators : Get<Mutate<StoreApi<T>, Mis>, 'setState', undefined>,
+  getState: number extends Mis['length'] ? UnknownBecauseOfGenericMutators : Get<Mutate<StoreApi<T>, Mis>, 'getState', undefined>,
+  store: number extends Mis['length'] ? UnknownBecauseOfGenericMutators : Mutate<StoreApi<T>, Mis>,
   $$storeMutations: Mis
 ) => U) & { $$storeMutators?: Mos }
 
@@ -45,6 +45,11 @@ type CreateStore = {
     initializer: StateCreator<T, [], Mos>
   ) => Mutate<StoreApi<T>, Mos>
 }
+
+/**
+ * TODO: write the jsdoc
+ */
+export interface UnknownBecauseOfGenericMutators {}
 
 type CreateStoreImpl = <
   T,

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -55,6 +55,7 @@ type CreateStore = {
 /**
  * TODO: write the jsdoc
  */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface UnknownBecauseOfGenericMutators {}
 
 type CreateStoreImpl = <

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -26,9 +26,15 @@ export type StateCreator<
   Mos extends [StoreMutatorIdentifier, unknown][] = [],
   U = T
 > = ((
-  setState: number extends Mis['length'] ? UnknownBecauseOfGenericMutators : Get<Mutate<StoreApi<T>, Mis>, 'setState', undefined>,
-  getState: number extends Mis['length'] ? UnknownBecauseOfGenericMutators : Get<Mutate<StoreApi<T>, Mis>, 'getState', undefined>,
-  store: number extends Mis['length'] ? UnknownBecauseOfGenericMutators : Mutate<StoreApi<T>, Mis>,
+  setState: number extends Mis['length']
+    ? UnknownBecauseOfGenericMutators
+    : Get<Mutate<StoreApi<T>, Mis>, 'setState', undefined>,
+  getState: number extends Mis['length']
+    ? UnknownBecauseOfGenericMutators
+    : Get<Mutate<StoreApi<T>, Mis>, 'getState', undefined>,
+  store: number extends Mis['length']
+    ? UnknownBecauseOfGenericMutators
+    : Mutate<StoreApi<T>, Mis>,
   $$storeMutations: Mis
 ) => U) & { $$storeMutators?: Mos }
 

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -1,4 +1,5 @@
-import create, { StateCreator, StoreApi, UseBoundStore } from 'zustand'
+import create, { StateCreator, StoreApi, StoreMutatorIdentifier, UseBoundStore } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 it('can use exposed types', () => {
   type ExampleState = {
@@ -187,4 +188,22 @@ it('state is covariant', () => {
     foo: string
     baz: string
   }> = store
+})
+
+it("Shows UnknownBecauseOfGenericMutators type when dealing with generic mutators", () => {
+  interface State
+    { count: number
+    , increment: () => void
+    }
+
+  const foo: <M extends [StoreMutatorIdentifier, unknown][]>() => StateCreator<State, M> =
+    () => (set, get) => ({
+      count: 0,
+      increment: () => {
+        // @ts-expect-errors
+        set({ count: get().count + 1 })
+      }
+    })
+
+  create<State>()(persist(foo()))
 })

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -1,4 +1,9 @@
-import create, { StateCreator, StoreApi, StoreMutatorIdentifier, UseBoundStore } from 'zustand'
+import create, {
+  StateCreator,
+  StoreApi,
+  StoreMutatorIdentifier,
+  UseBoundStore,
+} from 'zustand'
 import { persist } from 'zustand/middleware'
 
 it('can use exposed types', () => {
@@ -190,20 +195,22 @@ it('state is covariant', () => {
   }> = store
 })
 
-it("Shows UnknownBecauseOfGenericMutators type when dealing with generic mutators", () => {
-  interface State
-    { count: number
-    , increment: () => void
-    }
+it('Shows UnknownBecauseOfGenericMutators type when dealing with generic mutators', () => {
+  interface State {
+    count: number
+    increment: () => void
+  }
 
-  const foo: <M extends [StoreMutatorIdentifier, unknown][]>() => StateCreator<State, M> =
-    () => (set, get) => ({
-      count: 0,
-      increment: () => {
-        // @ts-expect-errors
-        set({ count: get().count + 1 })
-      }
-    })
+  const foo: <M extends [StoreMutatorIdentifier, unknown][]>() => StateCreator<
+    State,
+    M
+  > = () => (set, get) => ({
+    count: 0,
+    increment: () => {
+      // @ts-expect-errors
+      set({ count: get().count + 1 })
+    },
+  })
 
   create<State>()(persist(foo()))
 })

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -207,7 +207,7 @@ it('Shows UnknownBecauseOfGenericMutators type when dealing with generic mutator
   > = () => (set, get) => ({
     count: 0,
     increment: () => {
-      // @ts-expect-errors
+      // @ts-expect-error set and get are essentially unknown
       set({ count: get().count + 1 })
     },
   })


### PR DESCRIPTION
Closes #1368. Implements the option 1 mentioned in the issue.