### PR TITLE
docs/recipes: persist example should reference 'fishes', not 'fish'

### DIFF
--- a/docs/recipes/recipes.mdx
+++ b/docs/recipes/recipes.mdx
@@ -316,7 +316,7 @@ export const useStore = create(
   persist(
     (set, get) => ({
       fishes: 0,
-      addAFish: () => set({ fish: get().fish + 1 }),
+      addAFish: () => set({ fishes: get().fishes + 1 }),
     }),
     {
       name: 'food-storage', // unique name


### PR DESCRIPTION
## Summary

In the 'Persist middleware' example, there is no `fish` property; it should be `fishes`.

## Check List

- [x] `yarn run prettier` for formatting code and docs
