### PR TITLE
fix broken link caused by typo

### DIFF
--- a/docs/guides/nextjs.md
+++ b/docs/guides/nextjs.md
@@ -15,7 +15,7 @@ These challenges include:
   and again on the client. Having different outputs on both the client and the server will result
   in "hydration errors." The store will have to be initialized on the server and then
   re-initialized on the client with the same data in order to avoid that. Please read more about
-  that in our [SSR and Hydration](./ssr-and-hygration) guide.
+  that in our [SSR and Hydration](./ssr-and-hydration) guide.
 - **SPA routing friendly:** Next.js supports a hybrid model for client side routing, which means
   that in order to reset a store, we need to intialize it at the component level using a
   `Context`.


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #

## Summary
On the nextjs guide, there is a link to ssr and hydration, but the link had a typo in it resulting in a 404 page


## Check List

- [ ] `yarn run prettier` for formatting code and docs
