### PR TITLE
refactor: simplify SkipTwo type definition

### DIFF
--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -18,19 +18,7 @@ declare module '../vanilla' {
 }
 
 type Write<T, U> = Omit<T, keyof U> & U
-type SkipTwo<T> = T extends { length: 0 }
-  ? []
-  : T extends { length: 1 }
-    ? []
-    : T extends { length: 0 | 1 }
-      ? []
-      : T extends [unknown, unknown, ...infer A]
-        ? A
-        : T extends [unknown, unknown?, ...infer A]
-          ? A
-          : T extends [unknown?, unknown?, ...infer A]
-            ? A
-            : never
+type SkipTwo<T> = T extends [unknown?, unknown?, ...infer A] ? A : []
 
 type WithImmer<S> = Write<S, StoreImmer<S>>
 


### PR DESCRIPTION
## Summary

Just a small suggestion. 💙

Refactor the SkipTwo type definition to improve readability and reduce complexity. 

Previously, the type used a nested ternary operator, which made it harder to understand at a glance. The refactoring simplifies the conditional checks for arrays with a length of 0 or 1, always returning an empty array in these cases.

For arrays of length 3 or more, the type now correctly infers and returns the remaining elements `A` after skipping the first two. 

## Check List

- [x] `yarn run prettier` for formatting code and docs
