### PR TITLE
Fix typo in prevent-rerenders-with-use-shallow.md

### DIFF
--- a/docs/guides/prevent-rerenders-with-use-shallow.md
+++ b/docs/guides/prevent-rerenders-with-use-shallow.md
@@ -39,7 +39,7 @@ useMeals.setState({
 })
 ```
 
-This change causes `BearNames` rerenders even tho the actual output of `names` has not changed according to shallow equal.
+This change causes `BearNames` rerenders even though the actual output of `names` has not changed according to shallow equal.
 
 We can fix that using `useShallow`!
 


### PR DESCRIPTION
## Related Issues or Discussions

* n/a

## Summary

* Just a tiny typo fix.


## Check List

- [x] `yarn run prettier` for formatting code and docs
