### PR TITLE
docs: fix typo 'with be' to 'will be'

### DIFF
--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -267,7 +267,7 @@ export const useBoundStore = create(
 
 > Default: `undefined`
 
-By default the store with be hydrated on initialization.
+By default the store will be hydrated on initialization.
 
 In some applications you may need to control when the first hydration occurs.
 For example, in server-rendered apps.


### PR DESCRIPTION
## Fixes
Typo fix in docs.

## Summary
changed the following line:
- By default the store *with* be hydrated on initialization.

to

- By default the store *will* be hydrated on initialization.

## Check List

- [x] `yarn run prettier` for formatting code and docs
