### PR TITLE
docs: Update typescript guide persist examples...

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -122,8 +122,9 @@ In the next steps we are going to setup our Vitest environment in order to mock 
 import * as zustand from 'zustand'
 import { act } from '@testing-library/react'
 
-const { create: actualCreate } =
-  await vi.importActual<typeof zustand>('zustand')
+const { create: actualCreate } = await vi.importActual<typeof zustand>(
+  'zustand'
+)
 
 // a variable to hold reset functions for all stores declared in the app
 export const storeResetFns = new Set<() => void>()

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -122,9 +122,8 @@ In the next steps we are going to setup our Vitest environment in order to mock 
 import * as zustand from 'zustand'
 import { act } from '@testing-library/react'
 
-const { create: actualCreate } = await vi.importActual<typeof zustand>(
-  'zustand'
-)
+const { create: actualCreate } =
+  await vi.importActual<typeof zustand>('zustand')
 
 // a variable to hold reset functions for all stores declared in the app
 export const storeResetFns = new Set<() => void>()

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -181,7 +181,7 @@ const useBearStore = create<BearState>()(
         bears: 0,
         increase: (by) => set((state) => ({ bears: state.bears + by })),
       }),
-      { name: 'required name option' }
+      { name: 'bearStore' }
     )
   )
 )
@@ -193,7 +193,7 @@ Just make sure you are using them immediately inside `create` so as to make the 
 import { create } from 'zustand'
 import { devtools, persist } from 'zustand/middleware'
 
-const myMiddlewares = (f) => devtools(persist(f, { name: 'options name' }))
+const myMiddlewares = (f) => devtools(persist(f, { name: 'bearStore' }))
 
 interface BearState {
   bears: number

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -176,11 +176,13 @@ interface BearState {
 
 const useBearStore = create<BearState>()(
   devtools(
-    persist((set) => ({
-      bears: 0,
-      increase: (by) => set((state) => ({ bears: state.bears + by })),
-    }), 
-    { name: "required name option" })
+    persist(
+      (set) => ({
+        bears: 0,
+        increase: (by) => set((state) => ({ bears: state.bears + by })),
+      }),
+      { name: 'required name option' }
+    )
   )
 )
 ```
@@ -191,7 +193,7 @@ Just make sure you are using them immediately inside `create` so as to make the 
 import { create } from 'zustand'
 import { devtools, persist } from 'zustand/middleware'
 
-const myMiddlewares = (f) => devtools(persist(f, {name: "options name"}))
+const myMiddlewares = (f) => devtools(persist(f, { name: 'options name' }))
 
 interface BearState {
   bears: number

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -179,7 +179,8 @@ const useBearStore = create<BearState>()(
     persist((set) => ({
       bears: 0,
       increase: (by) => set((state) => ({ bears: state.bears + by })),
-    }))
+    }), 
+    { name: "required name option" })
   )
 )
 ```
@@ -190,7 +191,7 @@ Just make sure you are using them immediately inside `create` so as to make the 
 import { create } from 'zustand'
 import { devtools, persist } from 'zustand/middleware'
 
-const myMiddlewares = (f) => devtools(persist(f))
+const myMiddlewares = (f) => devtools(persist(f, {name: "options name"}))
 
 interface BearState {
   bears: number
@@ -351,7 +352,7 @@ const useBearStore = create<
 >(devtools(persist((set) => ({
   bears: 0,
   increase: (by) => set((state) => ({ bears: state.bears + by })),
-})))
+}), {name: "required name option"}))
 ```
 
 ### Slices pattern


### PR DESCRIPTION
...to add required name option.  

## Summary
The ts example calls to persist fail due to lack of 2nd parameter PersistOptions which has a required value of name.  Therefore minimum doc example requires persist calls to provide { name: "req. name" }.  
reference:  (https://docs.pmnd.rs/zustand/integrations/persisting-store-data)


## Check List

- [x] `yarn run prettier` for formatting code and docs
