### PR TITLE
improve docs readability

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -261,7 +261,6 @@ describe('Counter', () => {
     expect(await screen.findByText(/^2$/)).toBeInTheDocument()
   })
 })
-
 ```
 
 > **Note**: without [globals configuration](https://vitest.dev/config/#globals) enabled, we need

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -239,7 +239,7 @@ import { Counter } from './counter'
 
 describe('Counter', () => {
   test('should render successfully', async () => {
-    renderCounter()
+    render(<Counter />)
 
     expect(await screen.findByText(/^1$/)).toBeInTheDocument()
     expect(
@@ -250,7 +250,7 @@ describe('Counter', () => {
   test('should increase count by clicking a button', async () => {
     const user = userEvent.setup()
 
-    renderCounter()
+    render(<Counter />)
 
     expect(await screen.findByText(/^1$/)).toBeInTheDocument()
 
@@ -260,9 +260,6 @@ describe('Counter', () => {
   })
 })
 
-const renderCounter = () => {
-  return render(<Counter />)
-}
 ```
 
 > **Note**: without [globals configuration](https://vitest.dev/config/#globals) enabled, we need

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -53,7 +53,7 @@ this means your application logic does not need to be changed or mocked when wri
 ## Setting Up Zustand for testing
 
 > **Note**: Since Jest and Vitest have slight differences, like Vitest using **ES modules** and Jest using
-**CommonJS modules**, you need to keep that in mind if you are using Vitest instead of Jest.
+> **CommonJS modules**, you need to keep that in mind if you are using Vitest instead of Jest.
 
 The mock provided below will enable the relevant test runner to reset the zustand stores after each test.
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -55,9 +55,11 @@ this means your application logic does not need to be changed or mocked when wri
 Since Jest and Vitest have slight differences, like Vitest using **ES modules** and Jest using
 **CommonJS modules**, you need to keep that in mind if you are using Vitest instead of Jest.
 
+The mock provided below will enable both test runners to clear all zustand stores after each test.
+
 ### Jest
 
-In the next steps we are going to setup our Jest environment in order to mock Zustand
+In the next steps we are going to setup our Jest environment in order to mock Zustand.
 
 ```ts
 // __mocks__/zustand.ts

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -52,10 +52,10 @@ this means your application logic does not need to be changed or mocked when wri
 
 ## Setting Up Zustand for testing
 
-Since Jest and Vitest have slight differences, like Vitest using **ES modules** and Jest using
+> **Note**: Since Jest and Vitest have slight differences, like Vitest using **ES modules** and Jest using
 **CommonJS modules**, you need to keep that in mind if you are using Vitest instead of Jest.
 
-The mock provided below will enable both test runners to clear all zustand stores after each test.
+The mock provided below will enable the relevant test runner to reset the zustand stores after each test.
 
 ### Jest
 

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -89,7 +89,7 @@ So we have two problems: lack of inference and unsoundness. Lack of inference ca
 </details>
 
 <details>
-  <summary>Why that currying `()(...)`?</summary>
+  <summary>Why the currying `()(...)`?</summary>
 
   <br/>
 

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ You can try a live demo [here](https://githubbox.com/pmndrs/zustand/tree/main/ex
 npm install zustand # or yarn add zustand or pnpm add zustand
 ```
 
-:warning: This readme is written for JavaScript users. If you are a TypeScript user, don't miss [TypeScript Usage](#typescript-usage).
+:warning: This readme is written for JavaScript users. If you are a TypeScript user, be sure to check out our [TypeScript Usage section](#typescript-usage).
 
 ## First create a store
 
@@ -513,6 +513,7 @@ A more complete TypeScript guide is [here](docs/guides/typescript.md).
 - Recommended usage for this unopinionated library: [Flux inspired practice](./docs/guides/flux-inspired-practice.md).
 - [Calling actions outside a React event handler in pre-React 18](./docs/guides/event-handler-in-pre-react-18.md).
 - [Testing](./docs/guides/testing.md)
+- For more, have a look [in the docs folder](./docs/)
 
 ## Third-Party Libraries
 


### PR DESCRIPTION
## Summary
Had a look at the docs and made a few changes that I feel like make it easier to find stuff or read. For example I didn't immediately understand what the zustand mock enabled, or the renderCounter function being at the bottom of one of the codeblocks confused me for a little bit.


## Check List

- [X] `yarn run prettier` for formatting code and docs
