### PR TITLE
fix: delete root keys with immer middleware

### DIFF
--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -57,9 +57,19 @@ const immerImpl: ImmerImpl = (initializer) => (set, get, store) => {
   type T = ReturnType<typeof initializer>
 
   store.setState = (updater, replace, ...a) => {
-    const nextState = (
-      typeof updater === 'function' ? produce(updater as any) : updater
-    ) as ((s: T) => T) | T | Partial<T>
+    if (replace === false) {
+      throw new Error(
+        '`replace` must be `true` (or nullish) when using the `immer` middleware.',
+      )
+    }
+    // We always want to `replace` with `immer`.
+    replace = true
+    if (typeof updater !== 'function') {
+      throw new Error(
+        'You must pass a function to `setState` when using the `immer` middleware.',
+      )
+    }
+    const nextState = produce(updater as any) as (s: T) => T
 
     return set(nextState as any, replace, ...a)
   }

--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -55,7 +55,7 @@ type ImmerImpl = <T>(
 const immerImpl: ImmerImpl = (initializer) => (set, get, store) => {
   type T = ReturnType<typeof initializer>
 
-  store.setState = (updater, ...a) => {
+  store.setState = (updater, _, ...a) => {
     const nextState = produce(updater as any) as (s: T) => T
 
     return set(nextState as any, /* replace */ true, ...a)

--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -42,6 +42,7 @@ type StoreImmer<S> = S extends {
     ? {
         setState(
           nextStateOrUpdater: T | Partial<T> | ((state: Draft<T>) => void),
+          shouldReplace?: boolean | undefined,
           ...a: SkipTwo<A>
         ): Sr
       }

--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -42,7 +42,6 @@ type StoreImmer<S> = S extends {
     ? {
         setState(
           nextStateOrUpdater: T | Partial<T> | ((state: Draft<T>) => void),
-          shouldReplace?: boolean | undefined,
           ...a: SkipTwo<A>
         ): Sr
       }
@@ -56,22 +55,10 @@ type ImmerImpl = <T>(
 const immerImpl: ImmerImpl = (initializer) => (set, get, store) => {
   type T = ReturnType<typeof initializer>
 
-  store.setState = (updater, replace, ...a) => {
-    if (replace === false) {
-      throw new Error(
-        '`replace` must be `true` (or nullish) when using the `immer` middleware.',
-      )
-    }
-    // We always want to `replace` with `immer`.
-    replace = true
-    if (typeof updater !== 'function') {
-      throw new Error(
-        'You must pass a function to `setState` when using the `immer` middleware.',
-      )
-    }
+  store.setState = (updater, ...a) => {
     const nextState = produce(updater as any) as (s: T) => T
 
-    return set(nextState as any, replace, ...a)
+    return set(nextState as any, /* replace */ true, ...a)
   }
 
   return initializer(store.setState, get, store)

--- a/tests/immerMiddleware.test.tsx
+++ b/tests/immerMiddleware.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+import { createStore } from 'zustand/vanilla'
+
+describe('immer middleware', () => {
+  it('typical case', () => {
+    type CounterState = {
+      count: number
+      inc: () => void
+    }
+
+    const useBoundStore = create<CounterState>()(
+      immer((set, get) => ({
+        count: 0,
+        inc: () =>
+          set((state) => {
+            state.count = get().count + 1
+          }),
+      })),
+    )
+
+    expect(useBoundStore.getState().count).toEqual(0)
+
+    useBoundStore.getState().inc()
+
+    expect(useBoundStore.getState().count).toEqual(1)
+  })
+
+  it('`replace` must not be `false` in `setState`', () => {
+    const store = createStore<Record<string, any>>()(immer(() => ({})))
+
+    expect(() => {
+      store.setState((state) => {
+        state.x = 3
+      }, /* replace */ false)
+    }).toThrow('must be `true`')
+  })
+
+  it('must pass a function to `setState`', () => {
+    const store = createStore<Record<string, any>>()(immer(() => ({})))
+
+    expect(() => {
+      store.setState({ x: 3 })
+    }).toThrow('must pass a function')
+  })
+
+  // Bug: https://github.com/pmndrs/zustand/discussions/2480
+  it('delete key at root of state', () => {
+    type State = Record<string, any>
+
+    const store = createStore<State>()(immer(() => ({})))
+
+    expect(store.getState()).toEqual({})
+
+    store.setState((state) => {
+      state.x = 3
+    })
+
+    expect(store.getState()).toEqual({ x: 3 })
+    store.setState((state) => {
+      delete state.x
+    })
+    expect(store.getState()).toEqual({})
+  })
+})

--- a/tests/immerMiddleware.test.tsx
+++ b/tests/immerMiddleware.test.tsx
@@ -27,24 +27,6 @@ describe('immer middleware', () => {
     expect(useBoundStore.getState().count).toEqual(1)
   })
 
-  it('`replace` must not be `false` in `setState`', () => {
-    const store = createStore<Record<string, any>>()(immer(() => ({})))
-
-    expect(() => {
-      store.setState((state) => {
-        state.x = 3
-      }, /* replace */ false)
-    }).toThrow('must be `true`')
-  })
-
-  it('must pass a function to `setState`', () => {
-    const store = createStore<Record<string, any>>()(immer(() => ({})))
-
-    expect(() => {
-      store.setState({ x: 3 })
-    }).toThrow('must pass a function')
-  })
-
   // Bug: https://github.com/pmndrs/zustand/discussions/2480
   it('delete key at root of state', () => {
     type State = Record<string, any>


### PR DESCRIPTION
## Related Issues or Discussions

Fixes #2480

## Summary

Currently when calling `setState` with the `immer` middleware, `replace=false` is assumed by default. This means that the old state is merged with immer's `produce` output. I don't think there is any reason to merge those states: immer's `produce` already returns a smart version of the whole state where copies are used whenever possible. The merging is mostly equivalent to `replace=True`, *except* when keys are deleted: the old deleted keys get merged with the new state.

I'm also assuming that when using the `immer` middleware, we always want to do something like

```typescript
store.setState((state) => { state.x = 3})
```

and never
```typescript
store.setState({x: 3})
```
so I simplified the middleware consequently.

I added a test to reproduce the bug and some other simple tests.

**Someone with more experience with the `immer` middleware should double-check all this! There could very well be usage patterns that I'm not aware of.**



## Check List

- [x] `yarn run prettier` for formatting code and docs


@dai-shi @dbritto-dev Let me know if I can improve anything in the PR.