### PR TITLE
fix(build): patch entry points zustand/shallow for CJS

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -185,7 +185,7 @@ module.exports = function (args) {
           createStore: 'vanilla.createStore',
         },
         vanilla: { default: 'vanilla', createStore: 'createStore' },
-        shallow: { default: 'shallow$1', shallow: 'shallow' },
+        shallow: { default: 'shallow', shallow: 'shallow$1' },
       }[c],
     }),
     createESMConfig(`src/${c}.ts`, `dist/esm/${c}.js`),


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #2127

## Summary

When we added a new entry in zustand/shallow, our manual patch broke.
We don't have a test for this, but this patch will go away in v5 anyway.

## Check List

- [ ] `yarn run prettier` for formatting code and docs
