### PR TITLE
fix(docs): Add Slices pattern example

### DIFF
--- a/docs/guides/how-to-reset-state.md
+++ b/docs/guides/how-to-reset-state.md
@@ -74,6 +74,72 @@ export const resetAllSlices = () => {
 }
 ```
 
+Resetting bound store using Slices pettern
+
+```ts
+import create, { StateCreator } from "zustand";
+
+const resetters: (() => void)[] = [];
+
+// Bear slice
+const initialStateBear = { bears: 0 };
+
+interface BearSlice {
+  bears: number;
+  addBear: () => void;
+  eatFish: () => void;
+}
+
+const createBearSlice: StateCreator<
+  BearSlice & FishSlice,
+  [],
+  [],
+  BearSlice
+> = (set) => {
+  resetters.push(() => set(initialStateBear));
+  return {
+    ...initialStateBear,
+    addBear: () => set((state) => ({ bears: state.bears + 1 })),
+    eatFish: () => set((state) => ({ fishes: state.fishes - 1 })),
+  };
+};
+
+//Fish slice
+const initialStateFish = { fishes: 0 };
+
+interface FishSlice {
+  fishes: number;
+  addFish: () => void;
+}
+
+const createFishSlice: StateCreator<
+  BearSlice & FishSlice,
+  [],
+  [],
+  FishSlice
+> = (set) => {
+  resetters.push(() => set(initialStateFish));
+  return {
+    ...initialStateFish,
+    addFish: () => set((state) => ({ fishes: state.fishes + 1 })),
+  };
+};
+
+//Bound store
+const useBoundStore = create<BearSlice & FishSlice>()((...a) => ({
+  ...createBearSlice(...a),
+  ...createFishSlice(...a),
+}));
+
+export const resetAllSlices = () => {
+  for (const resetter of resetters) {
+    resetter();
+  }
+};
+
+export default useBoundStore;
+```
+
 ## CodeSandbox Demo
 
 - Basic: https://codesandbox.io/s/zustand-how-to-reset-state-basic-demo-rrqyon

--- a/docs/guides/how-to-reset-state.md
+++ b/docs/guides/how-to-reset-state.md
@@ -74,14 +74,13 @@ export const resetAllSlices = () => {
 }
 ```
 
-Resetting bound store using Slices pettern
+Resetting bound store using Slices pattern
 
 ```ts
 import create, { StateCreator } from "zustand";
 
 const resetters: (() => void)[] = [];
 
-// Bear slice
 const initialStateBear = { bears: 0 };
 
 interface BearSlice {
@@ -104,7 +103,7 @@ const createBearSlice: StateCreator<
   };
 };
 
-//Fish slice
+
 const initialStateFish = { fishes: 0 };
 
 interface FishSlice {
@@ -125,7 +124,6 @@ const createFishSlice: StateCreator<
   };
 };
 
-//Bound store
 const useBoundStore = create<BearSlice & FishSlice>()((...a) => ({
   ...createBearSlice(...a),
   ...createFishSlice(...a),

--- a/docs/guides/how-to-reset-state.md
+++ b/docs/guides/how-to-reset-state.md
@@ -77,16 +77,16 @@ export const resetAllSlices = () => {
 Resetting bound store using Slices pattern
 
 ```ts
-import create, { StateCreator } from "zustand";
+import create, { StateCreator } from 'zustand'
 
-const resetters: (() => void)[] = [];
+const resetters: (() => void)[] = []
 
-const initialStateBear = { bears: 0 };
+const initialBearState = { bears: 0 }
 
 interface BearSlice {
-  bears: number;
-  addBear: () => void;
-  eatFish: () => void;
+  bears: number
+  addBear: () => void
+  eatFish: () => void
 }
 
 const createBearSlice: StateCreator<
@@ -95,20 +95,19 @@ const createBearSlice: StateCreator<
   [],
   BearSlice
 > = (set) => {
-  resetters.push(() => set(initialStateBear));
+  resetters.push(() => set(initialBearState))
   return {
-    ...initialStateBear,
+    ...initialBearState,
     addBear: () => set((state) => ({ bears: state.bears + 1 })),
     eatFish: () => set((state) => ({ fishes: state.fishes - 1 })),
-  };
-};
+  }
+}
 
-
-const initialStateFish = { fishes: 0 };
+const initialStateFish = { fishes: 0 }
 
 interface FishSlice {
-  fishes: number;
-  addFish: () => void;
+  fishes: number
+  addFish: () => void
 }
 
 const createFishSlice: StateCreator<
@@ -117,25 +116,21 @@ const createFishSlice: StateCreator<
   [],
   FishSlice
 > = (set) => {
-  resetters.push(() => set(initialStateFish));
+  resetters.push(() => set(initialStateFish))
   return {
     ...initialStateFish,
     addFish: () => set((state) => ({ fishes: state.fishes + 1 })),
-  };
-};
+  }
+}
 
 const useBoundStore = create<BearSlice & FishSlice>()((...a) => ({
   ...createBearSlice(...a),
   ...createFishSlice(...a),
-}));
+}))
 
-export const resetAllSlices = () => {
-  for (const resetter of resetters) {
-    resetter();
-  }
-};
+export const resetAllSlices = () => resetters.forEach((resetter) => resetter())
 
-export default useBoundStore;
+export default useBoundStore
 ```
 
 ## CodeSandbox Demo


### PR DESCRIPTION
By ading this example we can combine the real Slices pattern implementation (instead of multiple stores) with the resetAll method.
Hope this helps! 😄

## Related Issues

Fixes #.

## Summary



## Check List

- [ ] `yarn run prettier` for formatting code and docs
