### PR TITLE
Fix return type for persist's partialize option

### DIFF
--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -108,7 +108,7 @@ export interface PersistOptions<S, PersistedState = S> {
    *
    * @params state The state's value
    */
-  partialize?: (state: S) => PersistedState
+  partialize?: (state: S) => Partial<PersistedState>
   /**
    * A function returning another (optional) function.
    * The main function will be called before the state rehydration.


### PR DESCRIPTION
## Summary
Fix return type for persist's partialize option


## Check List

- [ ] `pnpm run prettier` for formatting code and docs
