### PR TITLE
fix(vanilla): unexpected null state update behavior

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -73,7 +73,7 @@ const createStoreImpl: CreateStoreImpl = (createState) => {
     if (!Object.is(nextState, state)) {
       const previousState = state
       state =
-        replace ?? typeof nextState !== 'object'
+        replace ?? ( typeof nextState !== 'object' || nextState === null )
           ? (nextState as TState)
           : Object.assign({}, state, nextState)
       listeners.forEach((listener) => listener(state, previousState))

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -73,7 +73,7 @@ const createStoreImpl: CreateStoreImpl = (createState) => {
     if (!Object.is(nextState, state)) {
       const previousState = state
       state =
-        replace ?? ( typeof nextState !== 'object' || nextState === null )
+        replace ?? (typeof nextState !== 'object' || nextState === null)
           ? (nextState as TState)
           : Object.assign({}, state, nextState)
       listeners.forEach((listener) => listener(state, previousState))

--- a/tests/vanilla/basic.test.ts
+++ b/tests/vanilla/basic.test.ts
@@ -112,6 +112,24 @@ it('can set the store without merging', () => {
   expect(getState()).toEqual({ b: 2 })
 })
 
+it('can set the object store to null', () => {
+  const { setState, getState } = createStore<{ a: number } | null>(() => ({
+    a: 1,
+  }))
+
+  setState(null)
+
+  expect(getState()).toEqual(null)
+})
+
+it('can set the non-object store to null', () => {
+  const { setState, getState } = createStore<string | null>(() => 'value')
+
+  setState(null)
+
+  expect(getState()).toEqual(null)
+})
+
 it('works with non-object state', () => {
   const store = createStore<number>(() => 1)
   const inc = () => store.setState((c) => c + 1)


### PR DESCRIPTION
unexpected behavior when update state with [`null`]

[current logic here](https://github.com/pmndrs/zustand/blob/main/src/vanilla.ts#L76C28-L76C28)

the code above will cause something like
```typescript
const useStore = create<string | null>(() => 'default');

useStore.setState(null); // will actually run: Object.assign({}, 'default', null)

useStore.getState(); // get { "0": "d", "1": "e", "2": "f", "3": "a", "4": "u", "5": "l",  "6": "t" }
```

