### PR TITLE
fix: "value" to "content" attr for og:image

### DIFF
--- a/examples/demo/index.html
+++ b/examples/demo/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="🐻 Bear necessities for state management in React" />
     <link rel="apple-touch-icon" href="/logo192.png" />
-    <meta name="og:image" value="/ogimage.jpg" />    
+    <meta name="og:image" content="/ogimage.jpg" />
     <link rel="manifest" href="/manifest.json" />
     <title>Zustand</title>
   </head>


### PR DESCRIPTION
## Summary
I fixed the `og:iamge`
 attribute name to `content` according to the [Open Graph Protocol spec](https://ogp.me/#metadata). 

Thanks for always actively maintaining such a great library!

## Check List

- [x] `pnpm run prettier` for formatting code and docs
