### PR TITLE
docs: fix error usage in typescript at persist

### DIFF
--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -544,7 +544,7 @@ withStorageDOMEvents(useBoundStore)
 
 ### How do I use with TypeScript?
 
-Basic typescript usage doesn't require anything special except for writing `create<State>()(...)` instead of `create(...)`.
+Basic typescript usage require define middleware and state like below.
 
 ```tsx
 import create from 'zustand'
@@ -555,7 +555,10 @@ interface MyState {
   addAFish: () => void
 }
 
-export const useFishStore = create<MyState>()(
+export const useFishStore = create<
+  MyState,
+  [['zustand/persist', Pick<MyState, 'fishes'>]]
+>()(
   persist(
     (set, get) => ({
       fishes: 0,

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -544,7 +544,7 @@ withStorageDOMEvents(useBoundStore)
 
 ### How do I use with TypeScript?
 
-Basic typescript usage require define middleware and state like below.
+To use the persist middleware with TypeScript, you should describe both the shape of your store as well as each middleware being introduced. `create` accepts two generics parameters. Refer to the example below.
 
 ```tsx
 import create from 'zustand'


### PR DESCRIPTION
## Summary

in my real usage, we must define it with `zustand/persist` and storage state type


## Check List

- [x] `yarn run prettier` for formatting code and docs
