### PR TITLE
fix(docs): Update usage without React on recipes.mdx

### DIFF
--- a/docs/recipes/recipes.mdx
+++ b/docs/recipes/recipes.mdx
@@ -183,7 +183,7 @@ const store = createStore(() => ({ ... }))
 const { getState, setState, subscribe, destroy } = store
 ```
 
-You can use a vanilla store with `useStore` hook available since v4.
+You can use a vanilla store in React with a `useStore` hook.
 
 ```jsx
 import { useStore } from 'zustand'

--- a/docs/recipes/recipes.mdx
+++ b/docs/recipes/recipes.mdx
@@ -183,14 +183,15 @@ const store = createStore(() => ({ ... }))
 const { getState, setState, subscribe, destroy } = store
 ```
 
-You can even consume an existing vanilla store with React:
+You can use a vanilla store with `useStore` hook available since v4.
 
 ```jsx
-import { create } from 'zustand'
+import { useStore } from 'zustand'
 import { vanillaStore } from './vanillaStore'
 
-const useStore = create(vanillaStore)
+const useBoundStore = (selector) => useStore(vanillaStore, selector)
 ```
+
 
 ## Transient updates (for frequent state changes)
 

--- a/docs/recipes/recipes.mdx
+++ b/docs/recipes/recipes.mdx
@@ -192,7 +192,6 @@ import { vanillaStore } from './vanillaStore'
 const useBoundStore = (selector) => useStore(vanillaStore, selector)
 ```
 
-
 ## Transient updates (for frequent state changes)
 
 The `subscribe` function allows components to bind


### PR DESCRIPTION
I've noticed that the usage without React in the recipes section of the documentation shows a deprecated use, which is different from the usage from the readme. This PR makes the recipes usage inline with the readme one.