### PR TITLE
Enable usage of Corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -266,5 +266,6 @@
     "react": {
       "optional": true
     }
-  }
+  },
+  "packageManager": "yarn@1.22.21+sha256.dbed5b7e10c552ba0e1a545c948d5473bc6c5a28ce22a8fd27e493e3e5eb6370"
 }


### PR DESCRIPTION
## Related Issues or Discussions

## Summary

Corepack chooses package manager to use with the field `packageManager`. For users using Yarn through Corepack, this is a real convenience.

## Check List

- [x] `yarn run prettier` for formatting code and docs
