### PR TITLE
fix(docs/typescript): use correct initial state in test example

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -444,7 +444,7 @@ import { vanillaBearStore, initialBearState } from './BearStore'
 describe('MyComponent should', () => {
   // remember to reset the store
   beforeEach(() => {
-    vanillaBearStore.setState(initialState)
+    vanillaBearStore.setState(initialBearState)
   })
 
   it('set the value', () => {


### PR DESCRIPTION
## Related Issues
#1565 

Fixes #.
Comment on incorrect initial state usage in example

## Summary



## Check List

- [x] `yarn run prettier` for formatting code and docs
