### PR TITLE
Fix Jest example's usage of default imports

### DIFF
--- a/docs/guides/testing.mdx
+++ b/docs/guides/testing.mdx
@@ -50,11 +50,11 @@ const storeResetFns = new Set<() => void>()
 
 // when creating a store, we get its initial state, create a reset function and add it in the set
 export const create = <S>(createState: StateCreator<S>) => {
-    const store = actualCreate(createState)
-    const initialState = store.getState()
-    storeResetFns.add(() => store.setState(initialState, true))
-    return store
-  }
+  const store = actualCreate(createState)
+  const initialState = store.getState()
+  storeResetFns.add(() => store.setState(initialState, true))
+  return store
+}
 
 // Reset all stores after each test run
 beforeEach(() => {

--- a/docs/guides/testing.mdx
+++ b/docs/guides/testing.mdx
@@ -12,7 +12,7 @@ Thus, there can be cases where the state of one test can affect another. To make
 
 ```jsx
 import { create as actualCreate } from 'zustand'
-// import { create as actualCreate } from 'zustand' // if using jest
+// const { create: actualCreate } = jest.requireActual('zustand') // if using jest
 import { act } from 'react-dom/test-utils'
 
 // a variable to hold reset functions for all stores declared in the app
@@ -42,7 +42,9 @@ If you are using zustand, as documented in [TypeScript Guide](./typescript.md), 
 
 ```typescript
 import { create as actualCreate, StateCreator } from 'zustand'
-// import { create as actualCreate } from 'zustand' // if using jest
+// if using Jest:
+// import { StateCreator } from 'zustand';
+// const { create: actualCreate } = jest.requireActual<typeof import('zustand')>('zustand');
 import { act } from 'react-dom/test-utils'
 
 // a variable to hold reset functions for all stores declared in the app
@@ -68,7 +70,7 @@ You should use the following code in the `__mocks__/zustand.js` file (the `__moc
 
 ```js
 import { act } from '@testing-library/react-native'
-import { create as actualCreate } from 'zustand'
+const { create: actualCreate } = jest.requireActual('zustand')
 
 // a variable to hold reset functions for all stores declared in the app
 const storeResetFns = new Set()

--- a/docs/guides/testing.mdx
+++ b/docs/guides/testing.mdx
@@ -12,7 +12,7 @@ Thus, there can be cases where the state of one test can affect another. To make
 
 ```jsx
 import { create as actualCreate } from 'zustand'
-// const { create: actualCreate } = jest.requireActual('zustand') // if using jest
+// import { create as actualCreate } from 'zustand' // if using jest
 import { act } from 'react-dom/test-utils'
 
 // a variable to hold reset functions for all stores declared in the app
@@ -42,7 +42,7 @@ If you are using zustand, as documented in [TypeScript Guide](./typescript.md), 
 
 ```tsx
 import { create as actualCreate, StateCreator } from 'zustand'
-// const { create: actualCreate } = jest.requireActual('zustand') // if using jest
+// import { create as actualCreate } from 'zustand' // if using jest
 import { act } from 'react-dom/test-utils'
 
 // a variable to hold reset functions for all stores declared in the app
@@ -70,7 +70,7 @@ You should use the following code in the `__mocks__/zustand.js` file (the `__moc
 
 ```js
 import { act } from '@testing-library/react-native'
-const { create: actualCreate } = jest.requireActual('zustand')
+import { create as actualCreate } from 'zustand'
 
 // a variable to hold reset functions for all stores declared in the app
 const storeResetFns = new Set()

--- a/docs/guides/testing.mdx
+++ b/docs/guides/testing.mdx
@@ -12,7 +12,7 @@ Thus, there can be cases where the state of one test can affect another. To make
 
 ```jsx
 import { create as actualCreate } from 'zustand'
-// const actualCreate = jest.requireActual('zustand') // if using jest
+// const { create: actualCreate } = jest.requireActual('zustand') // if using jest
 import { act } from 'react-dom/test-utils'
 
 // a variable to hold reset functions for all stores declared in the app
@@ -42,7 +42,7 @@ If you are using zustand, as documented in [TypeScript Guide](./typescript.md), 
 
 ```tsx
 import { create as actualCreate, StateCreator } from 'zustand'
-// const actualCreate = jest.requireActual('zustand') // if using jest
+// const { create: actualCreate } = jest.requireActual('zustand') // if using jest
 import { act } from 'react-dom/test-utils'
 
 // a variable to hold reset functions for all stores declared in the app
@@ -70,14 +70,14 @@ You should use the following code in the `__mocks__/zustand.js` file (the `__moc
 
 ```js
 import { act } from '@testing-library/react-native'
-const actualCreate = jest.requireActual('zustand')
+const { create: actualCreate } = jest.requireActual('zustand')
 
 // a variable to hold reset functions for all stores declared in the app
 const storeResetFns = new Set()
 
 // when creating a store, we get its initial state, create a reset function and add it in the set
-const create = (createState) => {
-  const store = actualCreate.default(createState)
+export const create = (createState) => {
+  const store = actualCreate(createState)
   const initialState = store.getState()
   storeResetFns.add(() => {
     store.setState(initialState, true)
@@ -93,8 +93,6 @@ beforeEach(async () => {
     })
   )
 })
-
-export default create
 ```
 
 If the `jest.config.js` has `automock: false`, then you need to do the following in `jest.setup.js`:

--- a/docs/guides/testing.mdx
+++ b/docs/guides/testing.mdx
@@ -40,7 +40,7 @@ In [jest](https://jestjs.io/), you can create a `__mocks__/zustand.js` and place
 
 If you are using zustand, as documented in [TypeScript Guide](./typescript.md), use the following code:
 
-```tsx
+```typescript
 import { create as actualCreate, StateCreator } from 'zustand'
 // import { create as actualCreate } from 'zustand' // if using jest
 import { act } from 'react-dom/test-utils'
@@ -49,10 +49,8 @@ import { act } from 'react-dom/test-utils'
 const storeResetFns = new Set<() => void>()
 
 // when creating a store, we get its initial state, create a reset function and add it in the set
-export const create =
-  () =>
-  <S,>(createState: StateCreator<S>) => {
-    const store = actualCreate<S>(createState)
+export const create = <S>(createState: StateCreator<S>) => {
+    const store = actualCreate(createState)
     const initialState = store.getState()
     storeResetFns.add(() => store.setState(initialState, true))
     return store


### PR DESCRIPTION
## Related Issues or Discussions

Inspired by #559

## Summary
Default exports and imports are deprecated. The default import of `zustand` generates a deprecation warning on the console. The default export that was suggested previously would actually fail to compile. See the comments at the very bottom of #559 for further discussion.

This commit fixes the example in the documentation by introducing named exports & imports instead of default exports & imports.


## Check List

- [x] `yarn run prettier` for formatting code and docs
