### PR TITLE
Fix saving state in URL hash example demo

### DIFF
--- a/docs/guides/connect-to-state-with-url-hash.md
+++ b/docs/guides/connect-to-state-with-url-hash.md
@@ -15,7 +15,7 @@ const hashStorage: StateStorage = {
   getItem: (key): string => {
     const searchParams = new URLSearchParams(location.hash.slice(1))
     const storedValue = searchParams.get(key) ?? ''
-    return storedValue
+    return JSON.parse(storedValue)
   },
   setItem: (key, newValue): void => {
     const searchParams = new URLSearchParams(location.hash.slice(1))
@@ -45,4 +45,4 @@ export const useBoundStore = create(
 
 ## CodeSandbox Demo
 
-https://codesandbox.io/s/zustand-state-with-url-hash-demo-pn20n5?file=/src/store/index.ts
+https://codesandbox.io/s/zustand-state-with-url-hash-demo-f29b88?file=/src/store/index.ts


### PR DESCRIPTION
## Summary

I was trying to adapt [this URL hash example](https://docs.pmnd.rs/zustand/guides/connect-to-state-with-url-hash) to our codebase but it didn't worked. State didn't load on a refresh.

I figured out that it's because we `stringify` but not `parse` before loading the state.

Please take a look on the previous codesandbox and the new one in the diff.


## Check List

- [x] `yarn run prettier` for formatting code and docs
