### PR TITLE
Improve types in Immer middleware docs

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -5,7 +5,7 @@ nav: 8
 
 ## Basic usage
 
-The difference when using TypeScript is that instead of writing `create(...)`, you have to write `create<T>()(...)` (notice the extra parenthesis `()` too along with the type parameter) where `T` is the type of the state to annotate it. For example:
+The difference when using TypeScript is that instead of writing `create(...)`, you have to write `create<T>()(...)` (notice the extra parentheses `()` too along with the type parameter) where `T` is the type of the state to annotate it. For example:
 
 ```ts
 import { create } from 'zustand'

--- a/docs/integrations/immer-middleware.md
+++ b/docs/integrations/immer-middleware.md
@@ -34,8 +34,8 @@ type Actions = {
   decrement: (qty: number) => void
 }
 
-export const useCountStore = create(
-  immer<State & Actions>((set) => ({
+export const useCountStore = create<State & Actions>()(
+  immer((set) => ({
     count: 0,
     increment: (qty: number) =>
       set((state) => {
@@ -69,8 +69,8 @@ type Actions = {
   toggleTodo: (todoId: string) => void
 }
 
-export const useTodoStore = create(
-  immer<State & Actions>((set) => ({
+export const useTodoStore = create<State & Actions>()(
+  immer((set) => ({
     todos: {
       '82471c5f-4207-4b1d-abcb-b98547e01a3e': {
         id: '82471c5f-4207-4b1d-abcb-b98547e01a3e',

--- a/docs/integrations/immer-middleware.md
+++ b/docs/integrations/immer-middleware.md
@@ -19,6 +19,8 @@ npm install immer
 
 ## Usage
 
+(Notice the extra parentheses after the type parameter as mentioned in the [Typescript Guide](../guides/typescript.md)).
+
 Updating simple states
 
 ```ts


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #2136

## Summary

Moves the generic type from the `immer` middleware call to `create`. If you use the code as mentioned previously in the docs, you lose IDE introspection on where Actions or State are being used. 

I also added an extra note on the extra parenthesis with a link to the Typescript guide, but if people feel that's superfluous, I can revert that commit.

## Check List

- [x] `yarn run prettier` for formatting code and docs
