### PR TITLE
add usage trends in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -522,3 +522,4 @@ Some users may want to extend Zustand's feature set which can be done using thir
 ## Comparison with other libraries
 
 - [Difference between zustand and valtio](https://github.com/pmndrs/zustand/wiki/Difference-between-zustand-and-valtio)
+- [NPM Package Downloads Trend of React State Management Libraries](https://npm-compare.com/react-redux,zustand,xstate,mobx,jotai,recoil,valtio,mobx-state-tree,constate,@datorama/akita,unstated,@hookstate/core,easy-peasy,@ngneat/elf,nanostores,alt,storeon,overmind/#timeRange=THREE_YEARS)


### PR DESCRIPTION
## Summary

I would like to suggest adding a link to the zustand github readme.md. This link will help developers who are choosing a state management package for React.js to compare different options based on usage trends and GitHub stars.

I use this comparison tool to keep track of the usage trend of zustand, which I have noticed is increasing over time. Additionally, zustand has the highest number of GitHub stars among all other packages listed. I believe that this information could be valuable to other developers who are searching for a reliable state management package for their React.js projects, and that zustand may be a strong contender for their needs.

## Check List

- [x] `yarn run prettier` for formatting code and docs
