### PR TITLE
Add section for usage of persist middleware with NextJS

### DIFF
--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -463,7 +463,7 @@ The errors usually are:
 - Hydration failed because the initial UI does not match what was rendered on the server
 - There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering
 
-To solve these errors, you will need to create a custom hook that makes so that zustand waits a little bit before changing your components.
+To solve these errors, create a custom hook so that Zustand waits a little before changing your components.
 
 create a file and put this code:
 

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -454,7 +454,7 @@ in the [FAQ](#faq) section below.
 
 ### Usage in Next.js
 
-NextJS use Server Side Rendering, and it will compare the rendered component on the server with the one rendered on client. But since you are using data from browser to change your component, the two renders will differ and Next will throw an error at you.
+NextJS uses Server Side Rendering, and it will compare the rendered component on the server with the one rendered on client. But since you are using data from browser to change your component, the two renders will differ and Next will throw an warning at you.
 
 The errors usually are:
 
@@ -512,13 +512,13 @@ export const useBearStore = create(
 ```typescript
 // yourComponent.tsx
 
-import useStore from './use_store'
-import { useBearStore } from './stores/bear'
+import useStore from './useStore'
+import { useBearStore } from './stores/useBearStore'
 
 const bears = useStore(useBearStore, (state) => state.categorias)
 ```
 
-Credits: [This reply to an issue](https://github.com/pmndrs/zustand/issues/938#issuecomment-1481801942) which points to [this blog post](https://dev.to/abdulsamad/how-to-use-zustands-persist-middleware-in-nextjs-4lb5). Kudos for them!
+Credits: [This reply to an issue](https://github.com/pmndrs/zustand/issues/938#issuecomment-1481801942) which points to [this blog post](https://dev.to/abdulsamad/how-to-use-zustands-persist-middleware-in-nextjs-4lb5). Kudos to them!
 
 ## FAQ
 

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -454,7 +454,7 @@ in the [FAQ](#faq) section below.
 
 ### Usage in Next.js
 
-NextJS uses Server Side Rendering, and it will compare the rendered component on the server with the one rendered on client. But since you are using data from browser to change your component, the two renders will differ and Next will throw an warning at you.
+NextJS uses Server Side Rendering, and it will compare the rendered component on the server with the one rendered on client. But since you are using data from browser to change your component, the two renders will differ and Next will throw a warning at you.
 
 The errors usually are:
 

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -488,7 +488,7 @@ const useStore = <T, F>(
 export default useStore
 ```
 
-Now on your pages, you will use the hook a little bit differently:
+Now in your pages, you will use the hook a little bit differently:
 
 ```typescript
 // useBearStore.ts

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -452,6 +452,73 @@ If your app does depends on the persisted state at page load,
 see [_How can I check if my store has been hydrated_](#how-can-i-check-if-my-store-has-been-hydrated)
 in the [FAQ](#faq) section below.
 
+### Usage in Next.js
+NextJS use Server Side Rendering, and it will compare the rendered component on the server with the one rendered on client. But since you are using data from browser to change your component, the two renders will differ and Next will throw an error at you.
+
+The errors usually are:
+* Text content does not match server-rendered HTML
+* Hydration failed because the initial UI does not match what was rendered on the server
+* There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering
+
+To solve these errors, you will need to create a custom hook that makes so that zustand waits a little bit before changing your components.
+
+create a file and put this code:
+
+```typescript
+// useStore.ts
+import { useState, useEffect } from "react";
+
+const useStore = <T, F>(
+  store: (callback: (state: T) => unknown) => unknown,
+  callback: (state: T) => F
+) => {
+  const result = store(callback) as F;
+  const [data, setData] = useState<F>();
+
+  useEffect(() => {
+    setData(result);
+  }, [result]);
+
+  return data;
+};
+
+export default useStore;
+
+```
+
+Now on your pages, you will use the hook a little bit differently:
+```typescript
+// useBearStore.ts
+
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+
+// the store itself does not need any change
+export const useBearStore = create(
+  persist(
+    (set, get) => ({
+      bears: 0,
+      addABear: () => set({ bears: get().bears + 1 }),
+    }),
+    {
+      name: 'food-storage',
+    }
+  )
+)
+```
+
+```typescript
+// yourComponent.tsx
+
+import useStore from "./use_store";
+import { useBearStore } from "./stores/bear";
+
+const bears = useStore(useBearStore, state => state.categorias)
+```
+Credits: [This reply to an issue](https://github.com/pmndrs/zustand/issues/938#issuecomment-1481801942) which points to [this blog post](https://dev.to/abdulsamad/how-to-use-zustands-persist-middleware-in-nextjs-4lb5). Kudos for them!
+
+
 ## FAQ
 
 ### How can I check if my store has been hydrated

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -467,7 +467,7 @@ To solve these errors, create a custom hook so that Zustand waits a little befor
 
 Create a file with the following:
 
-```typescript
+```ts
 // useStore.ts
 import { useState, useEffect } from 'react'
 
@@ -490,7 +490,7 @@ export default useStore
 
 Now in your pages, you will use the hook a little bit differently:
 
-```typescript
+```ts
 // useBearStore.ts
 
 import { create } from 'zustand'
@@ -510,13 +510,13 @@ export const useBearStore = create(
 )
 ```
 
-```typescript
+```ts
 // yourComponent.tsx
 
 import useStore from './useStore'
 import { useBearStore } from './stores/useBearStore'
 
-const bears = useStore(useBearStore, (state) => state.categorias)
+const bears = useStore(useBearStore, (state) => state.bears)
 ```
 
 Credits: [This reply to an issue](https://github.com/pmndrs/zustand/issues/938#issuecomment-1481801942), which points to [this blog post](https://dev.to/abdulsamad/how-to-use-zustands-persist-middleware-in-nextjs-4lb5).

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -453,12 +453,14 @@ see [_How can I check if my store has been hydrated_](#how-can-i-check-if-my-sto
 in the [FAQ](#faq) section below.
 
 ### Usage in Next.js
+
 NextJS use Server Side Rendering, and it will compare the rendered component on the server with the one rendered on client. But since you are using data from browser to change your component, the two renders will differ and Next will throw an error at you.
 
 The errors usually are:
-* Text content does not match server-rendered HTML
-* Hydration failed because the initial UI does not match what was rendered on the server
-* There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering
+
+- Text content does not match server-rendered HTML
+- Hydration failed because the initial UI does not match what was rendered on the server
+- There was an error while hydrating. Because the error happened outside of a Suspense boundary, the entire root will switch to client rendering
 
 To solve these errors, you will need to create a custom hook that makes so that zustand waits a little bit before changing your components.
 
@@ -466,33 +468,32 @@ create a file and put this code:
 
 ```typescript
 // useStore.ts
-import { useState, useEffect } from "react";
+import { useState, useEffect } from 'react'
 
 const useStore = <T, F>(
   store: (callback: (state: T) => unknown) => unknown,
   callback: (state: T) => F
 ) => {
-  const result = store(callback) as F;
-  const [data, setData] = useState<F>();
+  const result = store(callback) as F
+  const [data, setData] = useState<F>()
 
   useEffect(() => {
-    setData(result);
-  }, [result]);
+    setData(result)
+  }, [result])
 
-  return data;
-};
+  return data
+}
 
-export default useStore;
-
+export default useStore
 ```
 
 Now on your pages, you will use the hook a little bit differently:
+
 ```typescript
 // useBearStore.ts
 
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-
 
 // the store itself does not need any change
 export const useBearStore = create(
@@ -511,13 +512,13 @@ export const useBearStore = create(
 ```typescript
 // yourComponent.tsx
 
-import useStore from "./use_store";
-import { useBearStore } from "./stores/bear";
+import useStore from './use_store'
+import { useBearStore } from './stores/bear'
 
-const bears = useStore(useBearStore, state => state.categorias)
+const bears = useStore(useBearStore, (state) => state.categorias)
 ```
-Credits: [This reply to an issue](https://github.com/pmndrs/zustand/issues/938#issuecomment-1481801942) which points to [this blog post](https://dev.to/abdulsamad/how-to-use-zustands-persist-middleware-in-nextjs-4lb5). Kudos for them!
 
+Credits: [This reply to an issue](https://github.com/pmndrs/zustand/issues/938#issuecomment-1481801942) which points to [this blog post](https://dev.to/abdulsamad/how-to-use-zustands-persist-middleware-in-nextjs-4lb5). Kudos for them!
 
 ## FAQ
 

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -465,7 +465,7 @@ The errors usually are:
 
 To solve these errors, create a custom hook so that Zustand waits a little before changing your components.
 
-create a file and put this code:
+Create a file with the following:
 
 ```typescript
 // useStore.ts

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -454,7 +454,8 @@ in the [FAQ](#faq) section below.
 
 ### Usage in Next.js
 
-NextJS uses Server Side Rendering, and it will compare the rendered component on the server with the one rendered on client. But since you are using data from browser to change your component, the two renders will differ and Next will throw a warning at you.
+NextJS uses Server Side Rendering, and it will compare the rendered component on the server with the one rendered on client.
+But since you are using data from browser to change your component, the two renders will differ and Next will throw a warning at you.
 
 The errors usually are:
 

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -519,7 +519,7 @@ import { useBearStore } from './stores/useBearStore'
 const bears = useStore(useBearStore, (state) => state.categorias)
 ```
 
-Credits: [This reply to an issue](https://github.com/pmndrs/zustand/issues/938#issuecomment-1481801942) which points to [this blog post](https://dev.to/abdulsamad/how-to-use-zustands-persist-middleware-in-nextjs-4lb5). Kudos to them!
+Credits: [This reply to an issue](https://github.com/pmndrs/zustand/issues/938#issuecomment-1481801942), which points to [this blog post](https://dev.to/abdulsamad/how-to-use-zustands-persist-middleware-in-nextjs-4lb5).
 
 ## FAQ
 


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #
Just docs 

## Summary
I have spent the last 1h30m trying to find the solution for `Hydration failed because the initial UI does not match what was rendered on the server` and after digging a lot I found the solution. So i thought: Maybe this could be on official documentation! So I made it. It's just copy and paste but at least it will be easier for future folks trying to solve the same problem



## Check List

- [x] `yarn run prettier` for formatting code and docs
