### PR TITLE
Revert breaking change in v4.3.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './vanilla'
 export * from './react'
+export { default as createStore } from './vanilla'
 export { default } from './react'


### PR DESCRIPTION


## Related Issues

Fixes downstream issues: https://github.com/charkour/zundo/issues/62

## Summary

The removal of `export { default as createStore } from './vanilla'` from index.ts in [zustand v4.3.0](https://github.com/pmndrs/zustand/compare/v4.2.0...v4.3.0) causes a (small) breaking change to users who use this code: `import { createVanilla } from 'zustand'`

Is this something we should revert? I know this export is deprecated and will be removed in the future. Thank you for your time.


## Check List

- [ ] `yarn run prettier` for formatting code and docs
