### PR TITLE
feat(shallow): Add support of Maps and Sets to shallow comparator

### DIFF
--- a/src/shallow.ts
+++ b/src/shallow.ts
@@ -15,7 +15,7 @@ function shallow<T>(objA: T, objB: T) {
     if (objA.size !== objB.size) return false
 
     for (const [key, value] of objA) {
-      if (value !== objB.get(key)) {
+      if (!Object.is(value, objB.get(key))) {
         return false
       }
     }

--- a/src/shallow.ts
+++ b/src/shallow.ts
@@ -10,6 +10,29 @@ function shallow<T>(objA: T, objB: T) {
   ) {
     return false
   }
+
+  if (objA instanceof Map && objB instanceof Map) {
+    if (objA.size !== objB.size) return false
+
+    for (const [key, value] of objA) {
+      if (value !== objB.get(key)) {
+        return false
+      }
+    }
+    return true
+  }
+
+  if (objA instanceof Set && objB instanceof Set) {
+    if (objA.size !== objB.size) return false
+
+    for (const value of objA) {
+      if (!objB.has(value)) {
+        return false
+      }
+    }
+    return true
+  }
+
   const keysA = Object.keys(objA)
   if (keysA.length !== Object.keys(objB).length) {
     return false

--- a/tests/shallow.test.tsx
+++ b/tests/shallow.test.tsx
@@ -39,6 +39,43 @@ describe('shallow', () => {
     expect(shallow([{ foo: 'bar' }], [{ foo: 'bar', asd: 123 }])).toBe(false)
   })
 
+  it('compares Maps', () => {
+    function createMap<T extends object>(obj: T) {
+      return new Map(Object.entries(obj))
+    }
+
+    expect(
+      shallow(
+        createMap({ foo: 'bar', asd: 123 }),
+        createMap({ foo: 'bar', asd: 123 })
+      )
+    ).toBe(true)
+
+    expect(
+      shallow(
+        createMap({ foo: 'bar', asd: 123 }),
+        createMap({ foo: 'bar', foobar: true })
+      )
+    ).toBe(false)
+
+    expect(
+      shallow(
+        createMap({ foo: 'bar', asd: 123 }),
+        createMap({ foo: 'bar', asd: 123, foobar: true })
+      )
+    ).toBe(false)
+  })
+
+  it('compares Sets', () => {
+    expect(shallow(new Set(['bar', 123]), new Set(['bar', 123]))).toBe(true)
+
+    expect(shallow(new Set(['bar', 123]), new Set(['bar', 2]))).toBe(false)
+
+    expect(shallow(new Set(['bar', 123]), new Set(['bar', 123, true]))).toBe(
+      false
+    )
+  })
+
   it('compares functions', () => {
     function firstFnCompare() {
       return { foo: 'bar' }


### PR DESCRIPTION
## Summary
Zustand allows storing Maps and Sets, however, the `shallow` comparator returns incorrect comparison results for these type.
This PR adds support for shallow comparison of ES6 `Map` and `Set`


## Check List

- [x] `yarn run prettier` for formatting code and docs
