### PR TITLE
[Documentation] Import shallow from right package

### DIFF
--- a/docs/recipes/recipes.mdx
+++ b/docs/recipes/recipes.mdx
@@ -129,7 +129,8 @@ subscribe(selector, callback, options?: { equalityFn, fireImmediately }): Unsubs
 
 ```jsx
 import { create } from 'zustand'
-import { subscribeWithSelector, shallow } from 'zustand/middleware'
+import { subscribeWithSelector } from 'zustand/middleware'
+import { shallow } from 'zustand/shallow'
 const useStore = create(
   subscribeWithSelector(() => ({ paw: true, snout: true, fur: true }))
 )


### PR DESCRIPTION

## Summary

Fixes documentation about shallow usage. 
Doc shows **import** from wrong package.

## Check List

- [x] `yarn run prettier` for formatting code and docs
