### PR TITLE
Fix store-persistence example

### DIFF
--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -575,7 +575,7 @@ const useBoundStore = create(
     {
       // ...
       onRehydrateStorage: (state) => {
-        state.setHasHydrated(true)
+        return () => state.setHasHydrated(true)
       }
     }
   )


### PR DESCRIPTION
I spent way too much time on figuring out why my state was empty.
I hope this change will save that time for other devs.

Calling `setHasHydrated` directly in `onRehydrateStorage` causes the state to only contain the `{ _hasHydrated: true }` rather than the actual hydrated state (which I believe is then lost).

`setHasHydrated` must instead be called from the function returned from  `onRehydrateStorage`, as that function will be called after the state has been hydrated.

## Related Bug Reports or Discussions

Fixes #

## Summary



## Check List

- [X] `pnpm run prettier` for formatting code and docs
