### PR TITLE
Fix: Programmatic `module.exports` addition for named and default exports in CJS

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -75,12 +75,15 @@ function createESMConfig(input, output) {
   }
 }
 
-function createCommonJSConfig(input, output, options = {}) {
-  const config = {
+function createCommonJSConfig(input, output, options) {
+  return {
     input,
     output: {
       file: `${output}.js`,
       format: 'cjs',
+      outro: options.addModuleExport
+        ? 'module.exports = exports.default; Object.assign(exports.default, exports)'
+        : '',
     },
     external,
     plugins: [
@@ -97,12 +100,6 @@ function createCommonJSConfig(input, output, options = {}) {
       babelPlugin(getBabelOptions({ ie: 11 })),
     ],
   }
-  if (options.addModuleExport) {
-    config.output.outro =
-      'module.exports = exports.default; Object.assign(exports.default,exports)'
-  }
-
-  return config
 }
 
 function createUMDConfig(input, output, env) {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -82,7 +82,7 @@ function createCommonJSConfig(input, output, options) {
       file: `${output}.js`,
       format: 'cjs',
       outro: options.addModuleExport
-        ? 'module.exports = exports.default; Object.assign(exports.default, exports)'
+        ? 'module.exports = exports.default; Object.assign(exports.default, exports);'
         : '',
     },
     external,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -75,10 +75,13 @@ function createESMConfig(input, output) {
   }
 }
 
-function createCommonJSConfig(input, output) {
-  return {
+function createCommonJSConfig(input, output, options = {}) {
+  const config = {
     input,
-    output: { file: `${output}.js`, format: 'cjs' },
+    output: {
+      file: `${output}.js`,
+      format: 'cjs',
+    },
     external,
     plugins: [
       alias({
@@ -94,6 +97,12 @@ function createCommonJSConfig(input, output) {
       babelPlugin(getBabelOptions({ ie: 11 })),
     ],
   }
+  if (options.addModuleExport) {
+    config.output.outro =
+      'module.exports = exports.default; Object.assign(exports.default,exports)'
+  }
+
+  return config
 }
 
 function createUMDConfig(input, output, env) {
@@ -166,7 +175,9 @@ module.exports = function (args) {
   }
   return [
     ...(c === 'index' ? [createDeclarationConfig(`src/${c}.ts`, 'dist')] : []),
-    createCommonJSConfig(`src/${c}.ts`, `dist/${c}`),
+    createCommonJSConfig(`src/${c}.ts`, `dist/${c}`, {
+      addModuleExport: c === 'index',
+    }),
     createESMConfig(`src/${c}.ts`, `dist/esm/${c}.js`),
     createESMConfig(`src/${c}.ts`, `dist/esm/${c}.mjs`),
     createUMDConfig(`src/${c}.ts`, `dist/umd/${c}`, 'development'),


### PR DESCRIPTION
Patches the base index file to export the default as classic node cjs module

## Related Issues

Fixes #559 

## Summary



## Check List

- [x] `yarn run prettier` for formatting code and docs
