### PR TITLE
docs: fixes typo on variable name

### DIFF
--- a/docs/guides/auto-generating-selectors.md
+++ b/docs/guides/auto-generating-selectors.md
@@ -62,7 +62,7 @@ Now the selectors are auto generated and you can access them directly:
 const bears = useBearStore.use.bears()
 
 // get the action
-const increase = useBearStore.use.increment()
+const increment = useBearStore.use.increment()
 ```
 
 ## Live Demo


### PR DESCRIPTION
## Summary

Small typo fix on the variable name for consistency with the other example a line above.