### PR TITLE
Export WithImmer type to use with UseBoundStoreWithEqualityFn

### DIFF
--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -32,7 +32,7 @@ type SkipTwo<T> = T extends { length: 0 }
             ? A
             : never
 
-type WithImmer<S> = Write<S, StoreImmer<S>>
+export type WithImmer<S> = Write<S, StoreImmer<S>>
 
 type StoreImmer<S> = S extends {
   getState: () => infer T


### PR DESCRIPTION
## Related Issues or Discussions

As I'm using multiple stores in the same app, I created the following helper:
```ts
export function createStore<S>(initializer: StateCreator<S, [['zustand/immer', never]], []>) {
  return createWithEqualityFn<S>()(immer(initializer), shallow)
}
```

While extracting the `createStore` helper to a `utilities` package with `"declaration": true,` I'm facing an inference issue for the return type.

As a workaround, I copied the `WithImmer` type to my project:

```ts
import type { Draft } from 'immer'

type SkipTwo<T> = T extends {
  length: 0
}
  ? []
  : T extends {
      length: 1
    }
  ? []
  : T extends {
      length: 0 | 1
    }
  ? []
  : T extends [unknown, unknown, ...infer A]
  ? A
  : T extends [unknown, unknown?, ...infer A]
  ? A
  : T extends [unknown?, unknown?, ...infer A]
  ? A
  : never

type StoreImmer<S> = S extends {
  getState: () => infer T
  setState: infer SetState
}
  ? SetState extends (...a: infer A) => infer Sr
    ? {
        setState(
          nextStateOrUpdater: T | Partial<T> | ((state: Draft<T>) => void),
          shouldReplace?: boolean | undefined,
          ...a: SkipTwo<A>
        ): Sr
      }
    : never
  : never
type Write<T, U> = Omit<T, keyof U> & U
type WithImmer<S> = Write<S, StoreImmer<S>>
```

then:

```ts
export function createStore<S>(
  initializer: StateCreator<S, [['zustand/immer', never]], []>
): UseBoundStoreWithEqualityFn<WithImmer<StoreApi<S>>> {
  return createWithEqualityFn<S>()(immer(initializer), shallow)
}
```

I see that exporting the `WithImmer` type may be helpful for cases like mine.

Fixes #

Type error: The inferred type of 'createStore' cannot be named without a reference to '.pnpm/immer@10.0.4/node_modules/immer'. This is likely not portable. A type annotation is necessary.

## Summary

I'm not aware of another way to solve the explained issue, that's why I thought to create this PR and get it in the library so we can use it directly instead of duplicating those types.

## Check List

- [ x] `yarn run prettier` for formatting code and docs
