### PR TITLE
fix nextjs guide in docs

### DIFF
--- a/docs/guides/nextjs.md
+++ b/docs/guides/nextjs.md
@@ -70,7 +70,7 @@ request.
 
 ```ts
 // src/stores/counter-store.ts
-import { createStore } from 'zustand/vanilla'
+import { createStore } from 'zustand'
 
 export type CounterState = {
   count: number


### PR DESCRIPTION
Current pull request change import statement in next js use-case guide.

Since release of Next-15-rc and use of experimental-react-compiler next js cannot use zustand/vanilla package anymore, as it does not has any bindings to React itself and cannot trigger component rerenders anymore. 

React-compiler memoizes zustand/vannila store and it actions. Actions does not provoke rerender or changing of store anymore
