### PR TITLE
fix(storage): avoid calling setItem with the state just retrieved

### DIFF
--- a/tests/persistSync.test.tsx
+++ b/tests/persistSync.test.tsx
@@ -738,4 +738,26 @@ describe('persist middleware with sync configuration', () => {
       undefined,
     )
   })
+
+  it('does not call setItem when hydrating from its own storage', async () => {
+    const setItem = vi.fn()
+    const storage = {
+      getItem: (name: string) => ({
+        state: { count: 42, name },
+        version: 0,
+      }),
+      setItem,
+      removeItem: () => {},
+    }
+
+    const useBoundStore = create(
+      persist(() => ({}), {
+        name: 'test-storage',
+        storage: storage,
+      }),
+    )
+
+    expect(useBoundStore.persist.hasHydrated()).toBe(true)
+    expect(setItem).toBeCalledTimes(0)
+  })
 })


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes https://github.com/pmndrs/zustand/discussions/2663

## Summary

This PR avoids a `setItem` call with the state just reteived from the storage.

## Check List

- [X] `pnpm run prettier` for formatting code and docs
