### PR TITLE
chore: show deprecated message only in DEV

### DIFF
--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -502,9 +502,11 @@ const persistImpl: PersistImpl = (config, baseOptions) => {
     'serialize' in baseOptions ||
     'deserialize' in baseOptions
   ) {
-    console.warn(
-      '[DEPRECATED] `getStorage`, `serialize` and `deserialize` options are deprecated. Please use `storage` option instead.'
-    )
+    if (__DEV__) {
+      console.warn(
+        '[DEPRECATED] `getStorage`, `serialize` and `deserialize` options are deprecated. Please use `storage` option instead.'
+      )
+    }
     return oldImpl(config, baseOptions)
   }
   return newImpl(config, baseOptions)

--- a/src/react.ts
+++ b/src/react.ts
@@ -91,8 +91,10 @@ export const create = (<T>(createState: StateCreator<T, [], []> | undefined) =>
  * @deprecated Use `import { create } from 'zustand'`
  */
 export default ((createState: any) => {
-  console.warn(
-    "[DEPRECATED] default export is deprecated, instead import { create } from'zustand'"
-  )
+  if (__DEV__) {
+    console.warn(
+      "[DEPRECATED] default export is deprecated, instead import { create } from'zustand'"
+    )
+  }
   return create(createState)
 }) as Create

--- a/src/shallow.ts
+++ b/src/shallow.ts
@@ -52,8 +52,10 @@ export function shallow<T>(objA: T, objB: T) {
  * @deprecated Use `import { shallow } from 'zustand/shallow'`
  */
 export default ((objA, objB) => {
-  console.warn(
-    "[DEPRECATED] default export is deprecated, instead import { shallow } from'zustand/shallow'"
-  )
+  if (__DEV__) {
+    console.warn(
+      "[DEPRECATED] default export is deprecated, instead import { shallow } from'zustand/shallow'"
+    )
+  }
   return shallow(objA, objB)
 }) as typeof shallow

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -109,9 +109,11 @@ export const createStore = ((createState) =>
  * @deprecated Use `import { createStore } from ...`
  */
 export default ((createState) => {
-  console.warn(
-    '[DEPRECATED] default export is deprecated, instead import { createStore } ...'
-  )
+  if (__DEV__) {
+    console.warn(
+      '[DEPRECATED] default export is deprecated, instead import { createStore } ...'
+    )
+  }
   return createStore(createState)
 }) as CreateStore
 


### PR DESCRIPTION
While writing 4.3.0 release note, I noticed deprecation messages will be shown in production. Let's make them dev only.