### PR TITLE
Update `Transient` in recipes to match Readme

### DIFF
--- a/docs/recipes/recipes.mdx
+++ b/docs/recipes/recipes.mdx
@@ -208,8 +208,7 @@ function Component() {
   const scratchRef = useRef(useStore.getState().scratches)
   // Connect to the store on mount, disconnect on unmount, catch state-changes in a reference
   useEffect(() => useStore.subscribe(
-    scratches => (scratchRef.current = scratches),
-    state => state.scratches
+    scratches => (scratchRef.current = scratches)
   ), [])
   // ...
 }

--- a/docs/recipes/recipes.mdx
+++ b/docs/recipes/recipes.mdx
@@ -201,13 +201,13 @@ This can make a [drastic](https://codesandbox.io/s/peaceful-johnson-txtws)
 performance impact, when you are allowed to mutate the view directly.
 
 ```jsx
-const useStore = create(set => ({ scratches: 0, ... }))
+const useScratchStore = create(set => ({ scratches: 0, ... }))
 
 function Component() {
   // Fetch initial state
-  const scratchRef = useRef(useStore.getState().scratches)
+  const scratchRef = useRef(useScratchStore.getState().scratches)
   // Connect to the store on mount, disconnect on unmount, catch state-changes in a reference
-  useEffect(() => useStore.subscribe(
+  useEffect(() => useScratchStore.subscribe(
     (state) => (scratchRef.current = state.scratches)
   ), [])
   // ...

--- a/docs/recipes/recipes.mdx
+++ b/docs/recipes/recipes.mdx
@@ -208,7 +208,7 @@ function Component() {
   const scratchRef = useRef(useStore.getState().scratches)
   // Connect to the store on mount, disconnect on unmount, catch state-changes in a reference
   useEffect(() => useStore.subscribe(
-    scratches => (scratchRef.current = scratches)
+    (state) => (scratchRef.current = state.scratches)
   ), [])
   // ...
 }


### PR DESCRIPTION
When looking at the [docs](https://docs.pmnd.rs/zustand/recipes/recipes#transient-updates-(for-frequent-state-changes))  for transient the params for subscribe accepts a second arg compared to the repo [Readme](https://github.com/pmndrs/zustand#transient-updates-for-often-occurring-state-changes).

- Removes second arg passed to `subscribe` in example
- Renamed `useStore` to `useScratchStore`

<hr>



<img width="400" alt="Screen Shot 2023-04-21 at 2 22 07 PM" src="https://user-images.githubusercontent.com/62242/233708497-91aa4c24-cdf2-4462-bb27-98bf86fa8aec.png">



## Check List

- [x] `yarn run prettier` for formatting code and docs
