### PR TITLE
feat: getInitialState

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -228,7 +228,7 @@ Zustand core can be imported and used without the React dependency. The only dif
 import { createStore } from 'zustand/vanilla'
 
 const store = createStore((set) => ...)
-const { getState, setState, subscribe } = store
+const { getState, setState, subscribe, getInitialState } = store
 
 export default store
 ```

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -271,8 +271,6 @@ const oldImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
     api,
   )
 
-  api.getServerState = () => configResult
-
   // a workaround to solve the issue of not storing rehydrated state in sync storage
   // the set(state) value would be later overridden with initial state by create()
   // to avoid this, we merge the state from localStorage into the initial state.

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -271,6 +271,8 @@ const oldImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
     api,
   )
 
+  api.getServerState = () => configResult
+
   // a workaround to solve the issue of not storing rehydrated state in sync storage
   // the set(state) value would be later overridden with initial state by create()
   // to avoid this, we merge the state from localStorage into the initial state.
@@ -424,6 +426,8 @@ const newImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
     get,
     api,
   )
+
+  api.getServerState = () => configResult
 
   // a workaround to solve the issue of not storing rehydrated state in sync storage
   // the set(state) value would be later overridden with initial state by create()

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -425,7 +425,7 @@ const newImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
     api,
   )
 
-  api.getServerState = () => configResult
+  api.getInitialState = () => configResult
 
   // a workaround to solve the issue of not storing rehydrated state in sync storage
   // the set(state) value would be later overridden with initial state by create()

--- a/src/react.ts
+++ b/src/react.ts
@@ -22,13 +22,19 @@ type ExtractState<S> = S extends { getState: () => infer T } ? T : never
 
 type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'subscribe'>
 
+type WithReact<S extends ReadonlyStoreApi<unknown>> = S & {
+  getServerState?: () => ExtractState<S>
+}
+
 let didWarnAboutEqualityFn = false
 
 const identity = <T>(arg: T): T => arg
 
-export function useStore<S extends StoreApi<unknown>>(api: S): ExtractState<S>
+export function useStore<S extends WithReact<StoreApi<unknown>>>(
+  api: S,
+): ExtractState<S>
 
-export function useStore<S extends StoreApi<unknown>, U>(
+export function useStore<S extends WithReact<StoreApi<unknown>>, U>(
   api: S,
   selector: (state: ExtractState<S>) => U,
 ): U
@@ -37,14 +43,14 @@ export function useStore<S extends StoreApi<unknown>, U>(
  * @deprecated Use `useStoreWithEqualityFn` from 'zustand/traditional'
  * https://github.com/pmndrs/zustand/discussions/1937
  */
-export function useStore<S extends StoreApi<unknown>, U>(
+export function useStore<S extends WithReact<StoreApi<unknown>>, U>(
   api: S,
   selector: (state: ExtractState<S>) => U,
   equalityFn: ((a: U, b: U) => boolean) | undefined,
 ): U
 
 export function useStore<TState, StateSlice>(
-  api: StoreApi<TState>,
+  api: WithReact<StoreApi<TState>>,
   selector: (state: TState) => StateSlice = identity as any,
   equalityFn?: (a: StateSlice, b: StateSlice) => boolean,
 ) {
@@ -69,7 +75,7 @@ export function useStore<TState, StateSlice>(
   return slice
 }
 
-export type UseBoundStore<S extends ReadonlyStoreApi<unknown>> = {
+export type UseBoundStore<S extends WithReact<ReadonlyStoreApi<unknown>>> = {
   (): ExtractState<S>
   <U>(selector: (state: ExtractState<S>) => U): U
   /**

--- a/src/react.ts
+++ b/src/react.ts
@@ -24,6 +24,8 @@ type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'subscribe'>
 
 let didWarnAboutEqualityFn = false
 
+const identity = <T>(arg: T): T => arg
+
 export function useStore<S extends StoreApi<unknown>>(api: S): ExtractState<S>
 
 export function useStore<S extends StoreApi<unknown>, U>(
@@ -43,7 +45,7 @@ export function useStore<S extends StoreApi<unknown>, U>(
 
 export function useStore<TState, StateSlice>(
   api: StoreApi<TState>,
-  selector: (state: TState) => StateSlice = api.getState as any,
+  selector: (state: TState) => StateSlice = identity as any,
   equalityFn?: (a: StateSlice, b: StateSlice) => boolean,
 ) {
   if (

--- a/src/react.ts
+++ b/src/react.ts
@@ -67,7 +67,7 @@ export function useStore<TState, StateSlice>(
   const slice = useSyncExternalStoreWithSelector(
     api.subscribe,
     api.getState,
-    api.getInitialState,
+    api.getServerState || api.getInitialState,
     selector,
     equalityFn,
   )

--- a/src/react.ts
+++ b/src/react.ts
@@ -104,6 +104,11 @@ const createImpl = <T>(createState: StateCreator<T, [], []>) => {
   const api =
     typeof createState === 'function' ? createStore(createState) : createState
 
+  if (!api.getServerState) {
+    const initialState = api.getState()
+    api.getServerState = () => initialState
+  }
+
   const useBoundStore: any = (selector?: any, equalityFn?: any) =>
     useStore(api, selector, equalityFn)
 

--- a/src/react.ts
+++ b/src/react.ts
@@ -22,17 +22,11 @@ type ExtractState<S> = S extends { getState: () => infer T } ? T : never
 
 type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'subscribe'>
 
-type WithReact<S extends ReadonlyStoreApi<unknown>> = S & {
-  getServerState?: () => ExtractState<S>
-}
-
 let didWarnAboutEqualityFn = false
 
-export function useStore<S extends WithReact<StoreApi<unknown>>>(
-  api: S,
-): ExtractState<S>
+export function useStore<S extends StoreApi<unknown>>(api: S): ExtractState<S>
 
-export function useStore<S extends WithReact<StoreApi<unknown>>, U>(
+export function useStore<S extends StoreApi<unknown>, U>(
   api: S,
   selector: (state: ExtractState<S>) => U,
 ): U
@@ -41,14 +35,14 @@ export function useStore<S extends WithReact<StoreApi<unknown>>, U>(
  * @deprecated Use `useStoreWithEqualityFn` from 'zustand/traditional'
  * https://github.com/pmndrs/zustand/discussions/1937
  */
-export function useStore<S extends WithReact<StoreApi<unknown>>, U>(
+export function useStore<S extends StoreApi<unknown>, U>(
   api: S,
   selector: (state: ExtractState<S>) => U,
   equalityFn: ((a: U, b: U) => boolean) | undefined,
 ): U
 
 export function useStore<TState, StateSlice>(
-  api: WithReact<StoreApi<TState>>,
+  api: StoreApi<TState>,
   selector: (state: TState) => StateSlice = api.getState as any,
   equalityFn?: (a: StateSlice, b: StateSlice) => boolean,
 ) {
@@ -73,7 +67,7 @@ export function useStore<TState, StateSlice>(
   return slice
 }
 
-export type UseBoundStore<S extends WithReact<ReadonlyStoreApi<unknown>>> = {
+export type UseBoundStore<S extends ReadonlyStoreApi<unknown>> = {
   (): ExtractState<S>
   <U>(selector: (state: ExtractState<S>) => U): U
   /**
@@ -107,13 +101,8 @@ const createImpl = <T>(createState: StateCreator<T, [], []>) => {
       "[DEPRECATED] Passing a vanilla store will be unsupported in a future version. Instead use `import { useStore } from 'zustand'`.",
     )
   }
-  const api = (
+  const api =
     typeof createState === 'function' ? createStore(createState) : createState
-  ) as WithReact<StoreApi<T>>
-
-  const defaultState = api.getState()
-
-  api.getServerState = () => defaultState
 
   const useBoundStore: any = (selector?: any, equalityFn?: any) =>
     useStore(api, selector, equalityFn)

--- a/src/react.ts
+++ b/src/react.ts
@@ -107,8 +107,13 @@ const createImpl = <T>(createState: StateCreator<T, [], []>) => {
       "[DEPRECATED] Passing a vanilla store will be unsupported in a future version. Instead use `import { useStore } from 'zustand'`.",
     )
   }
-  const api =
+  const api = (
     typeof createState === 'function' ? createStore(createState) : createState
+  ) as WithReact<StoreApi<T>>
+
+  const defaultState = api.getState()
+
+  api.getServerState = () => defaultState
 
   const useBoundStore: any = (selector?: any, equalityFn?: any) =>
     useStore(api, selector, equalityFn)

--- a/src/react.ts
+++ b/src/react.ts
@@ -61,7 +61,7 @@ export function useStore<TState, StateSlice>(
   const slice = useSyncExternalStoreWithSelector(
     api.subscribe,
     api.getState,
-    api.getServerState || api.getState,
+    api.getInitialState,
     selector,
     equalityFn,
   )
@@ -105,11 +105,6 @@ const createImpl = <T>(createState: StateCreator<T, [], []>) => {
   }
   const api =
     typeof createState === 'function' ? createStore(createState) : createState
-
-  if (!api.getServerState) {
-    const initialState = api.getState()
-    api.getServerState = () => initialState
-  }
 
   const useBoundStore: any = (selector?: any, equalityFn?: any) =>
     useStore(api, selector, equalityFn)

--- a/src/traditional.ts
+++ b/src/traditional.ts
@@ -26,6 +26,8 @@ type WithReact<S extends ReadonlyStoreApi<unknown>> = S & {
   getServerState?: () => ExtractState<S>
 }
 
+const identity = <T>(arg: T): T => arg
+
 export function useStoreWithEqualityFn<S extends WithReact<StoreApi<unknown>>>(
   api: S,
 ): ExtractState<S>
@@ -41,7 +43,7 @@ export function useStoreWithEqualityFn<
 
 export function useStoreWithEqualityFn<TState, StateSlice>(
   api: WithReact<StoreApi<TState>>,
-  selector: (state: TState) => StateSlice = api.getState as any,
+  selector: (state: TState) => StateSlice = identity as any,
   equalityFn?: (a: StateSlice, b: StateSlice) => boolean,
 ) {
   const slice = useSyncExternalStoreWithSelector(

--- a/src/traditional.ts
+++ b/src/traditional.ts
@@ -47,7 +47,7 @@ export function useStoreWithEqualityFn<TState, StateSlice>(
   const slice = useSyncExternalStoreWithSelector(
     api.subscribe,
     api.getState,
-    api.getServerState || api.getState,
+    api.getServerState || api.getInitialState,
     selector,
     equalityFn,
   )

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -8,6 +8,7 @@ type SetStateInternal<T> = {
 export interface StoreApi<T> {
   setState: SetStateInternal<T>
   getState: () => T
+  getServerState?: () => T
   subscribe: (listener: (state: T, prevState: T) => void) => () => void
   /**
    * @deprecated Use `unsubscribe` returned by `subscribe`

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -8,7 +8,7 @@ type SetStateInternal<T> = {
 export interface StoreApi<T> {
   setState: SetStateInternal<T>
   getState: () => T
-  getServerState?: () => T
+  getInitialState: () => T
   subscribe: (listener: (state: T, prevState: T) => void) => () => void
   /**
    * @deprecated Use `unsubscribe` returned by `subscribe`
@@ -83,6 +83,9 @@ const createStoreImpl: CreateStoreImpl = (createState) => {
 
   const getState: StoreApi<TState>['getState'] = () => state
 
+  const getInitialState: StoreApi<TState>['getInitialState'] = () =>
+    initialState
+
   const subscribe: StoreApi<TState>['subscribe'] = (listener) => {
     listeners.add(listener)
     // Unsubscribe
@@ -98,8 +101,8 @@ const createStoreImpl: CreateStoreImpl = (createState) => {
     listeners.clear()
   }
 
-  const api = { setState, getState, subscribe, destroy }
-  state = createState(setState, getState, api)
+  const api = { setState, getState, getInitialState, subscribe, destroy }
+  const initialState = (state = createState(setState, getState, api))
   return api as any
 }
 

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -31,6 +31,7 @@ it('creates a store hook and api object', () => {
         [Function],
         {
           "destroy": [Function],
+          "getInitialState": [Function],
           "getState": [Function],
           "setState": [Function],
           "subscribe": [Function],

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -31,7 +31,6 @@ it('creates a store hook and api object', () => {
         [Function],
         {
           "destroy": [Function],
-          "getServerState": [Function],
           "getState": [Function],
           "setState": [Function],
           "subscribe": [Function],

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -31,6 +31,7 @@ it('creates a store hook and api object', () => {
         [Function],
         {
           "destroy": [Function],
+          "getServerState": [Function],
           "getState": [Function],
           "setState": [Function],
           "subscribe": [Function],

--- a/tests/vanilla/basic.test.ts
+++ b/tests/vanilla/basic.test.ts
@@ -17,12 +17,13 @@ it('create a store', () => {
     return { value: null }
   })
   expect({ params, result }).toMatchInlineSnapshot(`
-   {
+    {
       "params": [
         [Function],
         [Function],
         {
           "destroy": [Function],
+          "getInitialState": [Function],
           "getState": [Function],
           "setState": [Function],
           "subscribe": [Function],
@@ -30,6 +31,7 @@ it('create a store', () => {
       ],
       "result": {
         "destroy": [Function],
+        "getInitialState": [Function],
         "getState": [Function],
         "setState": [Function],
         "subscribe": [Function],


### PR DESCRIPTION
This PR adds a new `getInitialState` method to the store api, which will always return the initial state that was used to create the store. The `persist` middleware also implements this method because it alters the initial state when restoring from a storage.

In React, this new method can then be used for `getServerSnaphot` in `useSyncExternalStore` to avoid avoid hydration mismatches when the state changes between the SSR and the first CSR. This could happen before when using the persist middleware, but can also happen whenever the store state was changed on the client only before completing the first CSR.

## Related Issues or Discussions

Fixes #1174

## Summary



## Check List

- [x] `yarn run prettier` for formatting code and docs
