### PR TITLE
Add missing parameter in mocking zustand testing guide

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -87,7 +87,7 @@ const createUncurried = <T>(stateCreator: zustand.StateCreator<T>) => {
 }
 
 // when creating a store, we get its initial state, create a reset function and add it in the set
-export const create = (<T>() => {
+export const create = (<T>(stateCreator: zustand.StateCreator<T>) => {
   console.log('zustand create mock')
 
   // to support curried version of create


### PR DESCRIPTION

## Related Issues or Discussions


## Summary

While mocking zustand for tests I encounter and error. It seems that the parameter was missing here, resulting in returning createUncurried instead of createUncurried(stateCreator).

## Check List

- [ ] `yarn run prettier` for formatting code and docs
