### PR TITLE
fix(middleware/persist): ensure `persist` does not drop updates in `onRehydrateStorage` when using a synchronous storage API

### DIFF
--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -449,6 +449,11 @@ const newImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
         return setItem()
       })
       .then(() => {
+        // TODO: In the asynchronous case, it's possible that the state has changed
+        // since it was set in the prior callback. As such, it would be better to
+        // pass 'get()' to the 'postRehydrationCallback' to ensure the most up-to-date
+        // state is used. However, this could be a breaking change, so this isn't being
+        // done now.
         postRehydrationCallback?.(stateFromStorage, undefined)
         hasHydrated = true
         finishHydrationListeners.forEach((cb) => cb(stateFromStorage as S))

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -455,6 +455,13 @@ const newImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
         // state is used. However, this could be a breaking change, so this isn't being
         // done now.
         postRehydrationCallback?.(stateFromStorage, undefined)
+
+        // It's possible that 'postRehydrationCallback' updated the state. To ensure
+        // that isn't overwritten when returning 'stateFromStorage' below
+        // (synchronous-case only), update 'stateFromStorage' to point to the latest
+        // state. In the asynchronous case, 'stateFromStorage' isn't used after this
+        // callback, so there's no harm in updating it to match the latest state.
+        stateFromStorage = get()
         hasHydrated = true
         finishHydrationListeners.forEach((cb) => cb(stateFromStorage as S))
       })

--- a/tests/persistAsync.test.tsx
+++ b/tests/persistAsync.test.tsx
@@ -611,6 +611,7 @@ describe('persist middleware with async configuration', () => {
       { count: 42, name: 'test-storage' },
       undefined
     )
+  })
 
   it('handles state updates during onRehydrateStorage', async () => {
     const storage = {

--- a/tests/persistAsync.test.tsx
+++ b/tests/persistAsync.test.tsx
@@ -561,4 +561,40 @@ describe('persist middleware with async configuration', () => {
     await useBoundStore.persist.rehydrate()
     expect(useBoundStore.persist.hasHydrated()).toBe(true)
   })
+
+  it('handles state updates during onRehydrateStorage', async () => {
+    const storage = {
+      getItem: async () => JSON.stringify({ state: { count: 1 } }),
+      setItem: () => {},
+      removeItem: () => {},
+    }
+
+    const useBoundStore = create<{ count: number; inc: () => void }>()(
+      persist(
+        (set) => ({
+          count: 0,
+          inc: () => set((s) => ({ count: s.count + 1 })),
+        }),
+        {
+          name: 'test-storage',
+          storage: createJSONStorage(() => storage),
+          onRehydrateStorage: () => (s) => s?.inc(),
+        }
+      )
+    )
+
+    function Counter() {
+      const { count } = useBoundStore()
+      return <div>count: {count}</div>
+    }
+
+    const { findByText } = render(
+      <StrictMode>
+        <Counter />
+      </StrictMode>
+    )
+
+    await findByText('count: 2')
+    expect(useBoundStore.getState().count).toEqual(2)
+  })
 })

--- a/tests/persistSync.test.tsx
+++ b/tests/persistSync.test.tsx
@@ -598,6 +598,7 @@ describe('persist middleware with sync configuration', () => {
       { count: 42, name: 'test-storage' },
       undefined
     )
+  })
 
   it('handles state updates during onRehydrateStorage', () => {
     const storage = {

--- a/tests/persistSync.test.tsx
+++ b/tests/persistSync.test.tsx
@@ -548,4 +548,28 @@ describe('persist middleware with sync configuration', () => {
     expect(onFinishHydrationSpy1).not.toBeCalledTimes(2)
     expect(onFinishHydrationSpy2).toBeCalledWith({ count: 2 })
   })
+
+  it('handles state updates during onRehydrateStorage', () => {
+    const storage = {
+      getItem: () => JSON.stringify({ state: { count: 1 } }),
+      setItem: () => {},
+      removeItem: () => {},
+    }
+
+    const useBoundStore = create<{ count: number; inc: () => void }>()(
+      persist(
+        (set) => ({
+          count: 0,
+          inc: () => set((s) => ({ count: s.count + 1 })),
+        }),
+        {
+          name: 'test-storage',
+          storage: createJSONStorage(() => storage),
+          onRehydrateStorage: () => (s) => s?.inc(),
+        }
+      )
+    )
+
+    expect(useBoundStore.getState().count).toEqual(2)
+  })
 })

--- a/tests/persistSync.test.tsx
+++ b/tests/persistSync.test.tsx
@@ -549,7 +549,6 @@ describe('persist middleware with sync configuration', () => {
     expect(onFinishHydrationSpy2).toBeCalledWith({ count: 2 })
   })
 
-
   it('can skip initial hydration', async () => {
     const storage = {
       getItem: (name: string) => ({


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #1688

## Summary

See #1688 for a detailed description of the problem. This PR resolves the issue by ensuring `stateFromStorage` gets updated to the most recent value. I also added tests verifying this update pattern works for both synchronous and asynchronous storage APIs.

One note for reviewers: I added a comment describing how, in the asynchronous case, it's possible that the state passed to `postRehydrationCallback` is _not_ the most up-to-date state. This would occur if there was a state update between callbacks in the hydration promise chain. Please let me know if I should leave the comment as-is, make the change, or simply remove the comment.

## Check List

- [X] `yarn run prettier` for formatting code and docs
