### PR TITLE
Revise v4 migrations doc page

### DIFF
--- a/docs/migrations/migrating-to-v4.md
+++ b/docs/migrations/migrating-to-v4.md
@@ -135,9 +135,16 @@ We're no longer using the trick to disallow `{ foo: undefined }`
 to be assigned to `Partial<{ foo: string }>`.
 Instead, we're relying on the users to turn on `exactOptionalPropertyTypes`.
 
-## `useStore` (from `zustand` and `zustand/react`)
+## `useStore`
 
-### Change
+**Applicable imports**
+
+```ts
+import { useStore } from 'zustand'
+import { useStore } from 'zustand/react'
+```
+
+**Change**
 
 ```diff
 - useStore:
@@ -157,9 +164,14 @@ Instead, we're relying on the users to turn on `exactOptionalPropertyTypes`.
 +       => StateSlice
 ```
 
-### Migration
+**Migration**
 
-If you're not passing any type parameters to `useStore` then there is no migration needed. If you are then it's recommended to remove them, or pass the store type instead of the state type as the first parameter.
+If you are not passing any type parameters to `useStore`,
+no migration is required.
+
+If you are,
+it's recommended to remove all the type parameters,
+or pass the **store** type instead of the **state** type as the first parameter.
 
 ## `UseBoundStore` (from `zustand` and `zustand/react`)
 

--- a/docs/migrations/migrating-to-v4.md
+++ b/docs/migrations/migrating-to-v4.md
@@ -233,7 +233,7 @@ Use `typeof MyContext.useStore` instead
 **Applicable imports**
 
 ```ts
-import { createContext } from 'zustand/context'
+import createContext from 'zustand/context'
 ```
 
 **Change**

--- a/docs/migrations/migrating-to-v4.md
+++ b/docs/migrations/migrating-to-v4.md
@@ -18,9 +18,18 @@ you can also check the
 [diff](https://github.com/pmndrs/zustand/compare/v3.7.2...v4.0.0?short_path=37e5b4c#diff-c21e24854115b390eccde717da83f91feb2d5927a76c1485e5f0fdd0135c2afa)
 of the test files in the repo from v3 to v4.
 
-## `create` (from `zustand` and `zustand/vanilla`)
+## `create`
 
-### Change
+**Applicable imports**
+
+```ts
+import create from 'zustand'
+import create from 'zustand/vanilla'
+```
+
+**Pattern:** `/import create from ?['"]zustand(/vanilla)?['"];?/`
+
+**Change**
 
 ```diff
 - create:
@@ -36,7 +45,7 @@ of the test files in the repo from v3 to v4.
 +   }
 ```
 
-### Migration
+**Migration**
 
 If you are not passing any type parameters to `create`,
 no migration is required.

--- a/docs/migrations/migrating-to-v4.md
+++ b/docs/migrations/migrating-to-v4.md
@@ -249,7 +249,15 @@ import createContext from 'zustand/context'
 Replace `createContext<T>()` with `createContext<StoreApi<T>>()`,
 and `createContext<T, S>()` with `createContext<S>()`.
 
-## `combine`, `devtools`, `subscribeWithSelector` (from `zustand/middleware`)
+## `combine`, `devtools`, `subscribeWithSelector`
+
+**Applicable imports**
+
+```ts
+import { combine } from 'zustand/middleware'
+import { devtools } from 'zustand/middleware'
+import { subscribeWithSelector } from 'zustand/middleware'
+```
 
 **Change**
 
@@ -272,9 +280,20 @@ and `createContext<T, S>()` with `createContext<S>()`.
 
 **Migration**
 
-If you're not passing any type parameters then there is no migration needed. If you're passing any type parameters, remove them as are inferred.
+If you are not passing any type parameters
+to `combine`, `devtools`, or `subscribeWithSelector`,
+no migration is required.
 
-## `persist` (from `zustand/middleware`)
+If you are passing any type parameters,
+remove them as they are inferred automatically.
+
+## `persist`
+
+**Applicable imports**
+
+```ts
+import { persist } from 'zustand/middleware'
+```
 
 **Change**
 
@@ -287,11 +306,31 @@ If you're not passing any type parameters then there is no migration needed. If 
 
 **Migration**
 
-If you're passing any type parameters, then remove them because they will be inferred. Next, if you're passing the `partialize` option then there's no further steps required for migration.
+If you are passing any type parameters,
+remove them as they are inferred automatically.
 
-But if you're not passing the `partialize` option then you might be seeing some compilation errors. If you're not seeing any compilation errors then there's no further steps required for migration.
+Next, if you are passing the `partialize` option,
+there is no further steps required for migration.
 
-But if you're seeing some compilation errors—because now the type of partialized state is `T` instead of `Partial<T>` which is in alignment with the runtime behavior of default `partialize` being `s => s`—then in that case you should fix the errors because they might be indicative of unsound code. To be clear the runtime behavior has not changed, the types have gotten more correct, but if your partialised state is truly `Partial<T>` then you can pass the `partialize` option as `s => s as Partial<typeof s>`. You can do this for a quickfix too.
+If you are **not** passing the `partialize` option,
+you might be seeing some compilation errors.
+If you do not see any,
+there is no further migration required.
+
+The type of partialized state is now `T` instead of `Partial<T>`,
+which aligns with the runtime behavior of the default `partialize`,
+which is an identity (`s => s`).
+
+If you see some compilation errors,
+you have to find and fix the errors yourself,
+because they might be indicative of unsound code.
+Alternatively, the workaround will be passing
+`s => s as Partial<typeof s>` to `partialize`.
+If your partialized state is truly `Partial<T>`,
+you should not encounter any bugs.
+
+The runtime behavior has not changed,
+only the types are now correct.
 
 ## `redux` (from `zustand/middleware`)
 

--- a/docs/migrations/migrating-to-v4.md
+++ b/docs/migrations/migrating-to-v4.md
@@ -284,8 +284,9 @@ If you are not passing any type parameters
 to `combine`, `devtools`, or `subscribeWithSelector`,
 no migration is required.
 
-If you are passing any type parameters,
-remove them as they are inferred automatically.
+If you are,
+remove all the type parameters,
+as they are inferred automatically.
 
 ## `persist`
 
@@ -332,7 +333,13 @@ you should not encounter any bugs.
 The runtime behavior has not changed,
 only the types are now correct.
 
-## `redux` (from `zustand/middleware`)
+## `redux`
+
+**Applicable imports**
+
+```ts
+import { redux } from 'zustand/middleware'
+```
 
 **Change**
 
@@ -345,4 +352,11 @@ only the types are now correct.
 
 **Migration**
 
-If you're not passing any type parameters then there is no migration needed. If you're passing type parameters them remove them and annotate the second (action) parameter. That is replace `redux<T, A>((state, action) => ..., ...)` with `redux((state, action: A) => ..., ...)`.
+If you are not passing any type parameters to `redux`,
+no migration is required.
+
+If you are,
+remove all the type parameters,
+and annotate only the second (action) parameter.
+That is, replace `redux<T, A>((state, action) => ..., ...)`
+with `redux((state, action: A) => ..., ...)`.

--- a/docs/migrations/migrating-to-v4.md
+++ b/docs/migrations/migrating-to-v4.md
@@ -16,7 +16,7 @@ so that the migration is easier to understand.
 In addition to this migration guide,
 you can also check the
 [diff](https://github.com/pmndrs/zustand/compare/v3.7.2...v4.0.0?short_path=37e5b4c#diff-c21e24854115b390eccde717da83f91feb2d5927a76c1485e5f0fdd0135c2afa)
-of the test files in the repo from v3 to v4.
+of the test files in the Zustand repository from v3 to v4.
 
 ## `create`
 
@@ -173,9 +173,16 @@ If you are,
 it's recommended to remove all the type parameters,
 or pass the **store** type instead of the **state** type as the first parameter.
 
-## `UseBoundStore` (from `zustand` and `zustand/react`)
+## `UseBoundStore`
 
-### Change
+**Applicable imports**
+
+```ts
+import type { UseBoundStore } from 'zustand'
+import type { UseBoundStore } from 'zustand/react'
+```
+
+**Change**
 
 ```diff
 - type UseBoundStore<
@@ -198,25 +205,38 @@ or pass the **store** type instead of the **state** type as the first parameter.
 +   & S
 ```
 
-### Migration
+**Migration**
 
-Replace `UseBoundStore<T>` with `UseBoundStore<StoreApi<T>>` and `UseBoundStore<T, S>` with `UseBoundStore<S>`
+Replace `UseBoundStore<T>` with `UseBoundStore<StoreApi<T>>`,
+and `UseBoundStore<T, S>` with `UseBoundStore<S>`
 
-## `UseContextStore` (from `zustand/context`)
+## `UseContextStore`
 
-### Change
+**Applicable imports**
+
+```ts
+import type { UseContextStore } from 'zustand/context'
+```
+
+**Change**
 
 ```diff
 - type UseContextStore
 ```
 
-### Migration
+**Migration**
 
 Use `typeof MyContext.useStore` instead
 
-## `createContext` (from `zustand/context`)
+## `createContext`
 
-### Change
+**Applicable imports**
+
+```ts
+import { createContext } from 'zustand/context'
+```
+
+**Change**
 
 ```diff
   createContext:
@@ -224,13 +244,14 @@ Use `typeof MyContext.useStore` instead
 +   <Store>() => ...
 ```
 
-### Migration
+**Migration**
 
-Replace `createContext<T>()` with `createContext<StoreApi<T>>()` and `createContext<T, S>()` with `createContext<S>()`.
+Replace `createContext<T>()` with `createContext<StoreApi<T>>()`,
+and `createContext<T, S>()` with `createContext<S>()`.
 
 ## `combine`, `devtools`, `subscribeWithSelector` (from `zustand/middleware`)
 
-### Change
+**Change**
 
 ```diff
 - combine:
@@ -249,13 +270,13 @@ Replace `createContext<T>()` with `createContext<StoreApi<T>>()` and `createCont
 +   <T, Mps, Mcs>(...) => ...
 ```
 
-### Migration
+**Migration**
 
 If you're not passing any type parameters then there is no migration needed. If you're passing any type parameters, remove them as are inferred.
 
 ## `persist` (from `zustand/middleware`)
 
-### Change
+**Change**
 
 ```diff
 - persist:
@@ -264,7 +285,7 @@ If you're not passing any type parameters then there is no migration needed. If 
 +   <T, Mps, Mcs, U = T>(...) => ...
 ```
 
-### Migration
+**Migration**
 
 If you're passing any type parameters, then remove them because they will be inferred. Next, if you're passing the `partialize` option then there's no further steps required for migration.
 
@@ -274,7 +295,7 @@ But if you're seeing some compilation errors—because now the type of partializ
 
 ## `redux` (from `zustand/middleware`)
 
-### Change
+**Change**
 
 ```diff
 - redux:
@@ -283,6 +304,6 @@ But if you're seeing some compilation errors—because now the type of partializ
 +   <T, A, Mps, Mcs>(...) => ...
 ```
 
-### Migration
+**Migration**
 
 If you're not passing any type parameters then there is no migration needed. If you're passing type parameters them remove them and annotate the second (action) parameter. That is replace `redux<T, A>((state, action) => ..., ...)` with `redux((state, action: A) => ..., ...)`.

--- a/docs/migrations/migrating-to-v4.md
+++ b/docs/migrations/migrating-to-v4.md
@@ -91,9 +91,16 @@ For that check the
 and [Common recipes](../guides/typescript.md#common-recipes)
 sections of the TypeScript Guide.
 
-## `PartialState` (from `zustand` and `zustand/vanilla`)
+## `PartialState`
 
-### Change
+**Applicable imports**
+
+```ts
+import type { PartialState } from 'zustand'
+import type { PartialState } from 'zustand/vanilla'
+```
+
+**Change**
 
 ```diff
 - type PartialState
@@ -110,11 +117,23 @@ sections of the TypeScript Guide.
 +   | ((state: T) => Partial<T>)
 ```
 
-### Migration
+**Migration**
 
-Replace `PartialState<T, ...>` with `PartialState<T>` and preferably turn on [`--exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes).
+Replace `PartialState<T, ...>` with `PartialState<T>`
+and preferably turn on [`exactOptionalPropertyTypes`](https://www.typescriptlang.org/tsconfig#exactOptionalPropertyTypes)
+in your `tsconfig.json`:
 
-We're no longer using the trick to disallow `{ foo: undefined }` to be assigned to `Partial<{ foo: string }>` instead now we're relying on the users to turn on `--exactOptionalPropertyTypes`.
+```json
+{
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  }
+}
+```
+
+We're no longer using the trick to disallow `{ foo: undefined }`
+to be assigned to `Partial<{ foo: string }>`.
+Instead, we're relying on the users to turn on `exactOptionalPropertyTypes`.
 
 ## `useStore` (from `zustand` and `zustand/react`)
 

--- a/docs/migrations/migrating-to-v4.md
+++ b/docs/migrations/migrating-to-v4.md
@@ -27,8 +27,6 @@ import create from 'zustand'
 import create from 'zustand/vanilla'
 ```
 
-**Pattern:** `/import create from ?['"]zustand(/vanilla)?['"];?/`
-
 **Change**
 
 ```diff
@@ -55,9 +53,16 @@ remove all type parameters from `create`.
 
 Else, replace `create<T, ...>(...)` with `create<T>()(...)`.
 
-## `StateCreator` (from `zustand` and `zustand/vanilla`)
+## `StateCreator`
 
-### Change
+**Applicable imports**
+
+```ts
+import type { StateCreator } from 'zustand'
+import type { StateCreator } from 'zustand/vanilla'
+```
+
+**Change**
 
 ```diff
 - type StateCreator
@@ -76,9 +81,15 @@ Else, replace `create<T, ...>(...)` with `create<T>()(...)`.
 +     ...
 ```
 
-### Migration
+**Migration**
 
-If you're using `StateCreator` you're likely authoring a middleware or using the "slices" pattern, for that check the TypeScript Guide's ["Authoring middlewares and advanced usage"](../guides/typescript.md#authoring-middlewares-and-advanced-usage) and ["Common recipes"](../guides/typescript.md#common-recipes) sections.
+If you are using `StateCreator`,
+you are likely authoring a middleware
+or using the "slices" pattern.
+For that check the
+[Authoring middlewares and advanced usage](../guides/typescript.md#authoring-middlewares-and-advanced-usage)
+and [Common recipes](../guides/typescript.md#common-recipes)
+sections of the TypeScript Guide.
 
 ## `PartialState` (from `zustand` and `zustand/vanilla`)
 

--- a/docs/migrations/migrating-to-v4.md
+++ b/docs/migrations/migrating-to-v4.md
@@ -1,5 +1,5 @@
 ---
-title: v4 Migrations
+title: Migrating to v4
 nav: 19
 ---
 
@@ -38,10 +38,10 @@ of the test files in the repo from v3 to v4.
 
 ### Migration
 
-If you're not passing any type parameters to `create`,
+If you are not passing any type parameters to `create`,
 no migration is required.
 
-If you're using a "leaf" middleware like `combine` or `redux`,
+If you are using a "leaf" middleware like `combine` or `redux`,
 remove all type parameters from `create`.
 
 Else, replace `create<T, ...>(...)` with `create<T>()(...)`.

--- a/docs/migrations/migrating-to-v4.md
+++ b/docs/migrations/migrating-to-v4.md
@@ -314,7 +314,7 @@ Next, if you are passing the `partialize` option,
 there is no further steps required for migration.
 
 If you are **not** passing the `partialize` option,
-you might be seeing some compilation errors.
+you might see some compilation errors.
 If you do not see any,
 there is no further migration required.
 

--- a/docs/migrations/v4-migration.md
+++ b/docs/migrations/v4-migration.md
@@ -38,7 +38,11 @@ of the test files in the repo from v3 to v4.
 
 ### Migration
 
-If you're not passing any type parameters to `create` then there is no migration needed. If you're using a "leaf" middleware like `combine` or `redux` then remove all type parameters from `create`. Else replace `create<T, ...>(...)` with `create<T>()(...)`.
+If you're not passing any type parameters to `create`,
+no migration is required.
+If you're using a "leaf" middleware like `combine` or `redux`,
+remove all type parameters from `create`.
+Else, replace `create<T, ...>(...)` with `create<T>()(...)`.
 
 ## `StateCreator` (from `zustand` and `zustand/vanilla`)
 
@@ -211,7 +215,7 @@ If you're not passing any type parameters then there is no migration needed. If 
 
 If you're passing any type parameters, then remove them because they will be inferred. Next, if you're passing the `partialize` option then there's no further steps required for migration.
 
-But if you're not passing the `partialize` option then you might be seeing some compilation errors. If you're not seeing any compilation errors then there's no further steps requierd for migration.
+But if you're not passing the `partialize` option then you might be seeing some compilation errors. If you're not seeing any compilation errors then there's no further steps required for migration.
 
 But if you're seeing some compilation errors—because now the type of partialized state is `T` instead of `Partial<T>` which is in alignment with the runtime behavior of default `partialize` being `s => s`—then in that case you should fix the errors because they might be indicative of unsound code. To be clear the runtime behavior has not changed, the types have gotten more correct, but if your partialised state is truly `Partial<T>` then you can pass the `partialize` option as `s => s as Partial<typeof s>`. You can do this for a quickfix too.
 

--- a/docs/migrations/v4-migration.md
+++ b/docs/migrations/v4-migration.md
@@ -3,11 +3,20 @@ title: v4 Migrations
 nav: 19
 ---
 
-If you're not using the typed version (either via TypeScript or via JSDoc) then there are no breaking changes for you and hence no migration is needed either.
+The only breaking changes are in types.
+If you are using Zustand with TypeScript
+or JSDoc type annotations,
+this guide applies.
+Otherwise, no migration is required.
 
-Also it's recommended to first read the new [TypeScript Guide](../guides/typescript.md), it'll be easier to understand the migration.
+Also, it's recommended to first read
+the new [TypeScript Guide](../guides/typescript.md),
+so that the migration is easier to understand.
 
-In addition to this migration guide you can also check the diff of the test files in the repo from v3 to v4.
+In addition to this migration guide,
+you can also check the
+[diff](https://github.com/pmndrs/zustand/compare/v3.7.2...v4.0.0?short_path=37e5b4c#diff-c21e24854115b390eccde717da83f91feb2d5927a76c1485e5f0fdd0135c2afa)
+of the test files in the repo from v3 to v4.
 
 ## `create` (from `zustand` and `zustand/vanilla`)
 

--- a/docs/migrations/v4-migration.md
+++ b/docs/migrations/v4-migration.md
@@ -40,8 +40,10 @@ of the test files in the repo from v3 to v4.
 
 If you're not passing any type parameters to `create`,
 no migration is required.
+
 If you're using a "leaf" middleware like `combine` or `redux`,
 remove all type parameters from `create`.
+
 Else, replace `create<T, ...>(...)` with `create<T>()(...)`.
 
 ## `StateCreator` (from `zustand` and `zustand/vanilla`)


### PR DESCRIPTION
## Related Issues

Relates to #1220.

## Summary

- Rename "v4 migrations" to "Migrating to v4", as it is more likely to be search by users.
- Restructure the documentation:
  - Drop the "Change" and "Migration" third-level headers,
    as they were cluttering the outline[^1],
    and produced incorrect section links
    (`#change` always linked to the first occurence).
    Use bolded text without it being header instead.
  - Drop the "(from `zustand`)" header add-ons.
  - The final outline is much cleaner now[^2].
- Instead of header add-ons,
  e.g., "(from `zustand` and `zustand/vanilla`)"[^3],
  add "Applicable imports" subsection[^4].
- Split the paragraphs with if/else instructions,
  so that they are easier to understand.
- Rephrase paragraphs, so they are more grammatically correct
  and easier to understand.

[^1]: Old outline: <img width="238" alt="Screenshot 2023-01-05 at 13 21 57" src="https://user-images.githubusercontent.com/18354178/210799847-6d20f8ec-3894-4205-a0a4-51be63cc4b9f.png">
[^2]: New outline: <img width="225" alt="Screenshot 2023-01-05 at 15 03 53" src="https://user-images.githubusercontent.com/18354178/210799940-ba77f198-429f-40b3-834d-cfbef0bb6ad4.png">
[^3]: Old section shape: <img width="825" alt="Screenshot 2023-01-05 at 13 23 21" src="https://user-images.githubusercontent.com/18354178/210801720-00b8a507-93a2-4baf-9fda-28946f46220c.png">
[^4]: New section shape: <img width="824" alt="Screenshot 2023-01-05 at 14 02 36" src="https://user-images.githubusercontent.com/18354178/210801841-01badc2d-e81c-443d-97eb-afcc4164935d.png">

## Check List

- [x] `yarn run prettier` for formatting code and docs

-----
