### PR TITLE
fix: re-export createStore from index

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -193,7 +193,12 @@ module.exports = function (args) {
     ...(c === 'index' ? [createDeclarationConfig(`src/${c}.ts`, 'dist')] : []),
     createCommonJSConfig(`src/${c}.ts`, `dist/${c}`, {
       addModuleExport: {
-        index: { default: 'react', create: 'create', useStore: 'useStore' },
+        index: {
+          default: 'react',
+          create: 'create',
+          useStore: 'useStore',
+          createStore: 'exports.createStore',
+        },
         vanilla: { default: 'vanilla', createStore: 'createStore' },
         shallow: { default: 'shallow$1', shallow: 'shallow' },
       }[c],


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #1659

## Summary
@barelyhuman forgot to export `createStore` from the index and it caused a breaking change with code like this (after transpiled to CJS).
```js
import { createStore, useStore } from 'zustand'
```

## Check List

- [x] `yarn run prettier` for formatting code and docs
