### PR TITLE
fix(react, types): relax react types

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -16,10 +16,9 @@ const { useSyncExternalStoreWithSelector } = useSyncExternalStoreExports
 
 type ExtractState<S> = S extends { getState: () => infer T } ? T : never
 
-type WithReact<S extends StoreApi<unknown>> = Pick<
-  S,
-  'getState' | 'subscribe'
-> & {
+type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'subscribe'>
+
+type WithReact<S extends ReadonlyStoreApi<unknown>> = S & {
   getServerState?: () => ExtractState<S>
 }
 
@@ -49,7 +48,7 @@ export function useStore<TState, StateSlice>(
   return slice
 }
 
-export type UseBoundStore<S extends WithReact<StoreApi<unknown>>> = {
+export type UseBoundStore<S extends WithReact<ReadonlyStoreApi<unknown>>> = {
   (): ExtractState<S>
   <U>(
     selector: (state: ExtractState<S>) => U,

--- a/src/react.ts
+++ b/src/react.ts
@@ -16,7 +16,10 @@ const { useSyncExternalStoreWithSelector } = useSyncExternalStoreExports
 
 type ExtractState<S> = S extends { getState: () => infer T } ? T : never
 
-type WithReact<S extends StoreApi<unknown>> = S & {
+type WithReact<S extends StoreApi<unknown>> = Pick<
+  S,
+  'getState' | 'subscribe'
+> & {
   getServerState?: () => ExtractState<S>
 }
 

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -233,3 +233,17 @@ it('StateCreator subtyping', () => {
   const _testSubtyping: StateCreator<State, [['zustand/persist', unknown]]> =
     {} as StateCreator<State, []>
 })
+
+it('set state exists on store with readonly store', () => {
+  interface State {
+    count: number
+    increment: () => void
+  }
+
+  const useStore = create<State>()((set, get) => ({
+    count: 0,
+    increment: () => set({ count: get().count + 1 }),
+  }))
+
+  useStore.setState((state) => ({ ...state, count: state.count + 1 }))
+})


### PR DESCRIPTION
## Summary

`UseBoundStore` strictly enforces the shape of the `setState` function but does not rely on the shape of the `setState` function internally.

## Why we should be relaxed about `setState`

I want to define a middleware that makes the action in `devtools` required (to improve debugging store mutations in a large app). But if I make the third argument to `setState` required, the modified `setState` function is no longer compatible with the default `setState` function.

We get the following error message (edited for readability).

```
Types of property 'setState' are incompatible.

'<A extends string | { type: unknown; }>(
   partial: T | Partial<T> | ((state: T) => T | Partial<T>), 
   replace: boolean | undefined, 
   action: A
) => void' 

is not assignable to 

'(partial: unknown, replace?: boolean | undefined) => void'.
```

Internally the `react` extension only seems to rely on `getState` and `subscribe`, so I made that explicit in the types.

## Check List

- [x] `yarn run prettier` for formatting code and docs
