### PR TITLE
fix(build): disable esModule and re-export for nodejs

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -81,8 +81,9 @@ function createCommonJSConfig(input, output, options) {
     output: {
       file: `${output}.js`,
       format: 'cjs',
+      esModule: false,
       outro: options.addModuleExport
-        ? 'module.exports = exports.default; Object.assign(exports.default, exports);'
+        ? ';(module.exports = (exports && exports.default) || {}),\n  Object.assign(module.exports, exports)'
         : '',
     },
     external,


### PR DESCRIPTION
## Related Issues

Fixes #1475

## Summary

Patches the issue where exports.default might not get translated because of the `_esModule` property


## Check List

- [x] `yarn run prettier` for formatting code and docs


## Additional Notes 

Tested with 
- Parcel v2 
- Webpack (Current CRA) 
- All CSB Additions from the CI
