### PR TITLE
fix(docs): Do not recommend deprecated useStore + equalityFn on initialize with props docs

### DIFF
--- a/docs/guides/initialize-state-with-props.md
+++ b/docs/guides/initialize-state-with-props.md
@@ -106,7 +106,7 @@ import { useContext } from 'react'
 import { useStore } from 'zustand'
 
 function useBearContext<T>(
-  selector: (state: BearState) => T,
+  selector: (state: BearState) => T
 ): T {
   const store = useContext(BearContext)
   if (!store) throw new Error('Missing BearContext.Provider in the tree')

--- a/docs/guides/initialize-state-with-props.md
+++ b/docs/guides/initialize-state-with-props.md
@@ -115,21 +115,6 @@ function useBearContext<T>(
 ```
 
 ```tsx
-// Allow custom equality function by using useStoreWithEqualityFn
-import { useContext } from 'react'
-import { useStoreWithEqualityFn } from 'zustand/traditional'
-
-function useBearContext<T>(
-  selector: (state: BearState) => T,
-  equalityFn?: (left: T, right: T) => boolean
-): T {
-  const store = useContext(BearContext)
-  if (!store) throw new Error('Missing BearContext.Provider in the tree')
-  return useStoreWithEqualityFn(store, selector, equalityFn)
-}
-```
-
-```tsx
 // Consumer usage of the custom hook
 function CommonConsumer() {
   const bears = useBearContext((s) => s.bears)
@@ -140,6 +125,23 @@ function CommonConsumer() {
       <button onClick={addBear}>Add bear</button>
     </>
   )
+}
+```
+
+### Optionally allow using a custom equality function
+
+```tsx
+// Allow custom equality function by using useStoreWithEqualityFn instead of useStore
+import { useContext } from 'react'
+import { useStoreWithEqualityFn } from 'zustand/traditional'
+
+function useBearContext<T>(
+  selector: (state: BearState) => T,
+  equalityFn?: (left: T, right: T) => boolean
+): T {
+  const store = useContext(BearContext)
+  if (!store) throw new Error('Missing BearContext.Provider in the tree')
+  return useStoreWithEqualityFn(store, selector, equalityFn)
 }
 ```
 

--- a/docs/guides/initialize-state-with-props.md
+++ b/docs/guides/initialize-state-with-props.md
@@ -103,6 +103,20 @@ function BearProvider({ children, ...props }: BearProviderProps) {
 ```tsx
 // Mimic the hook returned by `create`
 import { useContext } from 'react'
+import { useStore } from 'zustand'
+
+function useBearContext<T>(
+  selector: (state: BearState) => T,
+): T {
+  const store = useContext(BearContext)
+  if (!store) throw new Error('Missing BearContext.Provider in the tree')
+  return useStore(store, selector)
+}
+```
+
+```tsx
+// Allow custom equality function by using useStoreWithEqualityFn
+import { useContext } from 'react'
 import { useStoreWithEqualityFn } from 'zustand/traditional'
 
 function useBearContext<T>(

--- a/docs/guides/initialize-state-with-props.md
+++ b/docs/guides/initialize-state-with-props.md
@@ -105,9 +105,7 @@ function BearProvider({ children, ...props }: BearProviderProps) {
 import { useContext } from 'react'
 import { useStore } from 'zustand'
 
-function useBearContext<T>(
-  selector: (state: BearState) => T
-): T {
+function useBearContext<T>(selector: (state: BearState) => T): T {
   const store = useContext(BearContext)
   if (!store) throw new Error('Missing BearContext.Provider in the tree')
   return useStore(store, selector)

--- a/docs/guides/initialize-state-with-props.md
+++ b/docs/guides/initialize-state-with-props.md
@@ -103,7 +103,7 @@ function BearProvider({ children, ...props }: BearProviderProps) {
 ```tsx
 // Mimic the hook returned by `create`
 import { useContext } from 'react'
-import { useStore } from 'zustand'
+import { useStoreWithEqualityFn } from 'zustand/traditional'
 
 function useBearContext<T>(
   selector: (state: BearState) => T,
@@ -111,7 +111,7 @@ function useBearContext<T>(
 ): T {
   const store = useContext(BearContext)
   if (!store) throw new Error('Missing BearContext.Provider in the tree')
-  return useStore(store, selector, equalityFn)
+  return useStoreWithEqualityFn(store, selector, equalityFn)
 }
 ```
 


### PR DESCRIPTION
## Summary

Passing an equalityFn to the useStore hook is deprecated. The documentation to initialize the store from props is recommending the approach. It was updated to recommend using useStoreWithEqualityFn instead.

## Check List

- [x] `yarn run prettier` for formatting code and docs

BTW notice running prettier messed with a lot of files but didn't change the file I changed. I'm not pushing those other files formatting changes though.