### PR TITLE
fix: improve warning for deprecated equalityFn

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -42,15 +42,22 @@ export function useStore<S extends WithReact<StoreApi<unknown>>, U>(
   equalityFn: (a: U, b: U) => boolean
 ): U
 
+let didWarnAboutEqualityFn = false
+
 export function useStore<TState, StateSlice>(
   api: WithReact<StoreApi<TState>>,
   selector: (state: TState) => StateSlice = api.getState as any,
   equalityFn?: (a: StateSlice, b: StateSlice) => boolean
 ) {
-  if (import.meta.env?.MODE !== 'production' && equalityFn) {
+  if (
+    import.meta.env?.MODE !== 'production' &&
+    equalityFn &&
+    !didWarnAboutEqualityFn
+  ) {
     console.warn(
-      "[DEPRECATED] Use `createWithEqualityFn` from 'zustand/traditional'. https://github.com/pmndrs/zustand/discussions/1937"
+      "[DEPRECATED] Use `createWithEqualityFn` instead of `create` or use `useStoreWithEqualityFn` instead of `useStore`. They can be imported from 'zustand/traditional'. https://github.com/pmndrs/zustand/discussions/1937"
     )
+    didWarnAboutEqualityFn = true
   }
   const slice = useSyncExternalStoreWithSelector(
     api.subscribe,

--- a/src/react.ts
+++ b/src/react.ts
@@ -23,6 +23,8 @@ type WithReact<S extends ReadonlyStoreApi<unknown>> = S & {
   getServerState?: () => ExtractState<S>
 }
 
+let didWarnAboutEqualityFn = false
+
 export function useStore<S extends WithReact<StoreApi<unknown>>>(
   api: S
 ): ExtractState<S>
@@ -41,8 +43,6 @@ export function useStore<S extends WithReact<StoreApi<unknown>>, U>(
   selector: (state: ExtractState<S>) => U,
   equalityFn: (a: U, b: U) => boolean
 ): U
-
-let didWarnAboutEqualityFn = false
 
 export function useStore<TState, StateSlice>(
   api: WithReact<StoreApi<TState>>,


### PR DESCRIPTION
## Related Issues or Discussions

https://github.com/pmndrs/zustand/discussions/1937#discussioncomment-6639426
https://github.com/pmndrs/zustand/discussions/1937#discussioncomment-6643081
https://github.com/pmndrs/zustand/discussions/1937#discussioncomment-6646040

Follow-up #1945

## Summary

Improve the warning message based on the feedback.

## Check List

- [x] `yarn run prettier` for formatting code and docs
