### PR TITLE
Don't recommend memoizing selectors

### DIFF
--- a/docs/recipes/recipes.mdx
+++ b/docs/recipes/recipes.mdx
@@ -65,29 +65,6 @@ const currentBear = useCredentialsStore((state) => state.currentBear)
 const bear = useBearStore((state) => state.bears[currentBear])
 ```
 
-## Memoizing selectors
-
-It is generally recommended to memoize selectors with `useCallback`.
-This will prevent unnecessary computations each render.
-It also allows React to optimize performance in concurrent mode.
-
-```jsx
-const fruit = useStore(useCallback((state) => state.fruits[id], [id]))
-```
-
-If a selector doesn't depend on scope,
-you can define it outside the render function
-to obtain a fixed reference without `useCallback`.
-
-```jsx
-const selector = (state) => state.berries
-
-function Component() {
-  const berries = useStore(selector)
-  // ...
-}
-```
-
 ## Overwriting state
 
 The `set` function has a second argument, `false` by default.


### PR DESCRIPTION
## Related Issues or Discussions

- https://github.com/pmndrs/zustand/discussions/971 (This PR was requested [here](https://github.com/pmndrs/zustand/discussions/971#discussioncomment-5388443))
- https://github.com/pmndrs/zustand/discussions/658

## Summary

As per the discussions above, memoizing selectors does not improve performance significantly as of v4. Thus we should not recommend memoizing selectors.

Note that the same paragraph was removed from the README in https://github.com/pmndrs/zustand/pull/550 and this section may have been left behind as an oversight.

P. S. I wish the docs stated "selectors do not benefit significantly from memoization". I feel this doesn't belong in the Recipes page, though; perhaps a FAQ section is needed?

## Check List

- [x] `yarn run prettier` for formatting code and docs
