### PR TITLE
add wrapped store for comfy devtools usage

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -14,6 +14,7 @@ import type {
   StoreApi,
   StoreMutatorIdentifier,
 } from './vanilla.ts'
+import { devtools } from './middleware.ts'
 
 const { useDebugValue } = ReactExports
 const { useSyncExternalStoreWithSelector } = useSyncExternalStoreExports
@@ -138,3 +139,18 @@ export default ((createState: any) => {
   }
   return create(createState)
 }) as Create
+
+
+export type WithDevtools<S> = StateCreator<
+S,
+[["zustand/devtools", never]],
+[],
+S
+>;
+
+export const createWrappedStore = <T>(fn: WithDevtools<T>, name: string, productionMode?: boolean): UseBoundStore<StoreApi<T>> => {
+  if (!productionMode) {
+    return create(devtools(fn, {name}))
+  }
+  return create(fn)
+}


### PR DESCRIPTION
## Added wrapped store func to enabling devtools to each store easily
## These changes allow for more flexible configuration of devtools usage without the need to manually connect them in each store.

## Defined a new type WithDevtools<S> which extends StateCreator to include the devtools middleware

## Introduced a new function createWrappedStore which conditionally applies the devtools middleware based on the environment (development or production)

