### PR TITLE
fix: added 'create' and 'shallow' imports to docs

### DIFF
--- a/docs/guides/updating-state.md
+++ b/docs/guides/updating-state.md
@@ -34,8 +34,8 @@ const usePersonStore = create<State & Action>((set) => ({
 function App() {
   // "select" the needed state and actions, in this case, the firstName value
   // and the action updateFirstName
-const firstName = usePersonStore((state)=> state.firstName)
-const updateFirstName = usePersonStore((state)=> state.updateFirstName)
+  const firstName = usePersonStore((state) => state.firstName)
+  const updateFirstName = usePersonStore((state) => state.updateFirstName)
 
   return (
     <main>

--- a/docs/guides/updating-state.md
+++ b/docs/guides/updating-state.md
@@ -10,6 +10,8 @@ the new state, and it will be shallowly merged with the existing state in the
 store. **Note** See next section for nested state.
 
 ```tsx
+import { create } from 'zustand'
+
 type State = {
   firstName: string
   lastName: string
@@ -21,7 +23,7 @@ type Action = {
 }
 
 // Create your store, which includes both state and (optionally) actions
-const useStore = create<State & Action>((set) => ({
+const usePersonStore = create<State & Action>((set) => ({
   firstName: '',
   lastName: '',
   updateFirstName: (firstName) => set(() => ({ firstName: firstName })),
@@ -32,10 +34,8 @@ const useStore = create<State & Action>((set) => ({
 function App() {
   // "select" the needed state and actions, in this case, the firstName value
   // and the action updateFirstName
-  const [firstName, updateFirstName] = useStore(
-    (state) => [state.firstName, state.updateFirstName],
-    shallow
-  )
+const firstName = usePersonStore((state)=> state.firstName)
+const updateFirstName = usePersonStore((state)=> state.updateFirstName)
 
   return (
     <main>


### PR DESCRIPTION
Description:
This pull request adds import statements to the project's documentation to illustrate how to use the create and shallow functions from the zustand library.

Changes Made:

Added import statement for create from 'zustand'.
Added import statement for shallow from 'zustand/shallow'.

This pr addresses to issue #2024

The script is top before the changes- https://docs.pmnd.rs/zustand/guides/updating-state

Screenshots:
After my changes-
<img width="461" alt="צילום מסך 2023-09-05 203126" src="https://github.com/pmndrs/zustand/assets/114335827/39b224a9-f7b4-4ffe-b3c4-622bf899110d">
