### PR TITLE
demo: add docs link to the demo page

### DIFF
--- a/examples/demo/src/components/Details.js
+++ b/examples/demo/src/components/Details.js
@@ -1,7 +1,10 @@
 export default function Details() {
   return (
     <>
-      <a href="https://github.com/pmndrs/zustand" className="top-right" children="Github" />
+      <nav className="nav">
+        <a href="https://docs.pmnd.rs/zustand" children="Documentation" />
+        <a href="https://github.com/pmndrs/zustand" children="Github" />
+      </nav>
       <div className="bottom">
         <a
           href="https://github.com/pmndrs/zustand/tree/main/examples/demo"

--- a/examples/demo/src/styles.css
+++ b/examples/demo/src/styles.css
@@ -372,10 +372,22 @@ a.top-left {
   left: 40px;
 }
 
-a.top-right {
-  top: 40px;
+.nav {
+  align-items: center;
+  display: flex;
+  gap: 16px;
+  justify-content: flex-end;
+  left: 40px;
+  min-height: 38px;
+  position: fixed;
   right: 40px;
+  top: 40px;
   z-index: 1000;
+}
+
+.nav a {
+  position: relative;
+  flex: 0 0 auto;
 }
 
 a.bottom-left {
@@ -415,11 +427,13 @@ a.bottom-right {
     left: 40px;
   }
 
-  a.top-right {
-    position: fixed;
-    top: 40px;
+  .nav {
+    justify-content: flex-start;
+    left: 40px;
     right: 40px;
+    top: 90px;
   }
+
   span.header-left {
     position: fixed;
     top: 30px;
@@ -440,9 +454,10 @@ a.bottom-right {
     left: 20px;
   }
 
-  a.top-right {
-    top: 20px;
+  .nav {
+    left: 20px;
     right: 20px;
+    top: 60px;
   }
 
   a.bottom-left {


### PR DESCRIPTION
## Related Issues or Discussions

Fixes # https://github.com/pmndrs/zustand/discussions/1733

## Summary

Add docs link on the demo page

## Check List

- [ ] `yarn run prettier` for formatting code and docs - not ran, not available on the demo page


Various breakpoints shown below. On smaller devices I've pushed it to the left under the logo. 
Note there is an existing issue where the Source and Credit link is pushed out of view on mobile devices. This doesn't address that (you can check prior to merging) 

![CleanShot 2023-04-06 at 23 53 35](https://user-images.githubusercontent.com/55621012/230400819-4ae82d3d-cb13-4b26-89ca-8457651ff767.png)

![CleanShot 2023-04-06 at 23 53 42](https://user-images.githubusercontent.com/55621012/230400825-bbbb1507-fc32-4ba3-9587-f2c980f6e073.png)

![CleanShot 2023-04-06 at 23 53 27](https://user-images.githubusercontent.com/55621012/230400786-4e4aab3b-2fc1-4432-babf-d13a4671b9b1.png)

