### PR TITLE
docs(typescript): clean up bounded `useStore` recipe

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -415,14 +415,20 @@ const bearStore = create<BearState>()((set) => ({
 }))
 
 function useBearStore(): BearState
-function useBearStore<T>(selector: (state: BearState) => T, equals?: (a: T, b: T) => boolean): T
-function useBearStore<T>(selector?: (state: BearState) => T, equals?: (a: T, b: T) => boolean) {
+function useBearStore<T>(
+  selector: (state: BearState) => T,
+  equals?: (a: T, b: T) => boolean
+): T
+function useBearStore<T>(
+  selector?: (state: BearState) => T,
+  equals?: (a: T, b: T) => boolean
+) {
   return useStore(bearStore, selector!, equals)
 }
 ```
 
 You can also make an abstract `createBoundedUseStore` if you create bounded `useStore`s often and want to DRY things up...
-    
+
 ```ts
 import { create, useStore, StoreApi } from 'zustand'
 
@@ -436,19 +442,22 @@ const bearStore = create<BearState>()((set) => ({
   increase: (by) => set((state) => ({ bears: state.bears + by })),
 }))
 
-const createBoundedUseStore =
-  ((store) => (selector, equals) => useStore(store, selector as any, equals)) as
-    <S extends StoreApi<unknown>>(store: S) => {
-      (): ExtractState<S>
-      <T>(selector?: (state: ExtractState<S>) => T, equals?: (a: T, b: T) => boolean): T
-    }
+const createBoundedUseStore = ((store) => (selector, equals) =>
+  useStore(store, selector as any, equals)) as <S extends StoreApi<unknown>>(
+  store: S
+) => {
+  (): ExtractState<S>
+  <T>(
+    selector?: (state: ExtractState<S>) => T,
+    equals?: (a: T, b: T) => boolean
+  ): T
+}
 
-type ExtractState<S> =
-  S extends { get: () => infer X } ? X : never
+type ExtractState<S> = S extends { get: () => infer X } ? X : never
 
 const useBearStore = createBoundedUseStore(bearStore)
 ```
- 
+
 ## Middlewares and their mutators reference
 
 - `devtools` — `["zustand/devtools", never]`

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -399,91 +399,28 @@ A detailed explanation on the slices pattern can be found [here](./slices-patter
 
 If you have some middlewares then replace `StateCreator<MyState, [], [], MySlice>` with `StateCreator<MyState, Mutators, [], MySlice>`. For example, if you are using `devtools` then it will be `StateCreator<MyState, [["zustand/devtools", never]], [], MySlice>`. See the ["Middlewares and their mutators reference"](#middlewares-and-their-mutators-reference) section for a list of all mutators.
 
-### Using a vanilla store as a bound store
-
-Create your vanilla store:
+### A bounded `useStore` hook
 
 ```ts
-import { createStore } from 'zustand/vanilla'
+import { create, useStore } from 'zustand'
 
 interface BearState {
   bears: number
   increase: (by: number) => void
 }
 
-export const initialBearState = { bears: 0 }
-export const vanillaBearStore = createStore<BearState>((set, getState) => ({
-  ...initialBearState,
+export const bearStore = create<BearState>()((set) => ({
+  bears: 0,
   increase: (by) => set((state) => ({ bears: state.bears + by })),
 }))
-```
 
-Create a hook to provide a bound store to be used in your component:
-
-```ts
-import { useStore } from 'zustand'
-
-export function useBoundBearStore(): BearState
-export function useBoundBearStore<T>(
-  selector: (state: BearState) => T,
-  equals?: (a: T, b: T) => boolean
-): T
-export function useBoundBearStore(selector?: any, equals?: any) {
-  return useStore(vanillaBearStore, selector, equals)
+function useBearStore(): BearState
+function useBearStore<T>(selector: (state: BearState) => T, equals?: (a: T, b: T) => boolean): T
+function useBearStore<T>(selector?: (state: BearState) => T, equals?: (a: T, b: T) => boolean) {
+  return useStore(bearStore, selector!, equals)
 }
 ```
-
-> **_NOTE:_** We prefer function overloading here, as this closely follows the definition of `useStore` itself.  
-> If you are not familiar with this pattern, just have a look here: [Typescript Docs](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads)
-
-Now you can access your vanilla store (e.g. in your tests) like:
-
-```ts
-import { vanillaBearStore, initialBearState } from './BearStore'
-
-describe('MyComponent should', () => {
-  // remember to reset the store
-  beforeEach(() => {
-    vanillaBearStore.setState(initialBearState)
-  })
-
-  it('set the value', () => {
-    const store = vanillaBearStore
-    // do the test
-    expect(store.getState().bears).toEqual(0)
-  })
-})
-```
-
-And access the store in your component
-
-```tsx
-import { useBoundBearStore } from './BearStore'
-
-export const BearComponent = () => {
-  const bears = useBoundBearStore((state) => state.bears)
-
-  return <div>{bears}</div>
-}
-```
-
-If you want to use middlewares with your store:
-
-```ts
-import { createStore } from 'zustand/vanilla'
-import { devtools } from 'zustand/middleware'
-
-export const vanillaBearStore = createStore<BearState>()(
-  devtools((set, getState) => ({
-    ...initialBearState,
-    increase: (by) => set((state) => ({ bears: state.bears + by })),
-  }))
-)
-```
-
-For more information about why there are extra parentheses,
-please see the [Basic usage section](#basic-usage).
-
+ 
 ## Middlewares and their mutators reference
 
 - `devtools` — `["zustand/devtools", never]`

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -399,17 +399,18 @@ A detailed explanation on the slices pattern can be found [here](./slices-patter
 
 If you have some middlewares then replace `StateCreator<MyState, [], [], MySlice>` with `StateCreator<MyState, Mutators, [], MySlice>`. For example, if you are using `devtools` then it will be `StateCreator<MyState, [["zustand/devtools", never]], [], MySlice>`. See the ["Middlewares and their mutators reference"](#middlewares-and-their-mutators-reference) section for a list of all mutators.
 
-### A bounded `useStore` hook
+### Bounded `useStore` hook for vanilla stores
 
 ```ts
-import { create, useStore } from 'zustand'
+import { useStore } from 'zustand'
+import { createStore } from 'zustand/vanilla'
 
 interface BearState {
   bears: number
   increase: (by: number) => void
 }
 
-const bearStore = create<BearState>()((set) => ({
+const bearStore = createStore<BearState>()((set) => ({
   bears: 0,
   increase: (by) => set((state) => ({ bears: state.bears + by })),
 }))
@@ -430,14 +431,15 @@ function useBearStore<T>(
 You can also make an abstract `createBoundedUseStore` if you create bounded `useStore`s often and want to DRY things up...
 
 ```ts
-import { create, useStore, StoreApi } from 'zustand'
+import { useStore, StoreApi } from 'zustand'
+import { createStore } from 'zustand/vanilla'
 
 interface BearState {
   bears: number
   increase: (by: number) => void
 }
 
-const bearStore = create<BearState>()((set) => ({
+const bearStore = createStore<BearState>()((set) => ({
   bears: 0,
   increase: (by) => set((state) => ({ bears: state.bears + by })),
 }))

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -409,7 +409,7 @@ interface BearState {
   increase: (by: number) => void
 }
 
-export const bearStore = create<BearState>()((set) => ({
+const bearStore = create<BearState>()((set) => ({
   bears: 0,
   increase: (by) => set((state) => ({ bears: state.bears + by })),
 }))
@@ -419,6 +419,34 @@ function useBearStore<T>(selector: (state: BearState) => T, equals?: (a: T, b: T
 function useBearStore<T>(selector?: (state: BearState) => T, equals?: (a: T, b: T) => boolean) {
   return useStore(bearStore, selector!, equals)
 }
+```
+
+You can also make an abstract `createBoundedUseStore` if you create bounded `useStore`s often and want to DRY things up...
+    
+```ts
+import { create, useStore, StoreApi } from 'zustand'
+
+interface BearState {
+  bears: number
+  increase: (by: number) => void
+}
+
+const bearStore = create<BearState>()((set) => ({
+  bears: 0,
+  increase: (by) => set((state) => ({ bears: state.bears + by })),
+}))
+
+const createBoundedUseStore =
+  ((store) => (selector, equals) => useStore(store, selector as any, equals)) as
+    <S extends StoreApi<unknown>>(store: S) => {
+      (): ExtractState<S>
+      <T>(selector?: (state: ExtractState<S>) => T, equals?: (a: T, b: T) => boolean): T
+    }
+
+type ExtractState<S> =
+  S extends { get: () => infer X } ? X : never
+
+const useBearStore = createBoundedUseStore(bearStore)
 ```
  
 ## Middlewares and their mutators reference


### PR DESCRIPTION
Supercedes #1565.

The recipe added in #1565 is unnecessarily wordy beyond measure. That's not to blame the author (or the maintainers) as they might not be aware of how the TypeScript guide is supposed to be. I just want to clarify my intention of the TypeScript guide as the original author: A succint to-the-point document that shows you how to deal with TypeScript, period. (This ignores the extra collapsed sections of course, which is precisely why they are collapsed.)

Which means it's not there to teach you how to use zustand patterns or anything. If you look at every recipe, it's literally just a snippet to show you the typings. So when the user comes to the "slices pattern" recipe for example, it is assumed they know what "slices pattern" already is, hence we don't teach slices pattern here but instead link at a detailed explanation at the end if they aren't familiar with it.

This is the mistake that #1565 does, it's way too tutorialy (has "steps" and is worded like so), has too broad scope (talks about testing and stuff), repetitive in that it shows how to use middlewares, mentions the extra parenthesis etc (those are not needed here).

So my suggested change is in this PR. If we want to "teach" this bounded `useStore` pattern (well it's not much of a pattern, it's just partial application) then it can be done in the readme or a seperate guide and then link it at the end as we do for slices pattern recipe.

Just my two cents, please feel free to close this PR if you don't like it.