### PR TITLE
fix: no type field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "zustand",
   "description": "🐻 Bear necessities for state management in React",
   "private": true,
-  "type": "commonjs",
   "version": "4.5.3",
   "main": "./index.js",
   "types": "./index.d.ts",


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #2621

## Summary

Adding `"type": "commonjs"` seemed safe, but zustand v4 still has unofficial `"module"` condition which seems invalid. Let's revert it in v4 only.



