### PR TITLE
docs(guides): fix slices pattern types

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -379,12 +379,7 @@ interface FishSlice {
   fishes: number
   addFish: () => void
 }
-const createFishSlice: StateCreator<
-  BearSlice & FishSlice,
-  [],
-  [],
-  FishSlice
-> = (set) => ({
+const createFishSlice: StateCreator<FishSlice, [], [], FishSlice> = (set) => ({
   fishes: 0,
   addFish: () => set((state) => ({ fishes: state.fishes + 1 })),
 })


### PR DESCRIPTION
## Summary
There is no reason to use additional `BearSlice` interface for `createFishSlice`. We haven't got any `BearSlice` related methods or fields, so it could be confusing to use this interface.

## Check List

- [x] `yarn run prettier` for formatting code and docs
