### PR TITLE
(docs) remove unintended change from default merge behaviour to identical but manual one

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -401,7 +401,7 @@ const useBearStore = create(devtools((set) => ({
   ...
   eatFish: () => set(
     (prev) => ({ fishes: prev.fishes > 1 ? prev.fishes - 1 : 0 }),
-    false,
+    undefined,
     'bear/eatFish'
   ),
   ...
@@ -413,7 +413,7 @@ You can also log the action's type along with its payload:
   ...
   addFishes: (count) => set(
     (prev) => ({ fishes: prev.fishes + count }),
-    false,
+    undefined,
     { type: 'bear/addFishes', count, }
   ),
   ...


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

targeted section of the README talks about integration with redux devtools. to accomplish this the dev needs to define third argument for `set` function. since arguments for `set` function are positional it means he/she needs to define the second, `replace`, argument as well

currently README suggests just to use `false` value for `replace` arg i.e. to override the default value by identical manual one, but defined on the dev side.

more clean way would be to use `undefined` at the second argument position that will make JS itself to use the default value, meaning moving control of it back lib authors, not dev

## Check List

- [x] `pnpm run prettier` for formatting code and docs
