### PR TITLE
chore: remove redundant configuration from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules/
-coverage/
 dist/
 Thumbs.db
 ehthumbs.db
@@ -10,6 +9,5 @@ $RECYCLE.BIN/
 .docz/
 package-lock.json
 coverage/
-.idea
 .rpt2_cache/
 .idea


### PR DESCRIPTION
## Related Issues

Fixes #.

## Summary

Removes redundant configuration items `coverage/` and `.idea` from the .gitignore file.

## Check List

- [x] `yarn run prettier` for formatting code and docs
