### PR TITLE
fix(types): fix `StateCreator` subtyping

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -246,9 +246,9 @@ type Logger = <
 ) => StateCreator<T, Mps, Mcs>
 
 type LoggerImpl = <T extends State>(
-  f: PopArgument<StateCreator<T, [], []>>,
+  f: StateCreator<T, [], []>,
   name?: string
-) => PopArgument<StateCreator<T, [], []>>
+) => StateCreator<T, [], []>
 
 const loggerImpl: LoggerImpl = (f, name) => (set, get, store) => {
   type T = ReturnType<typeof f>
@@ -262,12 +262,6 @@ const loggerImpl: LoggerImpl = (f, name) => (set, get, store) => {
 }
 
 export const logger = loggerImpl as unknown as Logger
-
-type PopArgument<T extends (...a: never[]) => unknown> = T extends (
-  ...a: [...infer A, infer _]
-) => infer R
-  ? (...a: A) => R
-  : never
 
 // ---
 
@@ -310,9 +304,9 @@ declare module 'zustand' {
 }
 
 type FooImpl = <T extends State, A>(
-  f: PopArgument<StateCreator<T, [], []>>,
+  f: StateCreator<T, [], []>,
   bar: A
-) => PopArgument<StateCreator<T, [], []>>
+) => StateCreator<T, [], []>
 
 const fooImpl: FooImpl = (f, bar) => (set, get, _store) => {
   type T = ReturnType<typeof f>
@@ -324,12 +318,6 @@ const fooImpl: FooImpl = (f, bar) => (set, get, _store) => {
 }
 
 export const foo = fooImpl as unknown as Foo
-
-type PopArgument<T extends (...a: never[]) => unknown> = T extends (
-  ...a: [...infer A, infer _]
-) => infer R
-  ? (...a: A) => R
-  : never
 
 type Write<T extends object, U extends object> = Omit<T, keyof U> & U
 

--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -141,15 +141,9 @@ declare module '../vanilla' {
 }
 
 type DevtoolsImpl = <T>(
-  storeInitializer: PopArgument<StateCreator<T, [], []>>,
+  storeInitializer: StateCreator<T, [], []>,
   devtoolsOptions?: DevtoolsOptions
-) => PopArgument<StateCreator<T, [], []>>
-
-type PopArgument<T extends (...a: never[]) => unknown> = T extends (
-  ...a: [...infer A, infer _]
-) => infer R
-  ? (...a: A) => R
-  : never
+) => StateCreator<T, [], []>
 
 export type NamedSet<T> = WithDevtools<StoreApi<T>>['setState']
 

--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -49,15 +49,9 @@ type StoreImmer<S> = S extends {
     : never
   : never
 
-type PopArgument<T extends (...a: never[]) => unknown> = T extends (
-  ...a: [...infer A, infer _]
-) => infer R
-  ? (...a: A) => R
-  : never
-
 type ImmerImpl = <T>(
-  storeInitializer: PopArgument<StateCreator<T, [], []>>
-) => PopArgument<StateCreator<T, [], []>>
+  storeInitializer: StateCreator<T, [], []>
+) => StateCreator<T, [], []>
 
 const immerImpl: ImmerImpl = (initializer) => (set, get, store) => {
   type T = ReturnType<typeof initializer>

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -319,14 +319,8 @@ type WithPersist<S, A> = S extends { getState: () => infer T }
   : never
 
 type PersistImpl = <T>(
-  storeInitializer: PopArgument<StateCreator<T, [], []>>,
+  storeInitializer: StateCreator<T, [], []>,
   options: PersistOptions<T, T>
-) => PopArgument<StateCreator<T, [], []>>
-
-type PopArgument<T extends (...a: never[]) => unknown> = T extends (
-  ...a: [...infer A, infer _]
-) => infer R
-  ? (...a: A) => R
-  : never
+) => StateCreator<T, [], []>
 
 export const persist = persistImpl as unknown as Persist

--- a/src/middleware/redux.ts
+++ b/src/middleware/redux.ts
@@ -31,16 +31,10 @@ declare module '../vanilla' {
   }
 }
 
-type PopArgument<T extends (...a: never[]) => unknown> = T extends (
-  ...a: [...infer A, infer _]
-) => infer R
-  ? (...a: A) => R
-  : never
-
 type ReduxImpl = <T, A extends Action>(
   reducer: (state: T, action: A) => T,
   initialState: T
-) => PopArgument<StateCreator<T & ReduxState<A>, [], []>>
+) => StateCreator<T & ReduxState<A>, [], []>
 
 const reduxImpl: ReduxImpl = (reducer, initial) => (set, _get, api) => {
   type S = typeof initial
@@ -53,4 +47,4 @@ const reduxImpl: ReduxImpl = (reducer, initial) => (set, _get, api) => {
 
   return { dispatch: (...a) => (api as any).dispatch(...a), ...initial }
 }
-export const redux = reduxImpl as Redux
+export const redux = reduxImpl as unknown as Redux

--- a/src/middleware/subscribeWithSelector.ts
+++ b/src/middleware/subscribeWithSelector.ts
@@ -40,14 +40,8 @@ type StoreSubscribeWithSelector<T> = {
 }
 
 type SubscribeWithSelectorImpl = <T extends object>(
-  storeInitializer: PopArgument<StateCreator<T, [], []>>
-) => PopArgument<StateCreator<T, [], []>>
-
-type PopArgument<T extends (...a: never[]) => unknown> = T extends (
-  ...a: [...infer A, infer _]
-) => infer R
-  ? (...a: A) => R
-  : never
+  storeInitializer: StateCreator<T, [], []>
+) => StateCreator<T, [], []>
 
 const subscribeWithSelectorImpl: SubscribeWithSelectorImpl =
   (fn) => (set, get, api) => {

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -30,8 +30,7 @@ export type StateCreator<
 > = ((
   setState: Get<Mutate<StoreApi<T>, Mis>, 'setState', undefined>,
   getState: Get<Mutate<StoreApi<T>, Mis>, 'getState', undefined>,
-  store: Mutate<StoreApi<T>, Mis>,
-  $$storeMutations: Mis
+  store: Mutate<StoreApi<T>, Mis>
 ) => U) & { $$storeMutators?: Mos }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-interface
@@ -54,12 +53,6 @@ type CreateStoreImpl = <
 >(
   initializer: StateCreator<T, [], Mos>
 ) => Mutate<StoreApi<T>, Mos>
-
-type PopArgument<T extends (...a: never[]) => unknown> = T extends (
-  ...a: [...infer A, infer _]
-) => infer R
-  ? (...a: A) => R
-  : never
 
 const createStoreImpl: CreateStoreImpl = (createState) => {
   type TState = ReturnType<typeof createState>
@@ -94,11 +87,7 @@ const createStoreImpl: CreateStoreImpl = (createState) => {
 
   const destroy: () => void = () => listeners.clear()
   const api = { setState, getState, subscribe, destroy }
-  state = (createState as PopArgument<typeof createState>)(
-    setState,
-    getState,
-    api
-  )
+  state = createState(setState, getState, api)
   return api as any
 }
 

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -1,4 +1,5 @@
 import create, { StateCreator, StoreApi, UseBoundStore } from 'zustand'
+import { persist } from 'zustand/middleware'
 
 it('can use exposed types', () => {
   type ExampleState = {
@@ -187,4 +188,23 @@ it('state is covariant', () => {
     foo: string
     baz: string
   }> = store
+})
+
+it('StateCreator subtyping', () => {
+  interface State {
+    count: number
+    increment: () => void
+  }
+
+  const foo: () => StateCreator<State, []> = () => (set, get) => ({
+    count: 0,
+    increment: () => {
+      set({ count: get().count + 1 })
+    },
+  })
+
+  create<State>()(persist(foo()))
+
+  const _testSubtyping: StateCreator<State, [['zustand/persist', unknown]]> =
+    {} as StateCreator<State, []>
 })

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -1,4 +1,5 @@
-import create, {
+import create from 'zustand'
+import type {
   StateCreator,
   StoreApi,
   StoreMutatorIdentifier,


### PR DESCRIPTION
I originally had the phantom type because I assumed it would be required. I'm still a little skeptic about this change but just want to expermiment and see the CI results hence opening the PR.

This PR's branch is based on #1372's branch. Note that this does not require the change in #1372, but has it as base because if we're going with #1371 this PR would probably be much less useful.