### PR TITLE
fix(middleware/persist): Fix the storage type

### DIFF
--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -6,7 +6,7 @@ export interface StateStorage {
   removeItem: (name: string) => void | Promise<void>
 }
 
-type StorageValue<S> = {
+export type StorageValue<S> = {
   state: S
   version?: number
 }

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -89,7 +89,7 @@ export interface PersistOptions<S, PersistedState = S> {
    *
    * @default createJSONStorage(() => localStorage)
    */
-  storage?: PersistStorage<S> | undefined
+  storage?: PersistStorage<PersistedState> | undefined
   /**
    * Filter the persisted value.
    *


### PR DESCRIPTION
## Related Issues

Went ahead with the PR, skipped the issue.

## Summary

The storage must be operating with the persisted state type, which by default matches the state type. Otherwise it's not possible to introduce serialization/deserialization logic.

An example of how this would be useful:

```typescript

export function createSerdeStorage<State, RawState>(
  serialize: (state: State) => RawState,
  deserialize: (rawState: RawState) => State,
  getStorage: () => PersistStorage<RawState>
): PersistStorage<State> {
  const storage = getStorage();
  return {
    getItem: async (name) => {
      const data = await storage.getItem(name);
      if (data === null) return null;
      return {
        ...data,
        state: deserialize(data.state),
      };
    },
    setItem: (name, value) =>
      storage.setItem(name, { ...value, state: serialize(value.state) }),
    removeItem: storage.removeItem,
  };
}

// An implementation of the custom deserializer for the timestamp with the above logic.
export function createTimestampStorage<State>(
  getStorage: () => PersistStorage<string>
): PersistStorage<State> {
  return createSerdeStorage<State, string>(
    JSON.stringify,
    Temporal.ZonedDateTime.from,
    getStorage
  );
}
```

## Check List

- [x] `yarn run prettier` for formatting code and docs
