### PR TITLE
fix(types): accept undefined equalityFn for the deprecated useStore

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -39,7 +39,7 @@ export function useStore<S extends WithReact<StoreApi<unknown>>, U>(
 export function useStore<S extends WithReact<StoreApi<unknown>>, U>(
   api: S,
   selector: (state: ExtractState<S>) => U,
-  equalityFn: (a: U, b: U) => boolean
+  equalityFn: ((a: U, b: U) => boolean) | undefined
 ): U
 
 export function useStore<TState, StateSlice>(


### PR DESCRIPTION
## Related Issues or Discussions

https://github.com/pmndrs/zustand/discussions/1937#discussioncomment-6625047

## Summary

It's an overlook in #1945, which breaks types with existing (deprecated) usage.

## Check List

- [x] `yarn run prettier` for formatting code and docs
