### PR TITLE
docs(readme): fix import of "produce" function

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -261,7 +261,7 @@ const Component = () => {
 Reducing nested structures is tiresome. Have you tried [immer](https://github.com/mweststrate/immer)?
 
 ```jsx
-import produce from 'immer'
+import { produce } from 'immer'
 
 const useLushStore = create((set) => ({
   lush: { forest: { contains: { a: 'bear' } } },


### PR DESCRIPTION
## Summary

immer's "produce" function is being exported incorrectly, which can lead to potential confusion. For this you need to export using:

```ts
import { produce } from 'immer'
```