### PR TITLE
useStore uses ReadonlyStoreApi

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -20,7 +20,10 @@ const { useSyncExternalStoreWithSelector } = useSyncExternalStoreExports
 
 type ExtractState<S> = S extends { getState: () => infer T } ? T : never
 
-type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'subscribe'>
+type ReadonlyStoreApi<T> = Pick<
+  StoreApi<T>,
+  'getState' | 'getInitialState' | 'subscribe'
+>
 
 type WithReact<S extends ReadonlyStoreApi<unknown>> = S & {
   /** @deprecated please use api.getInitialState() */
@@ -31,11 +34,11 @@ let didWarnAboutEqualityFn = false
 
 const identity = <T>(arg: T): T => arg
 
-export function useStore<S extends WithReact<StoreApi<unknown>>>(
+export function useStore<S extends WithReact<ReadonlyStoreApi<unknown>>>(
   api: S,
 ): ExtractState<S>
 
-export function useStore<S extends WithReact<StoreApi<unknown>>, U>(
+export function useStore<S extends WithReact<ReadonlyStoreApi<unknown>>, U>(
   api: S,
   selector: (state: ExtractState<S>) => U,
 ): U
@@ -44,14 +47,14 @@ export function useStore<S extends WithReact<StoreApi<unknown>>, U>(
  * @deprecated The usage with three arguments is deprecated. Use `useStoreWithEqualityFn` from 'zustand/traditional'. The usage with one or two arguments is not deprecated.
  * https://github.com/pmndrs/zustand/discussions/1937
  */
-export function useStore<S extends WithReact<StoreApi<unknown>>, U>(
+export function useStore<S extends WithReact<ReadonlyStoreApi<unknown>>, U>(
   api: S,
   selector: (state: ExtractState<S>) => U,
   equalityFn: ((a: U, b: U) => boolean) | undefined,
 ): U
 
 export function useStore<TState, StateSlice>(
-  api: WithReact<StoreApi<TState>>,
+  api: WithReact<ReadonlyStoreApi<TState>>,
   selector: (state: TState) => StateSlice = identity as any,
   equalityFn?: (a: StateSlice, b: StateSlice) => boolean,
 ) {

--- a/src/traditional.ts
+++ b/src/traditional.ts
@@ -20,7 +20,10 @@ const { useSyncExternalStoreWithSelector } = useSyncExternalStoreExports
 
 type ExtractState<S> = S extends { getState: () => infer T } ? T : never
 
-type ReadonlyStoreApi<T> = Pick<StoreApi<T>, 'getState' | 'subscribe'>
+type ReadonlyStoreApi<T> = Pick<
+  StoreApi<T>,
+  'getState' | 'getInitialState' | 'subscribe'
+>
 
 type WithReact<S extends ReadonlyStoreApi<unknown>> = S & {
   /** @deprecated please use api.getInitialState() */
@@ -29,12 +32,12 @@ type WithReact<S extends ReadonlyStoreApi<unknown>> = S & {
 
 const identity = <T>(arg: T): T => arg
 
-export function useStoreWithEqualityFn<S extends WithReact<StoreApi<unknown>>>(
-  api: S,
-): ExtractState<S>
+export function useStoreWithEqualityFn<
+  S extends WithReact<ReadonlyStoreApi<unknown>>,
+>(api: S): ExtractState<S>
 
 export function useStoreWithEqualityFn<
-  S extends WithReact<StoreApi<unknown>>,
+  S extends WithReact<ReadonlyStoreApi<unknown>>,
   U,
 >(
   api: S,
@@ -43,7 +46,7 @@ export function useStoreWithEqualityFn<
 ): U
 
 export function useStoreWithEqualityFn<TState, StateSlice>(
-  api: WithReact<StoreApi<TState>>,
+  api: WithReact<ReadonlyStoreApi<TState>>,
   selector: (state: TState) => StateSlice = identity as any,
   equalityFn?: (a: StateSlice, b: StateSlice) => boolean,
 ) {


### PR DESCRIPTION
## Related Issues or Discussions

Fixes https://github.com/pmndrs/zustand/discussions/2581

## Summary

`UseBoundStore` types were relaxed in https://github.com/pmndrs/zustand/pull/1589 because the internals of this method did not use any of the setters, only getters. We can also do this for `useStore` types because its API only uses getters.

Context: I am building a library that returns a store API with only getter methods exposed and I would like folks to be able to pass this directly into Zustand's `useStore` React helper.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
