### PR TITLE
Add T | Partial<T> to immer middleware's TS return type

### DIFF
--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -41,7 +41,10 @@ type StoreImmer<S> = S extends {
   ? SetState extends (...a: infer A) => infer Sr
     ? {
         setState(
-          nextStateOrUpdater: T | Partial<T> | ((state: Draft<T>) => void),
+          nextStateOrUpdater:
+            | T
+            | Partial<T>
+            | ((state: Draft<T>) => T | Partial<T> | void),
           shouldReplace?: boolean | undefined,
           ...a: SkipTwo<A>
         ): Sr


### PR DESCRIPTION
## Related Issues or Discussions
#2491

## Summary
The `immer` middleware adds the capability to modify the `Draft<T>` in a `setState` call in-place and not return a partial state value.  But the vanilla functionality of returning a `T | Partial<T>`, without modifying the input state draft, is still supported and works properly.

However, the `immer` middleware's type definition does not currently contain the `T | Partial<T>` option and returns only `void`, which can lead to invalid code compiling cleanly but wrecking the underlying store since *anything* is assignable to `void` (see [playground](https://www.typescriptlang.org/play?exactOptionalPropertyTypes=true&ssl=1&ssc=1&pln=2&pc=1#code/JYWwDg9gTgLgBAbzgYygUwIYzQGjgZRizQGF0to4BfOAMyghDgCIAvAVwGciA7AE2YBuAFChIsRHFAg0UanQZM2XXnwD0IYHz4AbNAHcM6NdNlDhontii0MyNHABCmKPh3B7iYXDgAjF5wAXHA87CD+UCI+GNrORsEAFACUcAC8AHxwAG4QWlFwmDAAYsCcABaJKRnZuXwiVBbAVrK2niXlbh4OCN50pWVoQSFhEfkxfO0VcMlpmTl5veOTAIL8juQA1nFQQzPV83W9fIMwDACeACoDAKLIEJxn3GgglbM1Cw2W1q0O+GVGaD4nU8PWisQgMCmezmtXyAHM0DBHBCoVUYR8LHceNwUORsJNgWhgoRiGRCtAADy9baEuAAMjgBPc9hwvQA2mzlNwMPwTCAZFBmHgeGgsrIALri1k+NlS3pMrrCTKpaacRFo6agvrlQbBAAM0rgajUTjQyAwXAcEFocEhDlMcmOyB0RiwwAgPDwdttZzAVptapgM1KiQS3OwwQAIlAMLQYBSLukNQdesa4FdZGhaNAHGcIOwUDy4OgYOwoDw4DyzpCmnCAHSLbSTV4ZXo+NNXUpwD32zhSZrobi1vCcJqeDB9-RQYAwbCe21lLtdu5QdDIeA8vhwPgQQZwfT-eB5gtoAAefvXDZ87ZNAAkIPpRbIpDbvTBff6WP4jJxmPvM7aEAoP8PAIl6i6TvmOhbkOOg6CgjBgMAeiVvwlZwJw7C+DAehtkaJq+OwcL7lBW7+P2pwQHw7D2HwV7XoGCRhkQ2AagkSC0P0uoYSxaB1pxOp9gA1HAACMeDfjs+rUEkSSGks-SrHw6yYFsAQtukeFpvgWE4Q4hFwkMzACWUf5NE8MTdjaxlcb+qFbswkl2V2PAPguDhTh6xHvn69E+IxzHEGxHH9ME4Z8SZe4ieJfjqXAADkrn6HAACSlZMBgPHTqB8UyXJRwnOcGa3PcjzYC80xonhAXhRqWrXvhcAALI5gUcLoHC7pcH4RHBGgVjAOgPHEFIfb-PymZbhAYpyIR8AXPgCHgMhe7OpgPA6GcdY+AAckBdzLXoUB4TeBSrtAfZzXAx7xVuCIbsW7ADTIZ0MHIph8MAxCbX514lmWFYACwAEx4VQSTCODIhAA)).  This PR does not add any runtime JS functionality, but adds `T | Partial<T>` to the immer middleware's return type, so that if you are using immer middleware and you *do* return a value in a `setState`, that it will be type-checked.

## Check List

- [x] `yarn run prettier` for formatting code and docs
