### PR TITLE
fix(docs): correct create statement in TypeScript guides

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -415,7 +415,7 @@ const createSharedSlice: StateCreator<
   getBoth: () => get().bears + get().fishes,
 })
 
-const useBoundStore = create<BearSlice & FishSlice & SharedSlice>()((...a) => ({
+const useBoundStore = create<BearSlice & FishSlice & SharedSlice>((...a) => ({
   ...createBearSlice(...a),
   ...createFishSlice(...a),
   ...createSharedSlice(...a),


### PR DESCRIPTION
## Summary

Minor fix of `create()` statement on the [docs](https://docs.pmnd.rs/zustand/guides/typescript#slices-pattern)

## Check List

- [x] `yarn run prettier` for formatting code and docs
