### PR TITLE
fix: add explicity export paths for cjs

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -86,7 +86,13 @@ function createCommonJSConfig(input, output, options) {
       format: 'cjs',
       esModule: false,
       outro: options.addModuleExport
-        ? ';(module.exports = (exports && exports.default) || {}),\n  Object.assign(module.exports, exports)'
+        ? [
+            `module.exports = ${options.addModuleExport.default};`,
+            ...Object.entries(options.addModuleExport)
+              .filter(([key]) => key !== 'default')
+              .map(([key, value]) => `module.exports.${key} = ${value};`),
+            `exports.default = module.exports;`,
+          ].join('\n')
         : '',
     },
     external,
@@ -180,7 +186,11 @@ module.exports = function (args) {
   return [
     ...(c === 'index' ? [createDeclarationConfig(`src/${c}.ts`, 'dist')] : []),
     createCommonJSConfig(`src/${c}.ts`, `dist/${c}`, {
-      addModuleExport: ['index', 'vanilla', 'shallow'].includes(c),
+      addModuleExport: {
+        index: { default: 'react', create: 'create', useStore: 'useStore' },
+        vanilla: { default: 'vanilla', createStore: 'createStore' },
+        shallow: { default: 'shallow', shallow: 'shallow' },
+      }[c],
     }),
     createESMConfig(`src/${c}.ts`, `dist/esm/${c}.js`),
     createESMConfig(`src/${c}.ts`, `dist/esm/${c}.mjs`),


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #1563 

## Summary

Manually adds a set of `module.exports` for each file that needs a the CJS patch for exports. 
This is temporary and will be removed once zustand's API are all named instead of mixed.


## Check List

- [x] `yarn run prettier` for formatting code and docs
