### PR TITLE
fix(docs): resolve different section linking behavior with special ch…

### DIFF
--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -405,12 +405,12 @@ is not logged in because it's the default,
 but in reality the store has not been hydrated yet.
 
 If your app does depends on the persisted state at page load,
-see [_How can I check if my store has been hydrated?_](#how-can-i-check-if-my-store-has-been-hydrated)
+see [_How can I check if my store has been hydrated_](#how-can-i-check-if-my-store-has-been-hydrated)
 in the [FAQ](#faq) section below.
 
 ## FAQ
 
-### How can I check if my store has been hydrated?
+### How can I check if my store has been hydrated
 
 There are a few different ways to do this.
 
@@ -478,7 +478,7 @@ const useHydration = () => {
 }
 ```
 
-### How can I use a custom storage engine?
+### How can I use a custom storage engine
 
 If the storage you want to use does not match the expected API, you can create your own storage:
 
@@ -517,7 +517,7 @@ export const useBoundStore = create(
 )
 ```
 
-### How can I rehydrate on storage event?
+### How can I rehydrate on storage event
 
 You can use the Persist API to create your own implementation,
 similar to the example below:
@@ -543,7 +543,7 @@ const useBoundStore = create(persist(...))
 withStorageDOMEvents(useBoundStore)
 ```
 
-### How do I use it with TypeScript?
+### How do I use it with TypeScript
 
 Basic typescript usage doesn't require anything special
 except for writing `create<State>()(...)` instead of `create(...)`.
@@ -572,7 +572,7 @@ export const useBearStore = create<MyState>()(
 )
 ```
 
-### How do I use it with Map and Set?
+### How do I use it with Map and Set
 
 With the previous persist API, you would use `serialize`/`deserialize`
 to deal with `Map` and `Set` and convert them into


### PR DESCRIPTION
## Summary

I've found it by accident.
The issue is that there is different behavior on Github
and Next.js when linking sections with special characters like `?`
in a single Markdown file.
Incidentally, in VSCode, both links with question marks and without them work.

That's why I propose dropping the question marks in headings
to avoid broken links [like this one in Hydration and async storages section](https://docs.pmnd.rs/zustand/integrations/persisting-store-data#hydration-and-asynchronous-storages),
which points to [this section](https://docs.pmnd.rs/zustand/integrations/persisting-store-data#how-can-i-check-if-my-store-has-been-hydrated?).

Another issue is that the `?` sign is special in URIs.
I don't know if it could break anything, but my inner future self
wants to avoid potential hard-to-debug issues like that.

There are also question marks in headings in `recipes.mdx` and `readme.md`,
but they are crucial for the meaning and the tone of those headings,
and are not linked anywhere I looked.

An example:

```md
# Example

[link to why which works on Github](#why)

[link to why which works on Next.js](#why?)

## Why?

Markdown implementations, why?
```

## Check List

- [x] `yarn run prettier` for formatting code and docs
