### PR TITLE
feat: add `useHydration` hook

### DIFF
--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -414,7 +414,34 @@ in the [FAQ](#faq) section below.
 
 There are a few different ways to do this.
 
-You can use the [`onRehydrateStorage`](#onrehydratestorage)
+You can use the `useHydration` hook:
+
+```ts
+const useBoundStore = create(
+  persist(
+    (set, get) => ({
+      // ...
+    }),
+    {
+      // ...
+    }
+  )
+);
+
+export default function App() {
+  const hasHydrated = useHydration(useBoundStore);
+
+  if (!hasHydrated) {
+    return <p>Loading...</p>
+  }
+
+  return (
+    // ...
+  );
+}
+```
+
+You can also use the [`onRehydrateStorage`](#onrehydratestorage)
 listener function to update a field in the store:
 
 ```ts
@@ -448,33 +475,6 @@ export default function App() {
   return (
     // ...
   );
-}
-```
-
-You can also create a custom `useHydration` hook:
-
-```ts
-const useBoundStore = create(persist(...))
-
-const useHydration = () => {
-  const [hydrated, setHydrated] = useState(useBoundStore.persist.hasHydrated)
-
-  useEffect(() => {
-    // Note: This is just in case you want to take into account manual rehydration.
-    // You can remove the following line if you don't need it.
-    const unsubHydrate = useBoundStore.persist.onHydrate(() => setHydrated(false))
-
-    const unsubFinishHydration = useBoundStore.persist.onFinishHydration(() => setHydrated(true))
-
-    setHydrated(useBoundStore.persist.hasHydrated())
-
-    return () => {
-      unsubHydrate()
-      unsubFinishHydration()
-    }
-  }, [])
-
-  return hydrated
 }
 ```
 

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -123,7 +123,7 @@ export interface PersistOptions<S, PersistedState = S> {
 
 type PersistListener<S> = (state: S) => void
 
-type StorePersist<S, Ps> = {
+export type StorePersist<S, Ps> = {
   persist: {
     setOptions: (options: Partial<PersistOptions<S, Ps>>) => void
     clearStorage: () => void
@@ -528,7 +528,7 @@ declare module '../vanilla' {
   }
 }
 
-type Write<T, U> = Omit<T, keyof U> & U
+export type Write<T, U> = Omit<T, keyof U> & U
 
 type WithPersist<S, A> = S extends { getState: () => infer T }
   ? Write<S, StorePersist<T, A>>


### PR DESCRIPTION
## Related Issues or Discussions

## Summary
While checking if my store has been hydrateed [here](https://github.com/pmndrs/zustand/blob/main/docs/integrations/persisting-store-data.md#how-can-i-check-if-my-store-has-been-hydrated) I though that it'll cool idea to have `useHydration` to all stores, to don't create for every store `useHydration` hook inside codebase.

## Check List

- [x] `yarn run prettier` for formatting code and docs