### PR TITLE
Fix jest mock for `create` fn to prevent `getState is not a function` error in jest env

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -79,25 +79,15 @@ export const storeResetFns = new Set<() => void>()
 
 // when creating a store, we get its initial state, create a reset function and add it in the set
 export const create = (<T>(stateCreator: zustand.StateCreator<T> | undefined) => {
-  const addRestoreInitialState = (store: ReturnType<typeof zustand.create>) => {
-    const initialState = store.getState()
+    const makeStore = (stateCreator: zustand.StateCreator<T>) => {
+    const store = actualCreate(stateCreator);
+    const initialState = store.getState();
     storeResetFns.add(() => {
-      store.setState(initialState, true)
-    })
-    return store
+      store.setState(initialState, true);
+    });
+    return store;
   };
-
-  if (!stateCreator) {
-    return (stateCreator: zustand.StateCreator<T>) => {
-      const store = actualCreate(stateCreator)
-      return addRestoreInitialState(store)
-    }
-  }
-
-  const store = actualCreate(stateCreator)
-  return Object.assign(() => {
-    return addRestoreInitialState(store)
-  }, store)
+  return stateCreator ? makeStore(stateCreator) : makeStore;
 }) as typeof zustand.create
 
 // when creating a store, we get its initial state, create a reset function and add it in the set

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -78,17 +78,16 @@ const { create: actualCreate, createStore: actualCreateStore } =
 export const storeResetFns = new Set<() => void>()
 
 // when creating a store, we get its initial state, create a reset function and add it in the set
-export const create = (<T>() => {
+export const create = (<T>(stateCreator: zustand.StateCreator<T>) => {
   console.log('zustand create mock')
-
-  return (stateCreator: zustand.StateCreator<T>) => {
-    const store = actualCreate(stateCreator)
+  const store = actualCreate(stateCreator)
+  return Object.assign(() => {
     const initialState = store.getState()
     storeResetFns.add(() => {
       store.setState(initialState, true)
     })
     return store
-  }
+  }, store)
 }) as typeof zustand.create
 
 // when creating a store, we get its initial state, create a reset function and add it in the set


### PR DESCRIPTION
## Related Issues or Discussions

1. Follow instructions to set up jest mock : https://docs.pmnd.rs/zustand/guides/testing#jest

2. Try to run simple test case
```tsx
import { create } from 'zustand'

const useBearStore = create((set) => ({
  bears: 0,
  increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
  removeAllBears: () => set({ bears: 0 }),
}))

test('create should work properle',() => {
  expect(useBearStore.getState().bears).toBe(0); 
 //                                    ^^^ TypeError: useBearStore.getState is not a function
});
```


## Summary

With my changes it's unlock devs to use zustand store in class component without extra mocking   

## Check List

- [x] `yarn run prettier` for formatting code and docs


### To test

```tsx
import { create } from 'zustand';
import { renderHook } from '@testing-library/react-hooks';

interface State {
  bears: number;
  increasePopulation: () => void;
  removeAllBears: () => void;
}

describe('create(initializer: Function)', () => {
  const useBearStore = create<State>((set) => ({
    bears: 0,
    increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
    removeAllBears: () => set({ bears: 0 }),
  }));

  test('create should work properly 1', () => {
    const { result } = renderHook(() => useBearStore((s) => s.bears));
    expect(result.current).toBe(0);

    expect(useBearStore.getState().bears).toBe(0);

    // mutate state to check if next test run will reset state automatically
    useBearStore.getState().increasePopulation();
  });

  test('create should work properly 2', () => {
    const { result } = renderHook(() => useBearStore((s) => s.bears));
    expect(result.current).toBe(0);

    expect(useBearStore.getState().bears).toBe(0);
  });
});

describe('create(initializer: undefined)', () => {
  const createMyStore = create<State>();
  const useBearStore = createMyStore((set) => ({
    bears: 0,
    increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
    removeAllBears: () => set({ bears: 0 }),
  }));

  test('create should work properly 3', () => {
    const { result } = renderHook(() => useBearStore((s) => s.bears));
    expect(result.current).toBe(0);

    expect(useBearStore.getState().bears).toBe(0);

    // mutate state to check if next test run will reset state automatically
    useBearStore.getState().increasePopulation();
  });

  test('create should work properly 4', () => {
    const { result } = renderHook(() => useBearStore((s) => s.bears));
    expect(result.current).toBe(0);
    expect(useBearStore.getState().bears).toBe(0);
  });
});
```
