### PR TITLE
Persist documentation for Map & Set add storage and retrieval of version

### DIFF
--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -783,17 +783,19 @@ interface BearState {
     getItem: (name) => {
       const str = localStorage.getItem(name);
       if (!str) return null;
-      const { state } = JSON.parse(str);
+      const { state, version } = JSON.parse(str);
       return {
         state: {
           ...state,
           transactions: new Map(state.transactions),
         },
+        version
       }
     },
     setItem: (name, newValue: StorageValue<BearState>) => {
       // functions cannot be JSON encoded
       const str = JSON.stringify({
+        ...newValue,
         state: {
           ...newValue.state,
           transactions: Array.from(newValue.state.transactions.entries()),

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -783,13 +783,13 @@ interface BearState {
     getItem: (name) => {
       const str = localStorage.getItem(name);
       if (!str) return null;
-      const { state, version } = JSON.parse(str);
+      const existingValue = JSON.parse(str);
       return {
+        ...existingValue,
         state: {
-          ...state,
-          transactions: new Map(state.transactions),
-        },
-        version
+          ...existingValue.state,
+          transactions: new Map(existingValue.state.transactions),
+        }
       }
     },
     setItem: (name, newValue: StorageValue<BearState>) => {


### PR DESCRIPTION
--HG--
branch : discussion-2689-persist-doc-map-and-set-missing-version

## Related Bug Reports or Discussions

Fixes # Discussion 2689

## Summary

Fixes getItem and setItem on the storage for the Map & Set persist example, so that respectfully those methods retrieves and sets the version when present.

## Check List

- [v] `pnpm run prettier` for formatting code and docs
