### PR TITLE
feat(slices) add slice module for creating namespaced slices

### DIFF
--- a/src/slice.ts
+++ b/src/slice.ts
@@ -1,62 +1,69 @@
-import { type StoreApi } from './vanilla';
-import { type NamedSet } from './middleware';
+import { type StoreApi } from './vanilla'
+import { type NamedSet } from './middleware'
 
-type FirstSetStateArg<T> = Parameters<StoreApi<T>['setState']>[0];
-export type SetState<T> = (partial: FirstSetStateArg<T>, name?: string) => void;
-export type GetState<T> = StoreApi<T>['getState'];
+type FirstSetStateArg<T> = Parameters<StoreApi<T>['setState']>[0]
+export type SetState<T> = (partial: FirstSetStateArg<T>, name?: string) => void
+export type GetState<T> = StoreApi<T>['getState']
 
-type StateObject = Record<string, any>;
+type StateObject = Record<string, any>
 
 type SliceKey<S extends StateObject> = {
-  [K in keyof S]: S[K] extends S ? K : never;
-}[keyof StateObject];
+  [K in keyof S]: S[K] extends S ? K : never
+}[keyof StateObject]
 
 export const sliceGet = <S extends StateObject, K extends SliceKey<S>>(
   get: GetState<S>,
-  key: K
+  key: K,
 ): GetState<S[K]> => {
-  return () => get()[key];
-};
+  return () => get()[key]
+}
 
 export const sliceSet = <S extends StateObject, K extends SliceKey<S>>(
   set: NamedSet<S>,
-  key: K
+  key: K,
 ): SetState<S[K]> => {
   /**
    * differs from global set in that the `replace` option is removed in
    * favor of a `name` optional arg.
    */
   return (partial: FirstSetStateArg<S[K]>, name?: string) => {
-    const fullName = `${key}.${name ?? 'set'}`;
+    const fullName = `${key}.${name ?? 'set'}`
     set(
       (state) => {
         const nextState =
           typeof partial === 'function'
             ? (partial as (s: S[K]) => S[K])(state[key])
-            : partial;
+            : partial
 
         return {
           [key]: {
             ...state[key],
-            ...nextState
-          }
-        } as Partial<S>;
+            ...nextState,
+          },
+        } as Partial<S>
       },
       false,
-      fullName
-    );
-  };
-};
+      fullName,
+    )
+  }
+}
 
-export type CreateSlice<Slice extends StateObject, AppState extends StateObject = StateObject> = (
+export type CreateSlice<
+  Slice extends StateObject,
+  AppState extends StateObject = StateObject,
+> = (
   set: SetState<Slice>,
   get: GetState<Slice>,
   store: StoreApi<AppState>,
-) => Slice;
+) => Slice
 
 export const slice =
-  <S extends StateObject>(set: NamedSet<S>, get: GetState<S>, store: StoreApi<S>) =>
-    <K extends SliceKey<S>>(k: K, init: CreateSlice<S[K], S>) =>
-      init(sliceSet(set, k), sliceGet(get, k), store);
+  <S extends StateObject>(
+    set: NamedSet<S>,
+    get: GetState<S>,
+    store: StoreApi<S>,
+  ) =>
+  <K extends SliceKey<S>>(k: K, init: CreateSlice<S[K], S>) =>
+    init(sliceSet(set, k), sliceGet(get, k), store)
 
-export default slice;
+export default slice

--- a/src/slice.ts
+++ b/src/slice.ts
@@ -1,0 +1,62 @@
+import { type StoreApi } from './vanilla';
+import { type NamedSet } from './middleware';
+
+type FirstSetStateArg<T> = Parameters<StoreApi<T>['setState']>[0];
+export type SetState<T> = (partial: FirstSetStateArg<T>, name?: string) => void;
+export type GetState<T> = StoreApi<T>['getState'];
+
+type StateObject = Record<string, any>;
+
+type SliceKey<S extends StateObject> = {
+  [K in keyof S]: S[K] extends S ? K : never;
+}[keyof StateObject];
+
+export const sliceGet = <S extends StateObject, K extends SliceKey<S>>(
+  get: GetState<S>,
+  key: K
+): GetState<S[K]> => {
+  return () => get()[key];
+};
+
+export const sliceSet = <S extends StateObject, K extends SliceKey<S>>(
+  set: NamedSet<S>,
+  key: K
+): SetState<S[K]> => {
+  /**
+   * differs from global set in that the `replace` option is removed in
+   * favor of a `name` optional arg.
+   */
+  return (partial: FirstSetStateArg<S[K]>, name?: string) => {
+    const fullName = `${key}.${name ?? 'set'}`;
+    set(
+      (state) => {
+        const nextState =
+          typeof partial === 'function'
+            ? (partial as (s: S[K]) => S[K])(state[key])
+            : partial;
+
+        return {
+          [key]: {
+            ...state[key],
+            ...nextState
+          }
+        } as Partial<S>;
+      },
+      false,
+      fullName
+    );
+  };
+};
+
+export type CreateSlice<Slice extends StateObject, AppState extends StateObject = StateObject> = (
+  set: SetState<Slice>,
+  get: GetState<Slice>,
+  store: StoreApi<AppState>,
+) => Slice;
+
+export const slice =
+  <S extends StateObject>(set: NamedSet<S>, get: GetState<S>, store: StoreApi<S>) =>
+    <K extends SliceKey<S>>(k: K, init: CreateSlice<S[K], S>) =>
+      init(sliceSet(set, k), sliceGet(get, k), store);
+
+export default slice;

--- a/tests/slice-namespace.test.tsx
+++ b/tests/slice-namespace.test.tsx
@@ -1,0 +1,67 @@
+import { useEffect } from 'react'
+import { render } from '@testing-library/react'
+import { it } from 'vitest'
+import { create } from 'zustand'
+import { type CreateSlice, slice } from 'zustand/slice';
+
+type SliceAState = {
+  count: number;
+  incrementA: VoidFunction;
+}
+
+type SliceBState = {
+  count: number;
+  decrementB: VoidFunction;
+}
+
+type AppState = {
+  sliceA: SliceAState;
+  sliceB: SliceBState;
+}
+
+it('can create a store with namespaced slices', async () => {
+  const createSliceA: CreateSlice<SliceAState> = (set, get) => ({
+    count: 0,
+    incrementA: () => set({ count: get().count + 1 }, 'incrementA'),
+  });
+
+  const createSliceB: CreateSlice<SliceBState> = (set, get) => ({
+    count: 0,
+    decrementB: () => set({ count: get().count - 1 }),
+  });
+
+  const useBoundStore = create<AppState>((set, get, store) => {
+    const createSlice = slice(set, get, store);
+    return {
+      sliceA: createSlice<'sliceA'>('sliceA', createSliceA),
+      sliceB: createSlice<'sliceB'>('sliceB', createSliceB),
+    };
+  });
+
+  const useSliceA = () => useBoundStore(s => s.sliceA);
+  const useSliceB = () => useBoundStore(s => s.sliceB);
+
+  const Counter: React.FC = () => {
+    const { incrementA, count: countA } = useSliceA();
+    const { decrementB, count: countB } = useSliceB();
+
+    useEffect(incrementA, [incrementA]);
+    useEffect(decrementB, [decrementB]);
+
+    return (
+      <div>
+        <div>count a: {countA}</div>
+        <div>count b: {countB}</div>
+      </div>
+    )
+  }
+
+  const { findByText } = render(
+    <>
+      <Counter />
+    </>
+  );
+
+  await findByText('count a: 1');
+  await findByText('count b: -1');
+});

--- a/tests/slice-namespace.test.tsx
+++ b/tests/slice-namespace.test.tsx
@@ -2,51 +2,51 @@ import { useEffect } from 'react'
 import { render } from '@testing-library/react'
 import { it } from 'vitest'
 import { create } from 'zustand'
-import { type CreateSlice, slice } from 'zustand/slice';
+import { type CreateSlice, slice } from 'zustand/slice'
 
 type SliceAState = {
-  count: number;
-  incrementA: VoidFunction;
+  count: number
+  incrementA: VoidFunction
 }
 
 type SliceBState = {
-  count: number;
-  decrementB: VoidFunction;
+  count: number
+  decrementB: VoidFunction
 }
 
 type AppState = {
-  sliceA: SliceAState;
-  sliceB: SliceBState;
+  sliceA: SliceAState
+  sliceB: SliceBState
 }
 
 it('can create a store with namespaced slices', async () => {
   const createSliceA: CreateSlice<SliceAState> = (set, get) => ({
     count: 0,
     incrementA: () => set({ count: get().count + 1 }, 'incrementA'),
-  });
+  })
 
   const createSliceB: CreateSlice<SliceBState> = (set, get) => ({
     count: 0,
     decrementB: () => set({ count: get().count - 1 }),
-  });
+  })
 
   const useBoundStore = create<AppState>((set, get, store) => {
-    const createSlice = slice(set, get, store);
+    const createSlice = slice(set, get, store)
     return {
       sliceA: createSlice<'sliceA'>('sliceA', createSliceA),
       sliceB: createSlice<'sliceB'>('sliceB', createSliceB),
-    };
-  });
+    }
+  })
 
-  const useSliceA = () => useBoundStore(s => s.sliceA);
-  const useSliceB = () => useBoundStore(s => s.sliceB);
+  const useSliceA = () => useBoundStore((s) => s.sliceA)
+  const useSliceB = () => useBoundStore((s) => s.sliceB)
 
   const Counter: React.FC = () => {
-    const { incrementA, count: countA } = useSliceA();
-    const { decrementB, count: countB } = useSliceB();
+    const { incrementA, count: countA } = useSliceA()
+    const { decrementB, count: countB } = useSliceB()
 
-    useEffect(incrementA, [incrementA]);
-    useEffect(decrementB, [decrementB]);
+    useEffect(incrementA, [incrementA])
+    useEffect(decrementB, [decrementB])
 
     return (
       <div>
@@ -59,9 +59,9 @@ it('can create a store with namespaced slices', async () => {
   const { findByText } = render(
     <>
       <Counter />
-    </>
-  );
+    </>,
+  )
 
-  await findByText('count a: 1');
-  await findByText('count b: -1');
-});
+  await findByText('count a: 1')
+  await findByText('count b: -1')
+})


### PR DESCRIPTION
I use Zustand for a fairly large project with many different slices where using the currently documented approach would be too cumbersome and lead to possible clashes between slice properties. This approach, which I've been using for a while, has been effective at keeping the slices separate, however after upgrading Zustand I updated my slice code to fix some bugs in my implementation and to work better with the `devtools` middleware.

I figured I'd share/start a convo here if anybody was interested in this approach

## Summary
- New `slice` module for creating namespaced slices (somewhat similar to redux's `combineReducers`
- Exported `CreateSlice` type for defining slices
- Exported `slice` factory function for creating slices and attaching them to the main store
- Slice `set` function has different API than the default, removing the `replace` parameter in lieu of an optional `name` string
- An example gist: https://gist.github.com/weeksie/46a7e5fa1ddc481917155be856018dfd

Here's a screenshot of devtools from a project that uses a pretty big/complex store. I had only added name strings to a few of the existing calls, but even the default name is nice because they're scoped to the slice namespace.

![image](https://github.com/pmndrs/zustand/assets/147798/645330dd-c8dd-46b5-93ac-82cc35a1a4b0)

Anyway, I just want to say thanks for creating Zustand, it's been a wonderful addition to my workflow and a delight to use.

## Check List

- [x] `yarn run prettier` for formatting code and docs
