### PR TITLE
docs: fix typo

### DIFF
--- a/docs/previous-versions/zustand-v3-create-context.md
+++ b/docs/previous-versions/zustand-v3-create-context.md
@@ -117,7 +117,7 @@ Here's the diff showing how to migrate from v3 createContext to v4 API.
 + import { createStore, useStore } from "zustand";
 
 - const useStore = create((set) => ({
-+ const store =  createStore((set) => ({
++ const store = createStore((set) => ({
     bears: 0,
     increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
     removeAllBears: () => set({ bears: 0 })
@@ -125,7 +125,7 @@ Here's the diff showing how to migrate from v3 createContext to v4 API.
 
 + const MyContext = createContext()
 
-+ export const Provider = ({ children }) = <MyContext.Provider value={store}>{children}</MyContext.Provider>;
++ export const Provider = ({ children }) => <MyContext.Provider value={store}>{children}</MyContext.Provider>;
 
 + export const useMyStore = (selector) => useStore(useContext(MyContext), selector);
 ```


### PR DESCRIPTION
## Summary

Fixed a typo in `docs/previous-versions/zustand-v3-create-context.md`.

## Check List

- [x] `yarn run prettier` for formatting code and docs
