### PR TITLE
Docs Example (Persist API): Avoid 'any', avoid "might be null" error and make example clearer

### DIFF
--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -698,17 +698,28 @@ Let's say your state uses `Map` to handle a list of `transactions`,
 then you can convert the Map into an Array in the storage prop:
 
 ```ts
+
+interface BearState {
+  .
+  .
+  .
+  transactions: Map<any>
+}
+
   storage: {
     getItem: (name) => {
-      const str = localStorage.getItem(name)
+      const str = localStorage.getItem(name);
+      if (!str) return null;
+      const { state } = JSON.parse(str);
       return {
         state: {
-          ...JSON.parse(str).state,
-          transactions: new Map(JSON.parse(str).state.transactions),
+          ...state,
+          transactions: new Map(state.transactions),
         },
       }
     },
-    setItem: (name, newValue) => {
+    setItem: (name, newValue: StorageValue<BearState>) => {
+      // functions cannot be JSON encoded
       const str = JSON.stringify({
         state: {
           ...newValue.state,


### PR DESCRIPTION
## Related Issues or Discussions
https://github.com/pmndrs/zustand/discussions/1955

This is a small fix for one of the examples in the docs (persist API).
The example:
![image](https://github.com/pmndrs/zustand/assets/37377389/25cfef49-772c-4c25-9d23-230374ade5d7)
Link: https://docs.pmnd.rs/zustand/integrations/persisting-store-data#how-do-i-use-it-with-map-and-set
## Fixes  

Fixes TypeScript Error in this example and clarifies a certain type that isn't really any.

## Summary
The type of `newValue` isn't exactly `StorageValue<any>` but `StorageValue<YourStateType>`.
This PR helps to clarify that and helps users have better types.
In addition, `str` in `getItem` could be `null` and that's why **this code won't compile**.

`zustand` is incredible and I do not wish to waste your time, I just thought this might help 💛

