### PR TITLE
fix(doc): update state-with-url-hash demo

### DIFF
--- a/docs/guides/connect-to-state-with-url-hash.md
+++ b/docs/guides/connect-to-state-with-url-hash.md
@@ -14,8 +14,8 @@ import { persist, StateStorage, createJSONStorage } from 'zustand/middleware'
 const hashStorage: StateStorage = {
   getItem: (key): string => {
     const searchParams = new URLSearchParams(location.hash.slice(1))
-    const storedValue = searchParams.get(key)
-    return storedValue ? JSON.parse(storedValue) : ''
+    const storedValue = searchParams.get(key) ?? ''
+    return storedValue
   },
   setItem: (key, newValue): void => {
     const searchParams = new URLSearchParams(location.hash.slice(1))
@@ -45,4 +45,4 @@ export const useBoundStore = create(
 
 ## CodeSandbox Demo
 
-[https://codesandbox.io/s/silly-fire-gsjbc7?file=/src/App.tsx](https://codesandbox.io/s/zustand-state-with-url-hash-demo-pn20n5?file=/src/store/index.ts:1182-1227)
+https://codesandbox.io/s/zustand-state-with-url-hash-demo-pn20n5?file=/src/store/index.ts

--- a/docs/guides/connect-to-state-with-url-hash.md
+++ b/docs/guides/connect-to-state-with-url-hash.md
@@ -9,13 +9,13 @@ If you want to connect state of a store to URL hash, you can create your own has
 
 ```ts
 import { create } from 'zustand'
-import { persist, StateStorage } from 'zustand/middleware'
+import { persist, StateStorage, createJSONStorage } from 'zustand/middleware'
 
 const hashStorage: StateStorage = {
   getItem: (key): string => {
     const searchParams = new URLSearchParams(location.hash.slice(1))
     const storedValue = searchParams.get(key)
-    return JSON.parse(storedValue)
+    return storedValue ? JSON.parse(storedValue) : ''
   },
   setItem: (key, newValue): void => {
     const searchParams = new URLSearchParams(location.hash.slice(1))
@@ -37,7 +37,7 @@ export const useBoundStore = create(
     }),
     {
       name: 'food-storage', // unique name
-      getStorage: () => hashStorage,
+      storage: createJSONStorage(() => hashStorage),
     }
   )
 )
@@ -45,4 +45,4 @@ export const useBoundStore = create(
 
 ## CodeSandbox Demo
 
-https://codesandbox.io/s/silly-fire-gsjbc7?file=/src/App.tsx
+[https://codesandbox.io/s/silly-fire-gsjbc7?file=/src/App.tsx](https://codesandbox.io/s/zustand-state-with-url-hash-demo-pn20n5?file=/src/store/index.ts:1182-1227)


### PR DESCRIPTION
## Related Issues or Discussions

The old demo in connect-to-state-with-url-hash.md is not available.

## Summary

I have written a new demo.

## Check List

- [x] `yarn run prettier` for formatting code and docs
