### PR TITLE
docs: refine flux inspired docs to make pattern inspiration clearer

### DIFF
--- a/docs/guides/connect-to-state-with-url-hash.md
+++ b/docs/guides/connect-to-state-with-url-hash.md
@@ -45,7 +45,7 @@ export const useBoundStore = create(
 
 ### CodeSandbox Demo
 
-<https://codesandbox.io/s/zustand-state-with-url-hash-demo-f29b88?file=/src/store/index.ts>
+https://codesandbox.io/s/zustand-state-with-url-hash-demo-f29b88?file=/src/store/index.ts
 
 ## Persist and Connect State with URL Parameters (Example: URL Query Parameters)
 

--- a/docs/guides/flux-inspired-practice.md
+++ b/docs/guides/flux-inspired-practice.md
@@ -3,27 +3,47 @@ title: Flux inspired practice
 nav: 5
 ---
 
-Although zustand is an unopinionated library, here are some patterns we recommend:
+Although Zustand is an unopinionated library, we do recommend a few patterns.
+These are inspired by practices originally found in [Flux](https://github.com/facebookarchive/flux),
+and more recently [Redux](https://redux.js.org/understanding/thinking-in-redux/three-principles),
+so if you are coming from another library, you should feel right at home.
 
-- Create a single store;
-- Always use `set` to define a store;
-- Define your dispatch functions at the root level of the store to update one or more store slices.
+However, Zustand does differ in some fundamental ways,
+so some terminology may not perfectly align to other libraries.
+
+## Recommended patterns
+
+### Single store
+
+Your applications global state should be located in a single Zustand store.
+
+If you have a large application, Zustand supports [splitting the store into slices](./slices-pattern).
+
+### Use `set` / `setState` to update the store
+
+Always use `set` (or `setState`) to perform updates to your store.
+`set` (and `setState`) ensures the described update is immutably performed to the store.
+
+### Colocate store actions
+
+In Zustand, state can be updated without the use of dispatched actions and reducers found in other Flux libraries.
+These store actions can be added directly to the store as shown below.
+
+Optionally, by using `setState` they can be [located external to the store](./practice-with-no-store-actions.md)
 
 ```js
 const useBoundStore = create((set) => ({
   storeSliceA: ...,
   storeSliceB: ...,
   storeSliceC: ...,
-  dispatchX: () => set(...),
-  dispatchY: () => set(...),
+  updateX: () => set(...),
+  updateY: () => set(...),
 }))
 ```
 
-See [Splitting the store into separate slices](./slices-pattern.md) for how to define a store with separate slices.
+## Redux-like patterns
 
-## Flux like patterns / "dispatching" actions
-
-If you can't live without redux-like reducers, you can define a `dispatch` function on the root level of the store like so:
+If you can't live without Redux-like reducers, you can define a `dispatch` function on the root level of the store:
 
 ```typescript
 const types = { increase: 'INCREASE', decrease: 'DECREASE' }

--- a/docs/guides/flux-inspired-practice.md
+++ b/docs/guides/flux-inspired-practice.md
@@ -22,7 +22,7 @@ If you have a large application, Zustand supports [splitting the store into slic
 ### Use `set` / `setState` to update the store
 
 Always use `set` (or `setState`) to perform updates to your store.
-`set` (and `setState`) ensures the described update is immutably performed to the store.
+`set` (and `setState`) ensures the described update is correctly merged and listeners are appropriately notified.
 
 ### Colocate store actions
 


### PR DESCRIPTION
## Related Issues or Discussions

Addresses discussion 1863

## Summary

Try to highlight the similarities, but also differences, from standard flux practices. 


## Check List

- [x] `yarn run prettier` for formatting code and docs


**Note** I had to remove `<>` from the codesandbox link as it was causing issues when running the docs locally, see screenshot. 
![CleanShot 2023-06-17 at 21 13 08](https://github.com/pmndrs/zustand/assets/55621012/ba90d416-ecc4-4f2f-a02d-c10f0c4844c7)

