### PR TITLE
[v5]: Drop `getServerState`

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -22,37 +22,30 @@ type ExtractState<S> = S extends { getState: () => infer T } ? T : never
 
 type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'subscribe'>
 
-type WithReact<S extends ReadonlyStoreApi<unknown>> = S & {
-  /** @deprecated please use api.getState() */
-  getServerState?: () => ExtractState<S>
-}
-
 const identity = <T>(arg: T): T => arg
 
-export function useStore<S extends WithReact<StoreApi<unknown>>>(
-  api: S,
-): ExtractState<S>
+export function useStore<S extends StoreApi<unknown>>(api: S): ExtractState<S>
 
-export function useStore<S extends WithReact<StoreApi<unknown>>, U>(
+export function useStore<S extends StoreApi<unknown>, U>(
   api: S,
   selector: (state: ExtractState<S>) => U,
 ): U
 
 export function useStore<TState, StateSlice>(
-  api: WithReact<StoreApi<TState>>,
+  api: StoreApi<TState>,
   selector: (state: TState) => StateSlice = identity as any,
 ) {
   const slice = useSyncExternalStoreWithSelector(
     api.subscribe,
     api.getState,
-    api.getServerState || api.getInitialState,
+    api.getInitialState,
     selector,
   )
   useDebugValue(slice)
   return slice
 }
 
-export type UseBoundStore<S extends WithReact<ReadonlyStoreApi<unknown>>> = {
+export type UseBoundStore<S extends ReadonlyStoreApi<unknown>> = {
   (): ExtractState<S>
   <U>(selector: (state: ExtractState<S>) => U): U
 } & S

--- a/src/traditional.ts
+++ b/src/traditional.ts
@@ -22,35 +22,27 @@ type ExtractState<S> = S extends { getState: () => infer T } ? T : never
 
 type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'subscribe'>
 
-type WithReact<S extends ReadonlyStoreApi<unknown>> = S & {
-  /** @deprecated please use api.getState() */
-  getServerState?: () => ExtractState<S>
-}
-
 const identity = <T>(arg: T): T => arg
 
-export function useStoreWithEqualityFn<S extends WithReact<StoreApi<unknown>>>(
+export function useStoreWithEqualityFn<S extends StoreApi<unknown>>(
   api: S,
 ): ExtractState<S>
 
-export function useStoreWithEqualityFn<
-  S extends WithReact<StoreApi<unknown>>,
-  U,
->(
+export function useStoreWithEqualityFn<S extends StoreApi<unknown>, U>(
   api: S,
   selector: (state: ExtractState<S>) => U,
   equalityFn?: (a: U, b: U) => boolean,
 ): U
 
 export function useStoreWithEqualityFn<TState, StateSlice>(
-  api: WithReact<StoreApi<TState>>,
+  api: StoreApi<TState>,
   selector: (state: TState) => StateSlice = identity as any,
   equalityFn?: (a: StateSlice, b: StateSlice) => boolean,
 ) {
   const slice = useSyncExternalStoreWithSelector(
     api.subscribe,
     api.getState,
-    api.getServerState || api.getInitialState,
+    api.getInitialState,
     selector,
     equalityFn,
   )
@@ -58,9 +50,7 @@ export function useStoreWithEqualityFn<TState, StateSlice>(
   return slice
 }
 
-export type UseBoundStoreWithEqualityFn<
-  S extends WithReact<ReadonlyStoreApi<unknown>>,
-> = {
+export type UseBoundStoreWithEqualityFn<S extends ReadonlyStoreApi<unknown>> = {
   (): ExtractState<S>
   <U>(
     selector: (state: ExtractState<S>) => U,


### PR DESCRIPTION
## Related Issues or Discussions

For #2138

## Summary

After some discussion, we will drop `getServerState` in v5 because it is inaccessible from the userland, and `getInitialState` solves the problem. 

Please let me know if any updates should be made. Thank you

## Check List

- [x] `yarn run prettier` for formatting code and docs
