### PR TITLE
Remove extension warning

### DIFF
--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -158,11 +158,6 @@ const devtoolsImpl: DevtoolsImpl =
     }
 
     if (!extensionConnector) {
-      if (import.meta.env?.MODE !== 'production' && enabled) {
-        console.warn(
-          '[zustand devtools middleware] Please install/enable Redux devtools extension',
-        )
-      }
       return fn(set, get, api)
     }
 


### PR DESCRIPTION
## Related Issues or Discussions

#2404 

## Summary

This PR removes the Redux extension warning entirely.