### PR TITLE
fix(log): deprecated messages copyedit for consistency

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -27,7 +27,7 @@ type WithoutCallSignature<T> = { [K in keyof T]: T[K] }
 function createContext<S extends StoreApi<unknown>>() {
   if (__DEV__) {
     console.warn(
-      '[DEPRECATED] zustand/context will be removed in the future version. Please use `import { createStore, useStore } from "zustand"` for context usage. See: https://github.com/pmndrs/zustand/discussions/1180'
+      "[DEPRECATED] `context` will be removed in a future version. Instead use `import { createStore, useStore } from 'zustand'` alongside `createContext` and `useContext` hooks. See: https://github.com/pmndrs/zustand/discussions/1180."
     )
   }
   const ZustandContext = reactCreateContext<S | undefined>(undefined)

--- a/src/context.ts
+++ b/src/context.ts
@@ -27,7 +27,7 @@ type WithoutCallSignature<T> = { [K in keyof T]: T[K] }
 function createContext<S extends StoreApi<unknown>>() {
   if (__DEV__) {
     console.warn(
-      "[DEPRECATED] `context` will be removed in a future version. Instead use `import { createStore, useStore } from 'zustand'` alongside `createContext` and `useContext` hooks. See: https://github.com/pmndrs/zustand/discussions/1180."
+      "[DEPRECATED] `context` will be removed in a future version. Instead use `import { createStore, useStore } from 'zustand'`. See: https://github.com/pmndrs/zustand/discussions/1180."
     )
   }
   const ZustandContext = reactCreateContext<S | undefined>(undefined)

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -504,7 +504,7 @@ const persistImpl: PersistImpl = (config, baseOptions) => {
   ) {
     if (__DEV__) {
       console.warn(
-        '[DEPRECATED] `getStorage`, `serialize` and `deserialize` options are deprecated. Please use `storage` option instead.'
+        '[DEPRECATED] `getStorage`, `serialize` and `deserialize` options are deprecated. Use `storage` option instead.'
       )
     }
     return oldImpl(config, baseOptions)

--- a/src/react.ts
+++ b/src/react.ts
@@ -70,7 +70,7 @@ type Create = {
 const createImpl = <T>(createState: StateCreator<T, [], []>) => {
   if (__DEV__ && typeof createState !== 'function') {
     console.warn(
-      '[DEPRECATED] Passing a vanilla store will be unsupported in the future version. Please use `import { useStore } from "zustand"` to use the vanilla store in React.'
+      "[DEPRECATED] Passing a vanilla store will be unsupported in a future version. Instead use `import { useStore } from 'zustand'`."
     )
   }
   const api =
@@ -93,7 +93,7 @@ export const create = (<T>(createState: StateCreator<T, [], []> | undefined) =>
 export default ((createState: any) => {
   if (__DEV__) {
     console.warn(
-      "[DEPRECATED] default export is deprecated, instead import { create } from'zustand'"
+      "[DEPRECATED] Default export is deprecated. Instead use `import { create } from 'zustand'`."
     )
   }
   return create(createState)

--- a/src/shallow.ts
+++ b/src/shallow.ts
@@ -54,7 +54,7 @@ export function shallow<T>(objA: T, objB: T) {
 export default ((objA, objB) => {
   if (__DEV__) {
     console.warn(
-      "[DEPRECATED] default export is deprecated, instead import { shallow } from'zustand/shallow'"
+      "[DEPRECATED] Default export is deprecated. Instead use `import { create } from 'zustand/shallow'`."
     )
   }
   return shallow(objA, objB)

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -91,7 +91,7 @@ const createStoreImpl: CreateStoreImpl = (createState) => {
   const destroy: StoreApi<TState>['destroy'] = () => {
     if (__DEV__) {
       console.warn(
-        '[DEPRECATED] The destroy method will be unsupported in the future version. You should use unsubscribe function returned by subscribe. Everything will be garbage collected if store is garbage collected.'
+        '[DEPRECATED] The `destroy` method will be unsupported in a future version. Instead use unsubscribe function returned by subscribe. Everything will be garbage-collected if store is garbage-collected.'
       )
     }
     listeners.clear()
@@ -106,12 +106,12 @@ export const createStore = ((createState) =>
   createState ? createStoreImpl(createState) : createStoreImpl) as CreateStore
 
 /**
- * @deprecated Use `import { createStore } from ...`
+ * @deprecated Use `import { createStore } from 'zustand/vanilla'`
  */
 export default ((createState) => {
   if (__DEV__) {
     console.warn(
-      '[DEPRECATED] default export is deprecated, instead import { createStore } ...'
+      "[DEPRECATED] Default export is deprecated. Instead use import { createStore } from 'zustand/vanilla'."
     )
   }
   return createStore(createState)


### PR DESCRIPTION
## Summary
Make deprecated messages copy consistent. Minor copy cleanup otherwise.
* Most importantly, add space after `from` (e.g. in `import { shallow } from'zustand/shallow'`).

## Check List
- [x] `yarn run prettier` for formatting code and docs
