### PR TITLE
fix(docs): fix typo and redundant periods

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 [![Downloads](https://img.shields.io/npm/dt/zustand.svg?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/zustand)
 [![Discord Shield](https://img.shields.io/discord/740090768164651008?style=flat&colorA=000000&colorB=000000&label=discord&logo=discord&logoColor=ffffff)](https://discord.gg/poimandres)
 
-A small, fast and scalable bearbones state-management solution using simplified flux principles. Has a comfy api based on hooks, isn't boilerplatey or opinionated.
+A small, fast and scalable bearbones state-management solution using simplified flux principles. Has a comfy api based on hooks, isn't boilerplate or opinionated.
 
 Don't disregard it because it's cute. It has quite the claws, lots of time was spent to deal with common pitfalls, like the dreaded [zombie child problem](https://react-redux.js.org/api/hooks#stale-props-and-zombie-children), [react concurrency](https://github.com/bvaughn/rfcs/blob/useMutableSource/text/0000-use-mutable-source.md), and [context loss](https://github.com/facebook/react/issues/13332) between mixed renderers. It may be the one state-manager in the React space that gets all of these right.
 
@@ -466,7 +466,7 @@ const Component = () => {
 
 ## TypeScript Usage
 
-Basic typescript usage doesn't require anything special except for writing `create<State>()(...)` instead of `create(...)`...
+Basic typescript usage doesn't require anything special except for writing `create<State>()(...)` instead of `create(...)`.
 
 ```ts
 import create from 'zustand'


### PR DESCRIPTION
## Related Issues

Fixes #.

## Summary

- Correct boilerplatey -> boilerplate
- Remove redundant dots at the end line


## Check List

- [x] `yarn run prettier` for formatting code and docs
