### PR TITLE
fix(middleware/devtools): do not use optional catch binding syntax

### DIFF
--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -160,7 +160,7 @@ const devtoolsImpl: DevtoolsImpl =
     try {
       extensionConnector =
         (enabled ?? __DEV__) && window.__REDUX_DEVTOOLS_EXTENSION__
-    } catch {
+    } catch (e) {
       // ignored
     }
 


### PR DESCRIPTION
## Related Issues

Fixes #1427.

## Summary

Remove optional catch binding syntax usage in devtools.ts, since it's the only one place it has been used and it is not transpilled correctly to backward compatible syntax.

## Check List

- [x] `yarn run prettier` for formatting code and docs
