### PR TITLE
fix(middleware/persist): ensure argument for `onRehydrateStorage` and `onHydrate` is defined on first hydration

### DIFF
--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -259,15 +259,14 @@ const oldImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
 
     // On the first invocation of 'hydrate', state will not yet be defined (this is
     // true for both the 'asynchronous' and 'synchronous' case). Pass 'configResult'
-    // as a backup so listeners and 'onRehydrateStorage' are called with the latest
-    // available state.
-    const currentState = get() ?? configResult
+    // as a backup  to 'get()' so listeners and 'onRehydrateStorage' are called with
+    // the latest available state.
 
     hasHydrated = false
-    hydrationListeners.forEach((cb) => cb(currentState))
+    hydrationListeners.forEach((cb) => cb(get() ?? configResult))
 
     const postRehydrationCallback =
-      options.onRehydrateStorage?.(currentState) || undefined
+      options.onRehydrateStorage?.(get() ?? configResult) || undefined
 
     // bind is used to avoid `TypeError: Illegal invocation` error
     return toThenable(storage.getItem.bind(storage))(options.name)
@@ -419,15 +418,14 @@ const newImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
 
     // On the first invocation of 'hydrate', state will not yet be defined (this is
     // true for both the 'asynchronous' and 'synchronous' case). Pass 'configResult'
-    // as a backup so listeners and 'onRehydrateStorage' are called with the latest
-    // available state.
-    const currentState = get() ?? configResult
+    // as a backup  to 'get()' so listeners and 'onRehydrateStorage' are called with
+    // the latest available state.
 
     hasHydrated = false
-    hydrationListeners.forEach((cb) => cb(currentState))
+    hydrationListeners.forEach((cb) => cb(get() ?? configResult))
 
     const postRehydrationCallback =
-      options.onRehydrateStorage?.(currentState) || undefined
+      options.onRehydrateStorage?.(get() ?? configResult) || undefined
 
     // bind is used to avoid `TypeError: Illegal invocation` error
     return toThenable(storage.getItem.bind(storage))(options.name)

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -257,11 +257,17 @@ const oldImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
   const hydrate = () => {
     if (!storage) return
 
+    // On the first invocation of 'hydrate', state will not yet be defined (this is
+    // true for both the 'asynchronous' and 'synchronous' case). Pass 'configResult'
+    // as a backup so listeners and 'onRehydrateStorage' are called with the latest
+    // available state.
+    const currentState = get() ?? configResult
+
     hasHydrated = false
-    hydrationListeners.forEach((cb) => cb(get()))
+    hydrationListeners.forEach((cb) => cb(currentState))
 
     const postRehydrationCallback =
-      options.onRehydrateStorage?.(get()) || undefined
+      options.onRehydrateStorage?.(currentState) || undefined
 
     // bind is used to avoid `TypeError: Illegal invocation` error
     return toThenable(storage.getItem.bind(storage))(options.name)
@@ -411,11 +417,17 @@ const newImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
   const hydrate = () => {
     if (!storage) return
 
+    // On the first invocation of 'hydrate', state will not yet be defined (this is
+    // true for both the 'asynchronous' and 'synchronous' case). Pass 'configResult'
+    // as a backup so listeners and 'onRehydrateStorage' are called with the latest
+    // available state.
+    const currentState = get() ?? configResult
+
     hasHydrated = false
-    hydrationListeners.forEach((cb) => cb(get()))
+    hydrationListeners.forEach((cb) => cb(currentState))
 
     const postRehydrationCallback =
-      options.onRehydrateStorage?.(get()) || undefined
+      options.onRehydrateStorage?.(currentState) || undefined
 
     // bind is used to avoid `TypeError: Illegal invocation` error
     return toThenable(storage.getItem.bind(storage))(options.name)

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -257,16 +257,11 @@ const oldImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
   const hydrate = () => {
     if (!storage) return
 
-    // On the first invocation of 'hydrate', state will not yet be defined (this is
-    // true for both the 'asynchronous' and 'synchronous' case). Pass 'configResult'
-    // as a backup  to 'get()' so listeners and 'onRehydrateStorage' are called with
-    // the latest available state.
-
     hasHydrated = false
-    hydrationListeners.forEach((cb) => cb(get() ?? configResult))
+    hydrationListeners.forEach((cb) => cb(get()))
 
     const postRehydrationCallback =
-      options.onRehydrateStorage?.(get() ?? configResult) || undefined
+      options.onRehydrateStorage?.(get()) || undefined
 
     // bind is used to avoid `TypeError: Illegal invocation` error
     return toThenable(storage.getItem.bind(storage))(options.name)

--- a/tests/persistAsync.test.tsx
+++ b/tests/persistAsync.test.tsx
@@ -385,7 +385,7 @@ describe('persist middleware with async configuration', () => {
     })
   })
 
-  it('passes the latest state to onRehydrateStorage', async () => {
+  it('passes the latest state to onRehydrateStorage and onHydrate on first hydrate', async () => {
     const onRehydrateStorageSpy =
       jest.fn<<S>(s: S) => (s?: S, e?: unknown) => void>()
 
@@ -402,6 +402,18 @@ describe('persist middleware with async configuration', () => {
         onRehydrateStorage: onRehydrateStorageSpy,
       })
     )
+
+    /**
+     * NOTE: It's currently not possible to add an 'onHydrate' listener which will be
+     * invoked prior to the first hydration. This is because, during first hydration,
+     * the 'onHydrate' listener set (which will be empty) is evaluated before the
+     * 'persist' API is exposed to the caller of 'create'/'createStore'.
+     *
+     * const onHydrateSpy = jest.fn()
+     * useBoundStore.persist.onHydrate(onHydrateSpy)
+     * ...
+     * await waitFor(() => expect(onHydrateSpy).toBeCalledWith({ count: 0 }))
+     */
 
     function Counter() {
       const { count } = useBoundStore()

--- a/tests/persistSync.test.tsx
+++ b/tests/persistSync.test.tsx
@@ -226,7 +226,7 @@ describe('persist middleware with sync configuration', () => {
     )
   })
 
-  it('passes the latest state to onRehydrateStorage', () => {
+  it('passes the latest state to onRehydrateStorage and onHydrate on first hydrate', () => {
     const onRehydrateStorageSpy =
       jest.fn<<S>(s: S) => (s?: S, e?: unknown) => void>()
 
@@ -244,8 +244,19 @@ describe('persist middleware with sync configuration', () => {
       })
     )
 
-    // The 'onRehydrateStorage' spy is invoked prior to rehydration, so it should
-    // be passed the default state.
+    /**
+     * NOTE: It's currently not possible to add an 'onHydrate' listener which will be
+     * invoked prior to the first hydration. This is because, during first hydration,
+     * the 'onHydrate' listener set (which will be empty) is evaluated before the
+     * 'persist' API is exposed to the caller of 'create'/'createStore'.
+     *
+     * const onHydrateSpy = jest.fn()
+     * useBoundStore.persist.onHydrate(onHydrateSpy)
+     * expect(onHydrateSpy).toBeCalledWith({ count: 0 })
+     */
+
+    // The 'onRehydrateStorage' and 'onHydrate' spies are invoked prior to rehydration,
+    // so they should both be passed the default state.
     expect(onRehydrateStorageSpy).toBeCalledWith({ count: 0 })
     expect(useBoundStore.getState()).toEqual({ count: 1 })
   })

--- a/tests/persistSync.test.tsx
+++ b/tests/persistSync.test.tsx
@@ -226,6 +226,30 @@ describe('persist middleware with sync configuration', () => {
     )
   })
 
+  it('passes the latest state to onRehydrateStorage', () => {
+    const onRehydrateStorageSpy =
+      jest.fn<<S>(s: S) => (s?: S, e?: unknown) => void>()
+
+    const storage = {
+      getItem: () => JSON.stringify({ state: { count: 1 } }),
+      setItem: () => {},
+      removeItem: () => {},
+    }
+
+    const useBoundStore = create(
+      persist(() => ({ count: 0 }), {
+        name: 'test-storage',
+        storage: createJSONStorage(() => storage),
+        onRehydrateStorage: onRehydrateStorageSpy,
+      })
+    )
+
+    // The 'onRehydrateStorage' spy is invoked prior to rehydration, so it should
+    // be passed the default state.
+    expect(onRehydrateStorageSpy).toBeCalledWith({ count: 0 })
+    expect(useBoundStore.getState()).toEqual({ count: 1 })
+  })
+
   it('gives the merged state to onRehydrateStorage', () => {
     const onRehydrateStorageSpy = jest.fn()
 


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #1691

## Summary

This PR ensures that the argument passed to `onRehydrateStorage` and `onHydrate` is defined during the first hydration of a store. Instead of passing the result of `get()`, which will always be `undefined` before the first hydration, `get() ?? configResult` is passed. I also added tests validating that `onRehydrateStorage` is always passed a defined value for `state`.

One caveat is that it's actually _not possible_ to add an `onHydrate` listener which will be invoked prior to first hydration. As such, I can't test this case, but I've documented it in the test I added.

### Alternative Solution
An alternative solution would be to update the argument type signature of `onRehydrateStorage` and `onHydrate` and to `state?: S` instead of `state: S`, which reflects the potential for state to be `undefined`. This is probably not the right solution, however, as it both changes a public API and makes the `persist` API less useful.

## Check List

- [X] `yarn run prettier` for formatting code and docs
