### PR TITLE
fix: importing CJS React in ESM

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,14 +1,26 @@
-import {
-  createElement,
-  createContext as reactCreateContext,
-  useContext,
-  useMemo,
-  useRef,
-} from 'react'
+// import {
+//   createElement,
+//   createContext as reactCreateContext,
+//   useContext,
+//   useMemo,
+//   useRef,
+// } from 'react'
+// That doesnt work in ESM, because React libs are CJS only.
+// The following is a workaround until ESM is supported.
+// eslint-disable-next-line import/extensions
+import ReactExports from 'react'
 import type { ReactNode } from 'react'
 import type { StoreApi } from 'zustand'
 // eslint-disable-next-line import/extensions
 import { useStoreWithEqualityFn } from 'zustand/traditional'
+
+const {
+  createElement,
+  createContext: reactCreateContext,
+  useContext,
+  useMemo,
+  useRef,
+} = ReactExports
 
 type UseContextStore<S extends StoreApi<unknown>> = {
   (): ExtractState<S>

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,10 +1,12 @@
-import { useDebugValue } from 'react'
+// import { useDebugValue } from 'react'
 // import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector'
-// This doesn't work in ESM, because use-sync-external-store only exposes CJS.
+// Those don't work in ESM, because React libs are CJS only.
 // See: https://github.com/pmndrs/valtio/issues/452
 // The following is a workaround until ESM is supported.
-// eslint-disable-next-line import/extensions
+/* eslint-disable import/extensions */
+import ReactExports from 'react'
 import useSyncExternalStoreExports from 'use-sync-external-store/shim/with-selector'
+/* eslint-enable import/extensions */
 import { createStore } from './vanilla.ts'
 import type {
   Mutate,
@@ -13,6 +15,7 @@ import type {
   StoreMutatorIdentifier,
 } from './vanilla.ts'
 
+const { useDebugValue } = ReactExports
 const { useSyncExternalStoreWithSelector } = useSyncExternalStoreExports
 
 type ExtractState<S> = S extends { getState: () => infer T } ? T : never

--- a/src/react.ts
+++ b/src/react.ts
@@ -3,10 +3,10 @@
 // Those don't work in ESM, because React libs are CJS only.
 // See: https://github.com/pmndrs/valtio/issues/452
 // The following is a workaround until ESM is supported.
-/* eslint-disable import/extensions */
+// eslint-disable-next-line import/extensions
 import ReactExports from 'react'
+// eslint-disable-next-line import/extensions
 import useSyncExternalStoreExports from 'use-sync-external-store/shim/with-selector'
-/* eslint-enable import/extensions */
 import { createStore } from './vanilla.ts'
 import type {
   Mutate,

--- a/src/react/shallow.ts
+++ b/src/react/shallow.ts
@@ -1,5 +1,11 @@
-import { useRef } from 'react'
+// import { useDebugValue } from 'react'
+// That doesnt work in ESM, because React libs are CJS only.
+// The following is a workaround until ESM is supported.
+// eslint-disable-next-line import/extensions
+import ReactExports from 'react'
 import { shallow } from '../vanilla/shallow.ts'
+
+const { useRef } = ReactExports
 
 export function useShallow<S, U>(selector: (state: S) => U): (state: S) => U {
   const prev = useRef<U>()

--- a/src/traditional.ts
+++ b/src/traditional.ts
@@ -1,10 +1,12 @@
-import { useDebugValue } from 'react'
+// import { useDebugValue } from 'react'
 // import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector'
-// This doesn't work in ESM, because use-sync-external-store only exposes CJS.
+// Those don't work in ESM, because React libs are CJS only.
 // See: https://github.com/pmndrs/valtio/issues/452
 // The following is a workaround until ESM is supported.
-// eslint-disable-next-line import/extensions
+/* eslint-disable import/extensions */
+import ReactExports from 'react'
 import useSyncExternalStoreExports from 'use-sync-external-store/shim/with-selector'
+/* eslint-enable import/extensions */
 import { createStore } from './vanilla.ts'
 import type {
   Mutate,
@@ -13,6 +15,7 @@ import type {
   StoreMutatorIdentifier,
 } from './vanilla.ts'
 
+const { useDebugValue } = ReactExports
 const { useSyncExternalStoreWithSelector } = useSyncExternalStoreExports
 
 type ExtractState<S> = S extends { getState: () => infer T } ? T : never

--- a/src/traditional.ts
+++ b/src/traditional.ts
@@ -3,10 +3,10 @@
 // Those don't work in ESM, because React libs are CJS only.
 // See: https://github.com/pmndrs/valtio/issues/452
 // The following is a workaround until ESM is supported.
-/* eslint-disable import/extensions */
+// eslint-disable-next-line import/extensions
 import ReactExports from 'react'
+// eslint-disable-next-line import/extensions
 import useSyncExternalStoreExports from 'use-sync-external-store/shim/with-selector'
-/* eslint-enable import/extensions */
 import { createStore } from './vanilla.ts'
 import type {
   Mutate,


### PR DESCRIPTION
## Related Issues or Discussions

Fixes https://github.com/pmndrs/zustand/issues/1395#issuecomment-1783619389

## Summary

To avoid errors when Zustand is used on server as ESM.

## Check List

- [x] `yarn run prettier` for formatting code and docs
