### PR TITLE
Immer state creator should take 4 type params

### DIFF
--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -6,9 +6,10 @@ type Immer = <
   T,
   Mps extends [StoreMutatorIdentifier, unknown][] = [],
   Mcs extends [StoreMutatorIdentifier, unknown][] = [],
+  U = T
 >(
-  initializer: StateCreator<T, [...Mps, ['zustand/immer', never]], Mcs>,
-) => StateCreator<T, Mps, [['zustand/immer', never], ...Mcs]>
+  initializer: StateCreator<T, [...Mps, ['zustand/immer', never]], Mcs, U>,
+) => StateCreator<T, Mps, [['zustand/immer', never], ...Mcs], U>
 
 declare module '../vanilla' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
## Summary
Immer middleware state creator should mimic the StateCreator type and pass through the U type.

## Check List

- [ ] `pnpm run prettier` for formatting code and docs
