### PR TITLE
fix(docs): fixes ExtractState in TypeScript guide

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -455,7 +455,7 @@ const createBoundedUseStore = ((store) => (selector, equals) =>
   ): T
 }
 
-type ExtractState<S> = S extends { get: () => infer X } ? X : never
+type ExtractState<S> = S extends { getState: () => infer X } ? X : never
 
 const useBearStore = createBoundedUseStore(bearStore)
 ```


### PR DESCRIPTION
fixes #1735