### PR TITLE
fix(docs): add missing param in mocked create for Vitest testing guide

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -176,7 +176,7 @@ const createUncurried = <T>(stateCreator: zustand.StateCreator<T>) => {
 }
 
 // when creating a store, we get its initial state, create a reset function and add it in the set
-export const create = (<T>() => {
+export const create = (<T>(stateCreator: zustand.StateCreator<T>) => {
   console.log('zustand create mock')
 
   // to support curried version of create


### PR DESCRIPTION
## Related Issues or Discussions

None

## Summary

While following testing guide for Vitest, I noticed mocked `create` is missing function parameter `stateCreator: zustand.StateCreator<T>`. The PR just adds that.

## Check List

- [x] `yarn run prettier` for formatting code and docs
