### PR TITLE
fix(middleware) remove warning if there is no window

### DIFF
--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -141,6 +141,8 @@ const devtoolsImpl: DevtoolsImpl =
   (set, get, api) => {
     const { enabled, anonymousActionType, store, ...options } = devtoolsOptions
 
+    if (typeof window === 'undefined') return fn(set, get, api)
+
     type S = ReturnType<typeof fn> & {
       [store: string]: ReturnType<typeof fn>
     }


### PR DESCRIPTION
## Related Issues or Discussions

Fixes # devtools middleware  running on next.js development (next dev command) 

## Summary
if you develop next.js app, you are getting constant flow of repeating message to install extensions in terminal
so I am proposing an early return, since devtools are useless if there is no window
![image](https://github.com/pmndrs/zustand/assets/72526240/1cdd7694-8241-4e2c-9746-7ad88c52b368)

## Check List

- [x ] `yarn run prettier` for formatting code and docs
