### PR TITLE
Fix typos in nextjs.md

### DIFF
--- a/docs/guides/nextjs.md
+++ b/docs/guides/nextjs.md
@@ -142,7 +142,7 @@ export const useCounterStore = <T,>(
   const counterStoreContext = useContext(CounterStoreContext)
 
   if (!counterStoreContext) {
-    throw new Error(`useCounterStore must be use within CounterStoreProvider`)
+    throw new Error(`useCounterStore must be used within CounterStoreProvider`)
   }
 
   return useStore(counterStoreContext, selector)
@@ -235,7 +235,7 @@ export const useCounterStore = <T,>(
   const counterStoreContext = useContext(CounterStoreContext)
 
   if (!counterStoreContext) {
-    throw new Error(`useCounterStore must be use within CounterStoreProvider`)
+    throw new Error(`useCounterStore must be used within CounterStoreProvider`)
   }
 
   return useStore(counterStoreContext, selector)


### PR DESCRIPTION
There are two typos in the error message argument. `useCounterStore must be use` => `useCounterStore must be used`

## Related Issues or Discussions

Fixes #


## Summary
Same as above


## Check List

- [x] `yarn run prettier` for formatting code and docs
