### PR TITLE
fix(docs): Invalid example in comparison docs

### DIFF
--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -242,7 +242,7 @@ type State = {
 
 const store = create<State>(() => ({ obj: { count: 0 } }))
 
-store.setState((prev) => ({ obj: { count: prev.obj.count + 1 } })
+store.setState((prev) => ({ obj: { count: prev.obj.count + 1 } }))
 ```
 
 **Valtio**


### PR DESCRIPTION
Add missing close parenthesis on Zustand example
