### PR TITLE
feat: add useShallow

### DIFF
--- a/docs/guides/prevent-rerenders-with-use-shallow.md
+++ b/docs/guides/prevent-rerenders-with-use-shallow.md
@@ -13,7 +13,7 @@ equal the previous one.
 
 ## Example
 
-We have a store that associate to each bear a meal and we want to render their names.
+We have a store that associates to each bear a meal and we want to render their names.
 
 ```js
 import { create } from 'zustand'
@@ -60,4 +60,4 @@ export const BearNames = () => {
 }
 ```
 
-Now they can all order other meals without causing unnecessary rerenders of `BearNames`.
+Now they can all order other meals without causing unnecessary rerenders of our `BearNames` component.

--- a/docs/guides/prevent-rerenders-with-use-shallow.md
+++ b/docs/guides/prevent-rerenders-with-use-shallow.md
@@ -61,4 +61,3 @@ export const BearNames = () => {
 ```
 
 Now they can all order other meals without causing unnecessary rerenders of `BearNames`.
-

--- a/docs/guides/prevent-rerenders-with-use-shallow.md
+++ b/docs/guides/prevent-rerenders-with-use-shallow.md
@@ -1,0 +1,64 @@
+---
+title: Prevent rerenders with useShallow
+nav: 16
+---
+
+When you need to subscribe to a computed state from a store, the recommended way is to
+use a selector.
+
+The computed selector will cause a rererender if the output has changed according to [Object.is](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is?retiredLocale=it).
+
+In this case you might want to use `useShallow` to avoid a rerender if the computed value is always shallow
+equal the previous one.
+
+## Example
+
+We have a store that associate to each bear a meal and we want to render their names.
+
+```js
+import { create } from 'zustand'
+
+const useMeals = create(() => ({
+  papaBear: 'large porridge-pot',
+  mamaBear: 'middle-size porridge pot',
+  littleBear: 'A little, small, wee pot',
+}))
+
+export const BearNames = () => {
+  const names = useMeals((state) => Object.keys(state))
+
+  return <div>{names.join(', ')}</div>
+}
+```
+
+Now papa bear wants a pizza instead:
+
+```js
+useMeals.setState({
+  papaBear: 'a large pizza',
+})
+```
+
+This change causes `BearNames` rerenders even tho the actual output of `names` has not changed according to shallow equal.
+
+We can fix that using `useShallow`!
+
+```js
+import { create } from 'zustand'
+import { useShallow } from 'zustand/shallow'
+
+const useMeals = create(() => ({
+  papaBear: 'large porridge-pot',
+  mamaBear: 'middle-size porridge pot',
+  littleBear: 'A little, small, wee pot',
+}))
+
+export const BearNames = () => {
+  const names = useMeals(useShallow((state) => Object.keys(state)))
+
+  return <div>{names.join(', ')}</div>
+}
+```
+
+Now they can all order other meals without causing unnecessary rerenders of `BearNames`.
+

--- a/readme.md
+++ b/readme.md
@@ -86,36 +86,31 @@ const honey = useBearStore((state) => state.honey)
 
 If you want to construct a single object with multiple state-picks inside, similar to redux's mapStateToProps, you can tell zustand that you want the object to be diffed shallowly by passing the `shallow` equality function.
 
-To use a custom equality function, you need `createWithEqualityFn` instead of `create`. Usually you want to specify `Object.is` as the second argument for the default equality function, but it's configurable.
+To prevent unnecessary rerenders when the selector output does not change according to shallow equal, you can use [useShallow](./docs/guides/prevent-rerenders-with-use-shallow.md).
 
 ```jsx
-import { createWithEqualityFn } from 'zustand/traditional'
-import { shallow } from 'zustand/shallow'
+import { create } from 'zustand'
+import { useShallow } from 'zustand/shallow'
 
 // Use createWithEqualityFn instead of create
-const useBearStore = createWithEqualityFn(
-  (set) => ({
-    bears: 0,
-    increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
-    removeAllBears: () => set({ bears: 0 }),
-  }),
-  Object.is // Specify the default equality function, which can be shallow
-)
+const useBearStore = create((set) => ({
+  bears: 0,
+  increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
+  removeAllBears: () => set({ bears: 0 }),
+}))
 
 // Object pick, re-renders the component when either state.nuts or state.honey change
 const { nuts, honey } = useBearStore(
-  (state) => ({ nuts: state.nuts, honey: state.honey }),
-  shallow
+  useShallow((state) => ({ nuts: state.nuts, honey: state.honey }))
 )
 
 // Array pick, re-renders the component when either state.nuts or state.honey change
 const [nuts, honey] = useBearStore(
-  (state) => [state.nuts, state.honey],
-  shallow
+  useShallow((state) => [state.nuts, state.honey])
 )
 
 // Mapped picks, re-renders the component when state.treats changes in order, count or keys
-const treats = useBearStore((state) => Object.keys(state.treats), shallow)
+const treats = useBearStore(useShallow((state) => Object.keys(state.treats)))
 ```
 
 For more control over re-rendering, you may provide any custom equality function.

--- a/readme.md
+++ b/readme.md
@@ -84,9 +84,7 @@ const nuts = useBearStore((state) => state.nuts)
 const honey = useBearStore((state) => state.honey)
 ```
 
-If you want to construct a single object with multiple state-picks inside, similar to redux's mapStateToProps, you can tell zustand that you want the object to be diffed shallowly by passing the `shallow` equality function.
-
-To prevent unnecessary rerenders when the selector output does not change according to shallow equal, you can use [useShallow](./docs/guides/prevent-rerenders-with-use-shallow.md).
+If you want to construct a single object with multiple state-picks inside, similar to redux's mapStateToProps, you can use [useShallow](./docs/guides/prevent-rerenders-with-use-shallow.md) to prevent unnecessary rerenders when the selector output does not change according to shallow equal.
 
 ```jsx
 import { create } from 'zustand'

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,6 @@ To prevent unnecessary rerenders when the selector output does not change accord
 import { create } from 'zustand'
 import { useShallow } from 'zustand/shallow'
 
-// Use createWithEqualityFn instead of create
 const useBearStore = create((set) => ({
   bears: 0,
   increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),

--- a/src/shallow.ts
+++ b/src/shallow.ts
@@ -65,13 +65,10 @@ export default ((objA, objB) => {
 export function useShallow<S, U>(selector: (state: S) => U): (state: S) => U {
   const prev = useRef<U>()
 
-  return useMemo(
-    () => (state) => {
-      const next = selector(state)
-      return shallow(prev.current, next)
-        ? (prev.current as U)
-        : (prev.current = next)
-    },
-    [selector]
-  )
+  return (state) => {
+    const next = selector(state)
+    return shallow(prev.current, next)
+      ? (prev.current as U)
+      : (prev.current = next)
+  }
 }

--- a/src/shallow.ts
+++ b/src/shallow.ts
@@ -1,3 +1,5 @@
+import { useMemo, useRef } from 'react'
+
 export function shallow<T>(objA: T, objB: T) {
   if (Object.is(objA, objB)) {
     return true
@@ -59,3 +61,17 @@ export default ((objA, objB) => {
   }
   return shallow(objA, objB)
 }) as typeof shallow
+
+export function useShallow<S, U>(selector: (state: S) => U): (state: S) => U {
+  const prev = useRef<U>()
+
+  return useMemo(
+    () => (state) => {
+      const next = selector(state)
+      return shallow(prev.current, next)
+        ? (prev.current as U)
+        : (prev.current = next)
+    },
+    [selector]
+  )
+}

--- a/src/shallow.ts
+++ b/src/shallow.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react'
+import { useRef } from 'react'
 
 export function shallow<T>(objA: T, objB: T) {
   if (Object.is(objA, objB)) {

--- a/tests/shallow.test.tsx
+++ b/tests/shallow.test.tsx
@@ -165,6 +165,10 @@ describe('useShallow', () => {
       state: { a: 1, b: 2, c: 3 },
       selector: initialProps.selector,
     })
+
+    expect(res.result.current.selectorOutput).toEqual(
+      res.result.current.useShallowOutput
+    )
   })
 
   it('returns the previously computed instance when possible', () => {
@@ -226,7 +230,7 @@ describe('useShallow', () => {
     expect(res.getByTestId('test-shallow').textContent).toBe('a,b,c,d')
   })
 
-  it('does not cause state closure issues', () => {
+  it('does not cause stale closure issues', () => {
     const store = create((): Record<string, unknown> => ({ a: 1, b: 2, c: 3 }))
     const TestShallowWithState = () => {
       const [count, setCount] = useState(0)

--- a/tests/shallow.test.tsx
+++ b/tests/shallow.test.tsx
@@ -1,6 +1,9 @@
+import { useState } from 'react'
+import { act, fireEvent, render, renderHook } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { create } from 'zustand'
-import { shallow } from 'zustand/shallow'
+import { useStore } from 'zustand/react'
+import { shallow, useShallow } from 'zustand/shallow'
 
 describe('shallow', () => {
   it('compares primitive values', () => {
@@ -129,5 +132,124 @@ describe('unsupported cases', () => {
         new Date('2022-07-20T00:00:00.000Z')
       )
     ).not.toBe(false)
+  })
+})
+
+describe('useShallow', () => {
+  const useTestShallowSimple = <S, U>(props: {
+    selector: (state: S) => U
+    state: S
+  }): { selectorOutput: U; useShallowOutput: U } => {
+    const useShallowOutput = useShallow(props.selector)(props.state)
+    return {
+      selectorOutput: props.selector(props.state),
+      useShallowOutput,
+    }
+  }
+
+  it('input and output selectors always return shallow equal values', () => {
+    const initialProps = {
+      selector: (state: Record<string, number>) => Object.keys(state),
+      state: { a: 1, b: 2 } as Record<string, number>,
+    }
+
+    const res = renderHook((props) => useTestShallowSimple(props), {
+      initialProps,
+    })
+
+    expect(res.result.current.selectorOutput).toEqual(
+      res.result.current.useShallowOutput
+    )
+
+    res.rerender({
+      state: { a: 1, b: 2, c: 3 },
+      selector: initialProps.selector,
+    })
+  })
+
+  it('returns the previously computed instance when possible', () => {
+    const initialProps = {
+      selector: Object.keys,
+      state: { a: 1, b: 2 } as Record<string, number>,
+    }
+
+    const res = renderHook((props) => useTestShallowSimple(props), {
+      initialProps,
+    })
+
+    const output1 = res.result.current.useShallowOutput
+
+    res.rerender({
+      state: initialProps.state,
+      selector: (state: Record<string, number>) => Object.keys(state), // New selector instance
+    })
+    const output2 = res.result.current.useShallowOutput
+
+    expect(output1).toBe(output2)
+    res.rerender(initialProps)
+
+    expect(res.result.current.useShallowOutput).toBe(output1)
+  })
+
+  it('only re-renders if selector output has changed according to shallow', () => {
+    let countRenders = 0
+    const store = create((): Record<string, unknown> => ({ a: 1, b: 2, c: 3 }))
+    const TestShallow = ({
+      selector = (state) => Object.keys(state).sort(),
+    }: {
+      selector?: (state: Record<string, unknown>) => string[]
+    }) => {
+      const output = useStore(store, useShallow(selector))
+
+      ++countRenders
+
+      return <div data-testid="test-shallow">{output.join(',')}</div>
+    }
+
+    expect(countRenders).toBe(0)
+    const res = render(<TestShallow />)
+
+    expect(countRenders).toBe(1)
+    expect(res.getByTestId('test-shallow').textContent).toBe('a,b,c')
+
+    act(() => {
+      store.setState({ a: 4 }) // This will not cause a re-render.
+    })
+
+    expect(countRenders).toBe(1)
+
+    act(() => {
+      store.setState({ d: 10 }) // This will cause a re-render.
+    })
+
+    expect(countRenders).toBe(2)
+    expect(res.getByTestId('test-shallow').textContent).toBe('a,b,c,d')
+  })
+
+  it('does not cause state closure issues', () => {
+    const store = create((): Record<string, unknown> => ({ a: 1, b: 2, c: 3 }))
+    const TestShallowWithState = () => {
+      const [count, setCount] = useState(0)
+      const output = useStore(
+        store,
+        useShallow((state) => Object.keys(state).concat([count.toString()]))
+      )
+
+      return (
+        <div
+          data-testid="test-shallow"
+          onClick={() => setCount((prev) => ++prev)}>
+          {output.join(',')}
+        </div>
+      )
+    }
+
+    const res = render(<TestShallowWithState />)
+
+    expect(res.getByTestId('test-shallow').textContent).toBe('a,b,c,0')
+
+    fireEvent.click(res.getByTestId('test-shallow'))
+
+    expect(res.getByTestId('test-shallow').textContent).toBe('a,b,c,1')
   })
 })


### PR DESCRIPTION
## Summary

Adds a `useShallow` hook to prevent unnecessary re-renders when a selector outputs the same value according to shallow equal. 

### Basic usage

```tsx
import { create } from 'zustand'
import { useShallow } from 'zustand/shallow'

const useMyStore = create(() => ({ a: 1, b: 2, c: 3 }))

export const TestShallow = () => {
  const output = useMyStore(useShallow(Object.keys))

  return <div>{output.join(',')}</div>
}
```

See tests in `shallow.test.tsx` for more details.

---

## Related Issues or Discussions

- https://github.com/pmndrs/zustand/discussions/1937
- https://github.com/pmndrs/zustand/discussions/1937#discussioncomment-7118242
- https://github.com/pmndrs/zustand/discussions/1937#discussioncomment-6974554

## Check List

- [x] `yarn run prettier` for formatting code and docs
