### PR TITLE
Fix devtools warning in CLI

### DIFF
--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -158,7 +158,11 @@ const devtoolsImpl: DevtoolsImpl =
     }
 
     if (!extensionConnector) {
-      if (import.meta.env?.MODE !== 'production' && enabled) {
+      if (
+        typeof window !== 'undefined' &&
+        import.meta.env?.MODE !== 'production' &&
+        enabled
+      ) {
         console.warn(
           '[zustand devtools middleware] Please install/enable Redux devtools extension',
         )


### PR DESCRIPTION
## Related Issues or Discussions

n/a

## Summary

The warning always shows in the CLI. This fixes it.