### PR TITLE
Remove Partial type from init state on nextjs guide

### DIFF
--- a/docs/guides/nextjs.md
+++ b/docs/guides/nextjs.md
@@ -51,12 +51,12 @@ export type CounterActions = {
 
 export type CounterStore = CounterState & CounterActions
 
-export const defaultInitState: Partial<CounterState> = {
+export const defaultInitState: CounterState = {
   count: 0,
 }
 
 export const createCounterStore = (
-  initState: Partial<CounterState> = defaultInitState,
+  initState: CounterState = defaultInitState,
 ) => {
   return createStore<CounterStore>()((set) => ({
     ...initState,


### PR DESCRIPTION
## Related Issues or Discussions

Wrong type

## Check List

- [x] `yarn run prettier` for formatting code and docs
