### PR TITLE
Simplify TS slices example

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -357,42 +357,25 @@ const useBearStore = create<
 ### Slices pattern
 
 ```ts
-import { create, StateCreator } from 'zustand'
-
-interface BearSlice {
-  bears: number
-  addBear: () => void
-  eatFish: () => void
-}
-const createBearSlice: StateCreator<
-  BearSlice & FishSlice,
-  [],
-  [],
-  BearSlice
-> = (set) => ({
+const createBearSlice = set => ({
   bears: 0,
   addBear: () => set((state) => ({ bears: state.bears + 1 })),
   eatFish: () => set((state) => ({ fishes: state.fishes - 1 })),
-})
+});
 
-interface FishSlice {
-  fishes: number
-  addFish: () => void
-}
-const createFishSlice: StateCreator<
-  BearSlice & FishSlice,
-  [],
-  [],
-  FishSlice
-> = (set) => ({
+const createFishSlice = set => ({
   fishes: 0,
   addFish: () => set((state) => ({ fishes: state.fishes + 1 })),
 })
 
-const useBoundStore = create<BearSlice & FishSlice>()((...a) => ({
-  ...createBearSlice(...a),
-  ...createFishSlice(...a),
-}))
+const createSlices = (...a) => ({
+	...createBearSlice(...a),
+	...createFishSlice(...a),
+});
+
+type StoreState = ReturnType<typeof createSlices>;
+
+const useBoundStore = create<StoreState>()(createSlices);
 ```
 
 A detailed explanation on the slices pattern can be found [here](./slices-pattern.md).


### PR DESCRIPTION
Maximise type inference, minimise manual type annotation


## Summary

I recently migrated a large legacy project over to TS, and was struggling to find a way to add TS support to a Zustand store based on slices. The goal was to add TS support in such a way that there was minimal need for type annotation, maximum inference, and no need to maintain manual unions of slice types in the create function.

Proposed change is the result. I wanted to suggest it as a more user friendly approach for the documentation of adding TS support to a slices based Zustand store.

Would welcome feedback/understand if this doesn't match the preferred style of Zustand/there are shortcomings this overlooks.

Thanks

## Check List

- [ ] `yarn run prettier` for formatting code and docs
