### PR TITLE
docs(recipes): fix description of devtools store naming

### DIFF
--- a/docs/recipes/recipes.mdx
+++ b/docs/recipes/recipes.mdx
@@ -410,8 +410,8 @@ const useStore = create(devtools(store, { enabled: false }))
 ```
 
 The `devtools` middleware takes the store function as its first argument.
-Optionally, you can name the store with a second argument:
-`devtools(store, "MyStore")`, which will be prefixed to your actions.
+Optionally, you can name the store with a second argument `devtoolsOptions`:
+`devtools(store, { store: "MyStore" })`, which will be prefixed to your actions.
 
 `devtools` will only log actions from each separated store,
 unlike in a typical _combined reducers_ Redux store.


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #

## Summary

The doc's description that you can name the store by `devtools(store, "MySore")`, but the second parameter in the source is a `devtoolsOptions` object rather than a string.

https://github.com/pmndrs/zustand/blob/0784028ed7591daf890c22ad4c065205cb35d2be/src/middleware/devtools.ts#L203

## Check List

- [x] `yarn run prettier` for formatting code and docs
