### PR TITLE
Fix a code typo in persisting-store-data.md

### DIFF
--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -672,7 +672,7 @@ export const useBearStore = create<BearState>()(
     }),
     {
       name: 'food-storage',
-      storage,
+      storage: storage,
     },
   ),
 )


### PR DESCRIPTION
## Related Issues or Discussions
The code inside the documentation is `storage` with no values, the correct form would be `storage: storage`

## Check List

- [x] `yarn run prettier` for formatting code and docs
