### PR TITLE
fix(traditional): make defaultEqualityFn optional in TS Types

### DIFF
--- a/src/traditional.ts
+++ b/src/traditional.ts
@@ -65,11 +65,11 @@ export type UseBoundStoreWithEqualityFn<
 type CreateWithEqualityFn = {
   <T, Mos extends [StoreMutatorIdentifier, unknown][] = []>(
     initializer: StateCreator<T, [], Mos>,
-    defaultEqualityFn: <U>(a: U, b: U) => boolean
+    defaultEqualityFn?: <U>(a: U, b: U) => boolean
   ): UseBoundStoreWithEqualityFn<Mutate<StoreApi<T>, Mos>>
   <T>(): <Mos extends [StoreMutatorIdentifier, unknown][] = []>(
     initializer: StateCreator<T, [], Mos>,
-    defaultEqualityFn: <U>(a: U, b: U) => boolean
+    defaultEqualityFn?: <U>(a: U, b: U) => boolean
   ) => UseBoundStoreWithEqualityFn<Mutate<StoreApi<T>, Mos>>
 }
 


### PR DESCRIPTION
## Summary

With the updates in v4.4.0 and the addition of the `createWithEqualityFn`, the types currently require `defaultEqualityFn` when the implementation itself [is optional](https://github.com/pmndrs/zustand/blob/deba6ed0d05b0dcb66c95177035ec8a061715745/src/traditional.ts#L94).

Thank you


## Check List

- [x] `yarn run prettier` for formatting code and docs
