### PR TITLE
refactor(types): add readonly store and refine useStore typing

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -7,6 +7,7 @@ import useSyncExternalStoreExports from 'use-sync-external-store/shim/with-selec
 import { createStore } from './vanilla'
 import type {
   Mutate,
+  ReadOnlyStoreApi,
   StateCreator,
   StoreApi,
   StoreMutatorIdentifier,
@@ -16,15 +17,15 @@ const { useSyncExternalStoreWithSelector } = useSyncExternalStoreExports
 
 type ExtractState<S> = S extends { getState: () => infer T } ? T : never
 
-type WithReact<S extends StoreApi<unknown>> = S & {
+type WithReact<S extends ReadOnlyStoreApi<unknown>> = S & {
   getServerState?: () => ExtractState<S>
 }
 
-export function useStore<S extends WithReact<StoreApi<unknown>>>(
+export function useStore<S extends WithReact<ReadOnlyStoreApi<unknown>>>(
   api: S
 ): ExtractState<S>
 
-export function useStore<S extends WithReact<StoreApi<unknown>>, U>(
+export function useStore<S extends WithReact<ReadOnlyStoreApi<unknown>>, U>(
   api: S,
   selector: (state: ExtractState<S>) => U,
   equalityFn?: (a: U, b: U) => boolean

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -5,10 +5,13 @@ type SetStateInternal<T> = {
   ): void
 }['_']
 
-export interface StoreApi<T> {
-  setState: SetStateInternal<T>
+export interface ReadOnlyStoreApi<T> {
   getState: () => T
   subscribe: (listener: (state: T, prevState: T) => void) => () => void
+}
+
+export interface StoreApi<T> extends ReadOnlyStoreApi<T> {
+  setState: SetStateInternal<T>
   /**
    * @deprecated Use `unsubscribe` returned by `subscribe`
    */

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -1,6 +1,7 @@
 import { expect, it } from '@jest/globals'
 import { create } from 'zustand'
 import type {
+  ReadOnlyStoreApi,
   StateCreator,
   StoreApi,
   StoreMutatorIdentifier,
@@ -82,7 +83,8 @@ it('can use exposed types', () => {
     _destroy: StoreApi<ExampleState>['destroy'],
     _equalityFn: (a: ExampleState, b: ExampleState) => boolean,
     _stateCreator: StateCreator<ExampleState>,
-    _useBoundStore: UseBoundStore<StoreApi<ExampleState>>
+    _useBoundStore: UseBoundStore<StoreApi<ExampleState>>,
+    _readonlyStoreApi: ReadOnlyStoreApi<ExampleState>
   ) {
     expect(true).toBeTruthy()
   }
@@ -99,7 +101,8 @@ it('can use exposed types', () => {
     storeApi.destroy,
     equalityFn,
     stateCreator,
-    useBoundStore
+    useBoundStore,
+    { getState: storeApi.getState, subscribe: storeApi.subscribe }
   )
 })
 


### PR DESCRIPTION
## Related Issues or Discussions

https://github.com/pmndrs/zustand/pull/1589

Fixes #

Allows the creation of read only zustand stores compatible with `useStore`.

## Use case

I'm developing a library and I wanted to expose a read only zustand store.
I've created a function called `asReadOnly` to create a zustand store without `destroy` and `setState`.

Unfortunately I couldn't make it work with `useStore` so I had to come up with a workaround (`useSelector`).
I'd like to remove `useSelector`  from `asReadOnly` output and use `useStore` without having type issues.

### asReadOnly

```ts
import { useStore } from 'zustand'
import type { StoreApi } from 'zustand'

type Tail<Arr extends any[]> = Arr extends readonly [unknown, ...infer Rest] ? Rest : never

export function asReadOnly<State>({ getState, subscribe }: StoreApi<State>) {
  return {
    getState,
    subscribe,
    useSelector: ((...args: Tail<Parameters<typeof useStore>>) => useStore(store, ...args))
}
```

### asReadOnly usage

```ts
import { asReadOnly } from '../store'
import { createStore, StoreApi } from 'zustand'

describe('asReadOnly', () => {
  it('creates a readonly version of input store', () => {
    const writableStore = createStore(() => ({ a: 2, b: 3, c: 4, d: 5 }))
    const readonlyStore = asReadOnly(writableStore)

    expect(readonlyStore).not.toHaveProperty('setState')
    expect(writableStore.getState()).toBe(readonlyStore.getState())

    writableStore.setState({ a: 1 })
    expect(writableStore.getState().a).toBe(1)
    expect(readonlyStore.getState().a).toBe(1)
  })
})
```

## Summary

1. Adds `ReadOnlyStoreApi` a subset of StoreApi that can be used to type read only versions of zustand stores.
2. Refines useStore typings.
3. Adds ReadOnlyStoreApi to `checkTypes(...)`.

## Check List

- [x] `yarn run prettier` for formatting code and docs
