### PR TITLE
docs(guides): fix "useHydration hook"

### DIFF
--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -570,7 +570,7 @@ You can also create a custom `useHydration` hook:
 const useBoundStore = create(persist(...))
 
 const useHydration = () => {
-  const [hydrated, setHydrated] = useState(useBoundStore.persist.hasHydrated)
+  const [hydrated, setHydrated] = useState(false)
 
   useEffect(() => {
     // Note: This is just in case you want to take into account manual rehydration.


### PR DESCRIPTION
The initialization type of `useState` is incorrect. hydrated needs to be of boolean type, whereas the original `useBoundStore.persist.hasHydrated` is a function. This will lead to errors, such as during the static build of frameworks like Next.js.

## Related Issues or Discussions

Fixes #

## Summary



## Check List

- [x] `yarn run prettier` for formatting code and docs
