### PR TITLE
fix: declare @types/react as peerDep to avoid phantom dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,10 +181,14 @@
   },
   "peerDependencies": {
     "immer": ">=9.0",
+    "@types/react": ">=16.8",
     "react": ">=16.8"
   },
   "peerDependenciesMeta": {
     "immer": {
+      "optional": true
+    },
+    "@types/react": {
       "optional": true
     },
     "react": {


### PR DESCRIPTION
## Related Issues or Discussions

Fixes [#2047 of jotai](https://github.com/pmndrs/jotai/issues/2047)

## Summary



## Check List

- [ ] `yarn run prettier` for formatting code and docs
