### PR TITLE
fix: Add deprecation notice for getServerState() in WithReact type

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -23,6 +23,7 @@ type ExtractState<S> = S extends { getState: () => infer T } ? T : never
 type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'subscribe'>
 
 type WithReact<S extends ReadonlyStoreApi<unknown>> = S & {
+  /** @deprecated please use api.getState() */
   getServerState?: () => ExtractState<S>
 }
 

--- a/src/traditional.ts
+++ b/src/traditional.ts
@@ -23,6 +23,7 @@ type ExtractState<S> = S extends { getState: () => infer T } ? T : never
 type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'subscribe'>
 
 type WithReact<S extends ReadonlyStoreApi<unknown>> = S & {
+  /** @deprecated please use api.getState() */
   getServerState?: () => ExtractState<S>
 }
 


### PR DESCRIPTION
## Related Issues or Discussions

Related: https://github.com/pmndrs/zustand/discussions/1174#discussioncomment-7888322

## Summary

`api.getServerState` is unused and undocumented. Let's deprecate it for removal in v5 _unless_ we want to provide this as an escape hatch for when server and client state need to differ, if that's the case, then I'll close this and add documentation. @dai-shi, @dbritto-dev, @sewera, thoughts on documentation or deprecation?

## Check List

- [x] `yarn run prettier` for formatting code and docs
