### PR TITLE
Add zustand-di to third-party docs

### DIFF
--- a/docs/integrations/third-party-libraries.md
+++ b/docs/integrations/third-party-libraries.md
@@ -30,6 +30,7 @@ This can be done using third-party libraries created by the community.
 - [zundo](https://github.com/charkour/zundo) — 🍜 Undo and redo middleware for Zustand, enabling time-travel in your apps.
 - [zustand-constate](https://github.com/ntvinhit/zustand-constate) — Context-based state management based on Zustand and taking ideas from Constate.
 - [zustand-computed](https://github.com/chrisvander/zustand-computed) — A Zustand middleware to create computed states.
+- [zustand-di](https://github.com/charkour/zustand-di) - use react props to init zustand stores
 - [zustand-forms](https://github.com/Conduct/zustand-forms) — Fast, type safe form states as Zustand stores.
 - [zustand-middleware-computed-state](https://github.com/cmlarsen/zustand-middleware-computed-state) — A dead simple middleware for adding computed state to Zustand.
 - [zustand-middleware-xstate](https://github.com/biowaffeln/zustand-middleware-xstate) — A middleware for putting XState state machines into a global Zustand store.


### PR DESCRIPTION
## Summary

Add [zustand-di](https://github.com/charkour/zustand-di) third-party package in anticipation of `createContext` from `zustand/context` being removed in v5 of zustand.


## Check List

- [ ] `yarn run prettier` for formatting code and docs
