### PR TITLE
Simplifies vanilla `StoreApi`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ If you want to contribute to the [documentation](./docs/):
   As a temporary measure, you can do the following
   (don't commit any changes made in the pmndrs/website repo):
   - In your own Zustand fork, create a new working branch
-    (further related to as `[your-branch]`);
+    (referred to as `[your-branch]` going forward);
   - Inside website codebase, open `src/data/libraries.ts`;
   - Within the `zustand` key,
     change `docs: 'pmndrs/zustand/main/docs'`

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -19,10 +19,10 @@ type Get<T, K, F> = K extends keyof T ? T[K] : F
 export type Mutate<S, Ms> = number extends Ms['length' & keyof Ms]
   ? S
   : Ms extends []
-  ? S
-  : Ms extends [[infer Mi, infer Ma], ...infer Mrs]
-  ? Mutate<StoreMutators<S, Ma>[Mi & StoreMutatorIdentifier], Mrs>
-  : never
+    ? S
+    : Ms extends [[infer Mi, infer Ma], ...infer Mrs]
+      ? Mutate<StoreMutators<S, Ma>[Mi & StoreMutatorIdentifier], Mrs>
+      : never
 
 export type StateCreator<
   T,
@@ -36,7 +36,7 @@ export type StateCreator<
 ) => U) & { $$storeMutators?: Mos }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-interface
-export interface StoreMutators<S, A> { }
+export interface StoreMutators<S, A> {}
 export type StoreMutatorIdentifier = keyof StoreMutators<unknown, unknown>
 
 type CreateStore = {

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -1,7 +1,4 @@
-// This type intentionally shadows globalThis.Partial.
-// Keeping the name the same hides an implementation
-// detail from users, which is that this version is
-// evaluates its type argument _greedily_.
+// Shows users better types sooner than globalThis.Partial
 type Partial<T> = never | { [K in keyof T]+?: T[K] }
 
 export interface StoreApi<T> extends Deprecated.Api {


### PR DESCRIPTION
## Related Issues or Discussions
I will circle back later today and add comments explaining in more detail

## Summary
- removes `SetStateInternal` in favor of inline definition
- replaces `Partial` with a greedy version (lets us show users concrete types sooner)
- removes the type assertion on `partial` by fixing the variance hack elsewhere
- moves deprecated subset of the StoreApi to separate interface, to create some separation between them


## Check List

- [x] `yarn run prettier` for formatting code and docs
