### PR TITLE
feat: add helper createSelector

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,15 @@
       },
       "module": "./esm/context.js",
       "default": "./context.js"
+    },
+    "./createSelector": {
+      "types": "./createSelector.d.ts",
+      "import": {
+        "types": "./esm/createSelector.d.mts",
+        "default": "./esm/createSelector.mjs"
+      },
+      "module": "./esm/createSelector.js",
+      "default": "./createSelector.js"
     }
   },
   "sideEffects": false,

--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,8 @@ const { nuts, honey } = useBearStore(
   (state) => ({ nuts: state.nuts, honey: state.honey }),
   shallow
 )
+// or use helper with createSelector
+const { nuts, honey } = useBearStore(createSelector('nuts', 'honey'), shallow)
 
 // Array pick, re-renders the component when either state.nuts or state.honey change
 const [nuts, honey] = useBearStore(

--- a/src/createSelector.ts
+++ b/src/createSelector.ts
@@ -1,0 +1,18 @@
+/**
+ * @usage
+ * const { bears } = useBearStore(createSelector('bears'))
+ * const { bears, fishes } = useBearStore(createSelector('bears', 'fishes'))
+ *
+ * @param keys state keys
+ * @returns selector fn, like (state) => ({ foo: state.foo })
+ */
+export function createSelector<T, K extends keyof T>(...keys: K[]) {
+  return (state: T) => {
+    const out: Pick<T, K> = {} as any
+    keys.forEach((key) => {
+      out[key] = state[key]
+    })
+
+    return out
+  }
+}

--- a/tests/createSelector.test.tsx
+++ b/tests/createSelector.test.tsx
@@ -1,0 +1,89 @@
+import { act, render } from '@testing-library/react'
+import { useEffect } from 'react'
+import { describe, it } from 'vitest'
+import { create } from 'zustand'
+import { createSelector } from 'zustand/createSelector'
+import { shallow } from 'zustand/shallow'
+
+type CounterState = {
+  count: number
+  inc: () => void
+}
+
+describe('createSelector', () => {
+  it('pick single value', async () => {
+    const useBoundStore = create<CounterState>((set) => ({
+      count: 0,
+      inc: () => set((state) => ({ count: state.count + 1 })),
+    }))
+
+    function Counter() {
+      const { count } = useBoundStore(createSelector('count'))
+
+      return <div>count: {count}</div>
+    }
+
+    const { findByText } = render(
+      <>
+        <Counter />
+      </>
+    )
+
+    await findByText('count: 0')
+  })
+
+  it('pick multi value', async () => {
+    const useBoundStore = create<CounterState>((set) => ({
+      count: 0,
+      inc: () => set((state) => ({ count: state.count + 1 })),
+    }))
+
+    function Counter() {
+      const { count, inc } = useBoundStore(createSelector('count', 'inc'))
+
+      useEffect(inc, [inc])
+
+      return <div>count: {count}</div>
+    }
+
+    const { findByText } = render(
+      <>
+        <Counter />
+      </>
+    )
+
+    await findByText('count: 1')
+  })
+
+  it('filter unexpected modifications', async () => {
+    const useBoundStore = create(() => ({ item: 0, other: 0 }))
+    const { setState } = useBoundStore
+    let renderCount = 0
+
+    function Component() {
+      const { item } = useBoundStore(createSelector('item'), shallow)
+
+      return (
+        <div>
+          renderCount: {++renderCount}, value: {item}
+        </div>
+      )
+    }
+
+    const { findByText } = render(
+      <>
+        <Component />
+      </>
+    )
+
+    await findByText('renderCount: 1, value: 0')
+
+    // This will not cause a re-render.
+    act(() => setState({ other: 1 }))
+    await findByText('renderCount: 1, value: 0')
+
+    // This will cause a re-render.
+    act(() => setState({ item: 2 }))
+    await findByText('renderCount: 2, value: 2')
+  })
+})


### PR DESCRIPTION
## Summary

add helper fn **createSelector** to quick create typesafe selector fn.

```js
const { bears, fishes } = useBearStore(createSelector('bears', 'fishes'))
```

same as 

```js
const { bears, fishes } = useBearStore((state) => ({ bears: state.bears, fishes: state.fishes }))
```

The reason of create mapping selector is named export has better maintainability

## Check List

- [x] `yarn run prettier` for formatting code and docs
