### PR TITLE
fix(docs/typescript): provide example how to use middlewares with #1565

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -444,7 +444,7 @@ import { vanillaBearStore, initialBearState } from './BearStore'
 describe('MyComponent should', () => {
   // remember to reset the store
   beforeEach(() => {
-    vanillaBearStore.setState(initialState)
+    vanillaBearStore.setState(initialBearState)
   })
 
   it('set the value', () => {
@@ -466,6 +466,22 @@ export const BearComponent = () => {
   return <div>{bears}</div>
 }
 ```
+
+If you want to use middlewares with your store:
+
+```ts
+import { createStore } from 'zustand/vanilla'
+import { devtools } from 'zustand/middleware'
+
+export const vanillaBearStore = createStore<BearState>()(
+  devtools((set, getState) => ({
+    ...initialBearState,
+    increase: (by) => set((state) => ({ bears: state.bears + by })),
+  }))
+)
+```
+
+For the extra parantheses please see [this](https://github.com/pmndrs/zustand/blob/main/docs/guides/typescript.md#basic-usage)
 
 ## Middlewares and their mutators reference
 

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -481,7 +481,8 @@ export const vanillaBearStore = createStore<BearState>()(
 )
 ```
 
-For the extra parantheses please see [this](https://github.com/pmndrs/zustand/blob/main/docs/guides/typescript.md#basic-usage)
+For more information about why there are extra parentheses,
+please see the [Basic usage section](#basic-usage).
 
 ## Middlewares and their mutators reference
 


### PR DESCRIPTION
## Related Issues
#1565 

Fixes #.

## Summary
Providing an example of using middlewares with vanilla stores using typescript


## Check List

- [x] `yarn run prettier` for formatting code and docs
