### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -162,7 +162,9 @@ const useSoundStore = create((set, get) => ({
 Sometimes you need to access state in a non-reactive way, or act upon the store. For these cases the resulting hook has utility functions attached to its prototype.
 
 ```jsx
-const useDogStore = create(() => ({ paw: true, snout: true, fur: true }))
+import {createStore} from 'zustand
+
+const useDogStore = createStore(() => ({ paw: true, snout: true, fur: true }))
 
 // Getting non-reactive fresh state
 const paw = useDogStore.getState().paw


### PR DESCRIPTION
## Related Issues

Fixes #.

## Summary

The readme for using zustand store with vanillaJS needs a fix. To create the store you cannot use the create method cuz it will directly return the hook wich needs to be fired in react fn component ONLY. The doc should inform about the createStore method

## Check List

- [ ] `yarn run prettier` for formatting code and docs
