### PR TITLE
docs: remove now superfluous warning messages

### DIFF
--- a/docs/getting-started/concepts.md
+++ b/docs/getting-started/concepts.md
@@ -1,9 +1,0 @@
----
-title: Concepts
-description:
-nav: 1
----
-
-<Hint>
-  ⚠️ This doc is still under construction. https://github.com/pmndrs/zustand/discussions/1033
-</Hint>

--- a/docs/getting-started/introduction.mdx
+++ b/docs/getting-started/introduction.mdx
@@ -4,11 +4,6 @@ description: How to use Zustand
 nav: 0
 ---
 
-<Hint>
-  ⚠️ This doc is still under construction.
-  https://github.com/pmndrs/zustand/discussions/1033
-</Hint>
-
 <div class="flex justify-center mb-4">
   <img src="https://github.com/pmndrs/zustand/raw/main/bear.jpg" />
 </div>

--- a/docs/recipes/recipes.mdx
+++ b/docs/recipes/recipes.mdx
@@ -4,8 +4,6 @@ description: How to do all you need with Zustand
 nav: 15
 ---
 
-⚠️ This doc is still under construction. https://github.com/pmndrs/zustand/discussions/1033
-
 ## Fetching everything
 
 You can, but bear in mind that it will cause the component to update on every state change!


### PR DESCRIPTION
## Related Issues

Addresses #1220 and comment https://github.com/pmndrs/zustand/discussions/1033#discussioncomment-4689567

## Summary

Removes now superfluous warning messages. With all the improvements on the docs, these messages are no longer needed. 

The "concepts" page has also been dropped as there is no content and is covered by the intro page. 

## Check List

- [X] `yarn run prettier` for formatting code and docs
