### PR TITLE
Persisting store doc href hash fixes and tweaks

### DIFF
--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -409,7 +409,7 @@ Why does it matter?
 Asynchronous hydration can cause some unexpected behaviors.
 For instance, if you use Zustand in a React app, the store will _not_ be hydrated at the initial render. In cases where you app depends on the persisted value at page load, you might want to wait until the store has been hydrated before showing anything (e.g. your app might think the user is not logged in because it's the default, while in reality the store has not been hydrated yet).
 
-If your app does depends on the persisted state at page load, see [How can I check if my store has been hydrated?](#how-can-i-check-if-my-store-has-been-hydrated?) in the Q/A.
+If your app does depends on the persisted state at page load, see **_How can I check if my store has been hydrated?_** in the Q/A section.
 
 ## Q/A
 

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -28,8 +28,6 @@ export const useFishStore = create(
 )
 ```
 
-See [Options](#options) for more details.
-
 ## Options
 
 ### `name`
@@ -206,8 +204,7 @@ export const useBoundStore = create(
 
 If you want to introduce a breaking change in your storage (e.g. renaming a field), you can specify a new version number.
 By default, if the version in the storage does not match the version in the code, the stored value won't be used.
-
-See the `migrate` option below for more details about handling breaking changes.
+You can use the `migrate` option to handle breaking changes in order to persist previously stored data.
 
 ### `migrate`
 

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -6,7 +6,7 @@ nav: 17
 The persist middleware enables you to store your Zustand state in a storage (e.g. `localStorage`, `AsyncStorage`, `IndexedDB`, etc...) thus persisting it's data.
 
 Note that this middleware does support both synchronous storages (e.g. `localStorage`) and asynchronous storages (e.g. `AsyncStorage`), but using an asynchronous storage does come with a cost.
-See [Hydration and asynchronous storages](#Hydration-and-asynchronous-storages) for more details.
+See [Hydration and asynchronous storages](#hydration-and-asynchronous-storages) for more details.
 
 Quick example:
 
@@ -28,7 +28,7 @@ export const useFishStore = create(
 )
 ```
 
-See [Options](#Options) for more details.
+See [Options](#options) for more details.
 
 ## Options
 
@@ -412,7 +412,7 @@ Why does it matter?
 Asynchronous hydration can cause some unexpected behaviors.
 For instance, if you use Zustand in a React app, the store will _not_ be hydrated at the initial render. In cases where you app depends on the persisted value at page load, you might want to wait until the store has been hydrated before showing anything (e.g. your app might think the user is not logged in because it's the default, while in reality the store has not been hydrated yet).
 
-If your app does depends on the persisted state at page load, see [How can I check if my store has been hydrated?](#how-can-I-check-if-my-store-has-been-hydrated) in the Q/A.
+If your app does depends on the persisted state at page load, see [How can I check if my store has been hydrated?](#how-can-i-check-if-my-store-has-been-hydrated?) in the Q/A.
 
 ## Q/A
 


### PR DESCRIPTION
## Related Issues

Issue not created, but the problem can be replicated by visiting https://docs.pmnd.rs/zustand/integrations/persisting-store-data, then clicking on the "Hydration and asynchronous storages" link in the second paragraph.

## Summary
#### Main fix
Make section hash hrefs all lowercase so in-page links work properly on Persisting Store page. The problem likely stemmed from porting Github's implementation of markdown, which is capitalization agnostic about URL hashes, to the new docs framework.

#### Secondary enhancements
- Remove a "see below for more details" link that is linked to the next section.
- Add additional context to a different "see below" statement.



## Check List

- [x] `yarn run prettier` for formatting code and docs
