### PR TITLE
Add code heading in comparison with Zustand and Redux

### DIFF
--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -21,6 +21,8 @@ both are based on an immutable state model.
 However, Redux requires your app to be wrapped
 in context providers; Zustand does not.
 
+**Zustand**
+
 ```ts
 import { create } from 'zustand'
 
@@ -73,6 +75,7 @@ const useCountStore = create<State & Actions>((set) => ({
   dispatch: (action: Action) => set((state) => countReducer(state, action)),
 }))
 ```
+**Redux**
 
 ```ts
 import { createStore } from 'redux'

--- a/docs/getting-started/comparison.md
+++ b/docs/getting-started/comparison.md
@@ -75,6 +75,7 @@ const useCountStore = create<State & Actions>((set) => ({
   dispatch: (action: Action) => set((state) => countReducer(state, action)),
 }))
 ```
+
 **Redux**
 
 ```ts


### PR DESCRIPTION
## Related Issues or Discussions

Fixes 

## Summary
Fix to show the code heading in the comparison of Zustand and Redux code.


## Check List

- [x] `yarn run prettier` for formatting code and docs
