### PR TITLE
chore: unused import type {} from '@redux-devtools/extension'

### DIFF
--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -1,4 +1,3 @@
-import type {} from '@redux-devtools/extension'
 import type { StateCreator, StoreApi, StoreMutatorIdentifier } from '../vanilla'
 
 // Copy types to avoid import type { Config } from '@redux-devtools/extension'


### PR DESCRIPTION
## Summary

Unused import type {} from '@redux-devtools/extension'


## Check List

- [x] `yarn run prettier` for formatting code and docs
