### PR TITLE
feat(middleware/persist): add skip hydration option #405

### DIFF
--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -272,7 +272,7 @@ By default the store with be hydrated on initialization.
 In some applications you may need to control when the first hydration occurs.
 For example, in server-rendered apps.
 
-If you set `skipHydration` the initial call for hydration isn't called,
+If you set `skipHydration`, the initial call for hydration isn't called,
 and it is left up to you to manually call `reHydrate()`.
 
 ```ts

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -269,7 +269,8 @@ export const useBoundStore = create(
 
 By default the store with be hydrated on initialization.
 
-In some applications you may need to control when the first hydration occurs. For example in server rendered apps.
+In some applications you may need to control when the first hydration occurs.
+For example, in server-rendered apps.
 
 If you set `skipHydration` the initial call for hydration isn't called,
 and it is left up to you to manually call `reHydrate()`.

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -261,6 +261,49 @@ export const useBoundStore = create(
 )
 ```
 
+### `skipHydration`
+
+> Type: `boolean | undefined`
+
+> Default: `undefined`
+
+By default the store with be hydrated on initialization.
+
+In some applications you may need to control when the first hydration occurs. For example in server rendered apps.
+
+If you set `skipHydration` the initial call for hydration isn't called,
+and it is left up to you to manually call `reHydrate()`.
+
+```ts
+export const useBoundStore = create(
+  persist(
+    () => ({
+      count: 0,
+      // ...
+    }),
+    {
+      // ...
+      skipHydration: true,
+    }
+  )
+)
+```
+
+```tsx
+export function StoreConsumer(){
+  const store = useBoundStore();
+
+  // hydrate persisted store after on mount
+  useEffect(() => {
+    store.persist.reHydrate();
+  }, [])
+
+  return (
+    //...
+  )
+}
+```
+
 ## API
 
 > Version: >=3.6.3

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -126,7 +126,7 @@ export interface PersistOptions<S, PersistedState = S> {
    *
    * This is useful in SSR application.
    *
-   * @default undefined
+   * @default false
    */
   skipHydration?: boolean
 }

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -121,11 +121,14 @@ export interface PersistOptions<S, PersistedState = S> {
   merge?: (persistedState: unknown, currentState: S) => S
 
   /**
-   * A boolean that will prevent the persist middleware automatically triggering hydration on initialization,
-   * This allows you to call the rehydrate function at a specific point in your apps rendering life-cycle.
-   * This is useful in SSR applications and mobile applications for example.
+   * An optional boolean that will prevent the persist middleware from triggering hydration on initialization,
+   * This allows you to call `rehydrate()` at a specific point in your apps rendering life-cycle.
+   *
+   * This is useful in SSR applications, or if you need to check for user permission first for example.
+   *
+   * @default undefined hydration will run automatically.
    */
-  manualHydration?: boolean
+  skipHydration?: boolean
 }
 
 type PersistListener<S> = (state: S) => void
@@ -349,9 +352,7 @@ const oldImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
     },
   }
 
-  if (!options.manualHydration) {
-    hydrate()
-  }
+  hydrate()
 
   return stateFromStorage || configResult
 }
@@ -500,7 +501,7 @@ const newImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
     },
   }
 
-  if (!options.manualHydration) {
+  if (!options.skipHydration) {
     hydrate()
   }
 

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -124,9 +124,9 @@ export interface PersistOptions<S, PersistedState = S> {
    * An optional boolean that will prevent the persist middleware from triggering hydration on initialization,
    * This allows you to call `rehydrate()` at a specific point in your apps rendering life-cycle.
    *
-   * This is useful in SSR applications, or if you need to check for user permission first for example.
+   * This is useful in SSR application.
    *
-   * @default undefined hydration will run automatically.
+   * @default undefined
    */
   skipHydration?: boolean
 }

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -119,6 +119,13 @@ export interface PersistOptions<S, PersistedState = S> {
    * By default, this function does a shallow merge.
    */
   merge?: (persistedState: unknown, currentState: S) => S
+
+  /**
+   * A boolean that will prevent the persist middleware automatically triggering hydration on initialization,
+   * This allows you to call the rehydrate function at a specific point in your apps rendering life-cycle.
+   * This is useful in SSR applications and mobile applications for example.
+   */
+  manualHydration?: boolean
 }
 
 type PersistListener<S> = (state: S) => void
@@ -342,7 +349,9 @@ const oldImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
     },
   }
 
-  hydrate()
+  if (!options.manualHydration) {
+    hydrate()
+  }
 
   return stateFromStorage || configResult
 }
@@ -491,7 +500,9 @@ const newImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
     },
   }
 
-  hydrate()
+  if (!options.manualHydration) {
+    hydrate()
+  }
 
   return stateFromStorage || configResult
 }

--- a/tests/persistSync.test.tsx
+++ b/tests/persistSync.test.tsx
@@ -548,4 +548,55 @@ describe('persist middleware with sync configuration', () => {
     expect(onFinishHydrationSpy1).not.toBeCalledTimes(2)
     expect(onFinishHydrationSpy2).toBeCalledWith({ count: 2 })
   })
+
+  it('can skip initial hydration', async () => {
+    const storage = {
+      getItem: (name: string) => ({
+        state: { count: 42, name },
+        version: 0,
+      }),
+      setItem: () => {},
+      removeItem: () => {},
+    }
+
+    const onRehydrateStorageSpy = jest.fn()
+    const useBoundStore = create(
+      persist(
+        () => ({
+          count: 0,
+          name: 'empty',
+        }),
+        {
+          name: 'test-storage',
+          storage: storage,
+          onRehydrateStorage: () => onRehydrateStorageSpy,
+          skipHydration: true,
+        }
+      )
+    )
+
+    expect(useBoundStore.getState()).toEqual({
+      count: 0,
+      name: 'empty',
+    })
+
+    // Because `skipHydration` is only in newImpl and the hydration function for newImpl is now a promise
+    // In the default case we would need to await `onFinishHydration` to assert the auto hydration has completed
+    // As we are testing the skip hydration case we await nextTick, to make sure the store is initialised
+    await new Promise((resolve) => process.nextTick(resolve))
+
+    // Asserting store hasn't hydrated from nextTick
+    expect(useBoundStore.persist.hasHydrated()).toBe(false)
+
+    await useBoundStore.persist.rehydrate()
+
+    expect(useBoundStore.getState()).toEqual({
+      count: 42,
+      name: 'test-storage',
+    })
+    expect(onRehydrateStorageSpy).toBeCalledWith(
+      { count: 42, name: 'test-storage' },
+      undefined
+    )
+  })
 })


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #405

## Summary

Add `skipHydration` boolean to persist options. This allows the developer to control when the persist middleware will hydate manually.

## Check List

- [x] `yarn run prettier` for formatting code and docs
