### PR TITLE
[v5] Remove Devtools warning

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -360,6 +360,8 @@ const useGrumpyStore = create(redux(reducer, initialState))
 
 ## Redux devtools
 
+Install the [Redux DevTools Chrome extension](https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) to use the devtools middleware.
+
 ```jsx
 import { devtools } from 'zustand/middleware'
 

--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -158,11 +158,6 @@ const devtoolsImpl: DevtoolsImpl =
     }
 
     if (!extensionConnector) {
-      if (import.meta.env?.MODE !== 'production' && enabled) {
-        console.warn(
-          '[zustand devtools middleware] Please install/enable Redux devtools extension',
-        )
-      }
       return fn(set, get, api)
     }
 
@@ -269,7 +264,7 @@ const devtoolsImpl: DevtoolsImpl =
                 if (Object.keys(action.state as S).length !== 1) {
                   console.error(
                     `
-                    [zustand devtools middleware] Unsupported __setState action format. 
+                    [zustand devtools middleware] Unsupported __setState action format.
                     When using 'store' option in devtools(), the 'state' should have only one key, which is a value of 'store' that was passed in devtools(),
                     and value of this only key should be a state object. Example: { "type": "__setState", "state": { "abc123Store": { "foo": "bar" } } }
                     `,

--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -153,16 +153,6 @@ describe('If there is no extension installed...', () => {
     createStore(devtools(() => ({ count: 0 })))
     expect(console.warn).not.toBeCalled()
   })
-
-  it.skip('[PRD-ONLY] does not warn if not in dev env', async () => {
-    createStore(devtools(() => ({ count: 0 })))
-    expect(console.warn).not.toBeCalled()
-  })
-
-  it.skip('[PRD-ONLY] does not warn if not in dev env even if enabled', async () => {
-    createStore(devtools(() => ({ count: 0 }), { enabled: true }))
-    expect(console.warn).not.toBeCalled()
-  })
 })
 
 describe('When state changes...', () => {

--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -154,11 +154,6 @@ describe('If there is no extension installed...', () => {
     expect(console.warn).not.toBeCalled()
   })
 
-  it('[DEV-ONLY] warns if enabled in dev mode', async () => {
-    createStore(devtools(() => ({ count: 0 }), { enabled: true }))
-    expect(console.warn).toBeCalled()
-  })
-
   it.skip('[PRD-ONLY] does not warn if not in dev env', async () => {
     createStore(devtools(() => ({ count: 0 })))
     expect(console.warn).not.toBeCalled()

--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -148,11 +148,6 @@ describe('If there is no extension installed...', () => {
       createStore(devtools(() => ({ count: 0 })))
     }).not.toThrow()
   })
-
-  it('does not warn if not enabled', async () => {
-    createStore(devtools(() => ({ count: 0 })))
-    expect(console.warn).not.toBeCalled()
-  })
 })
 
 describe('When state changes...', () => {

--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -148,6 +148,11 @@ describe('If there is no extension installed...', () => {
       createStore(devtools(() => ({ count: 0 })))
     }).not.toThrow()
   })
+
+  it('does not warn if not enabled', async () => {
+    createStore(devtools(() => ({ count: 0 })))
+    expect(console.warn).not.toBeCalled()
+  })
 })
 
 describe('When state changes...', () => {

--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -149,7 +149,7 @@ describe('If there is no extension installed...', () => {
     }).not.toThrow()
   })
 
-  it('does not warn if not enabled', async () => {
+  it('does not warn', async () => {
     createStore(devtools(() => ({ count: 0 })))
     expect(console.warn).not.toBeCalled()
   })


### PR DESCRIPTION
For #2138

## Related Issues or Discussions

Fixes #2404
Related #2405 

## Summary

Using the devtools middleware will warn in all non-browser environments during development. This was added many years ago and likely can be removed. The docs are updated to link to the Redux DevTools Chrome extension. 

## Check List

- [x] `yarn run prettier` for formatting code and docs
