### PR TITLE
fix: typo in shallow.ts

### DIFF
--- a/src/shallow.ts
+++ b/src/shallow.ts
@@ -54,7 +54,7 @@ export function shallow<T>(objA: T, objB: T) {
 export default ((objA, objB) => {
   if (import.meta.env?.MODE !== 'production') {
     console.warn(
-      "[DEPRECATED] Default export is deprecated. Instead use `import { create } from 'zustand/shallow'`."
+      "[DEPRECATED] Default export is deprecated. Instead use `import { shallow } from 'zustand/shallow'`."
     )
   }
   return shallow(objA, objB)


### PR DESCRIPTION
## Summary

Fix typo in `zustand/shallow` deprecation warning.

## Check List

- [x] `yarn run prettier` for formatting code and docs
