### PR TITLE
fix(types): mitigate devtools typing

### DIFF
--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -8,7 +8,7 @@ import type {
 type Config = Parameters<
   (Window extends { __REDUX_DEVTOOLS_EXTENSION__?: infer T }
     ? T
-    : any)['connect']
+    : { connect: (param: any) => any })['connect']
 >[0]
 
 declare module '../vanilla' {


### PR DESCRIPTION
Follow up #1991.

It infers to `any` instead of `unknown` if the type package isn't found.