### PR TITLE
Fix Immer type inference for `setState`

### DIFF
--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -44,6 +44,9 @@ type StoreImmer<S> = S extends {
       (...a: infer A2): infer Sr2
     }
     ? {
+        // Ideally, we would want to infer the `nextStateOrUpdater` `T` type from the
+        // `A1` type, but this is infeasible since it is an intersection with
+        // a partial type.
         setState(
           nextStateOrUpdater:
             | SetStateType<A2>

--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -18,6 +18,7 @@ declare module '../vanilla' {
 }
 
 type Write<T, U> = Omit<T, keyof U> & U
+type First<T> = T extends [infer A] ? A : never
 type SkipTwo<T> = T extends { length: 0 }
   ? []
   : T extends { length: 1 }
@@ -35,7 +36,6 @@ type SkipTwo<T> = T extends { length: 0 }
 type WithImmer<S> = Write<S, StoreImmer<S>>
 
 type StoreImmer<S> = S extends {
-  getState: () => infer T
   setState: infer SetState
 }
   ? SetState extends {
@@ -44,12 +44,15 @@ type StoreImmer<S> = S extends {
     }
     ? {
         setState(
-          nextStateOrUpdater: T | Partial<T> | ((state: Draft<T>) => void),
+          nextStateOrUpdater:
+            | First<A1>
+            | Partial<First<A1>>
+            | ((state: Draft<First<A1>>) => void),
           shouldReplace?: false,
           ...a: SkipTwo<A1>
         ): Sr1
         setState(
-          nextStateOrUpdater: T | ((state: Draft<T>) => void),
+          nextStateOrUpdater: First<A2> | ((state: Draft<First<A2>>) => void),
           shouldReplace: true,
           ...a: SkipTwo<A2>
         ): Sr2

--- a/tests/middlewareTypes.test.tsx
+++ b/tests/middlewareTypes.test.tsx
@@ -1,9 +1,9 @@
 /* eslint @typescript-eslint/no-unused-expressions: off */ // FIXME
 /* eslint react-compiler/react-compiler: off */
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import { create } from 'zustand'
-import type { StoreApi } from 'zustand'
+import type { StateCreator, StoreApi, StoreMutatorIdentifier } from 'zustand'
 import {
   combine,
   devtools,
@@ -17,6 +17,27 @@ import { createStore } from 'zustand/vanilla'
 type CounterState = {
   count: number
   inc: () => void
+}
+
+type ExampleStateCreator<T, A> = <
+  Mps extends [StoreMutatorIdentifier, unknown][] = [],
+  Mcs extends [StoreMutatorIdentifier, unknown][] = [],
+  U = T,
+>(
+  f: StateCreator<T, [...Mps, ['org/example', A]], Mcs>,
+) => StateCreator<T, Mps, [['org/example', A], ...Mcs], U & A>
+
+type Write<T, U> = Omit<T, keyof U> & U
+type StoreModifyAllButSetState<S, A> = S extends {
+  getState: () => infer T
+}
+  ? Omit<StoreApi<T & A>, 'setState'>
+  : never
+
+declare module 'zustand/vanilla' {
+  interface StoreMutators<S, A> {
+    'org/example': Write<S, StoreModifyAllButSetState<S, A>>
+  }
 }
 
 describe('counter state spec (no middleware)', () => {
@@ -64,6 +85,32 @@ describe('counter state spec (single middleware)', () => {
       immer(() => ({ count: 0 })),
     )
     expect(testSubtyping).toBeDefined()
+
+    const exampleMiddleware = ((initializer) =>
+      initializer) as ExampleStateCreator<CounterState, { additional: number }>
+
+    const testDerivedSetStateType = create<CounterState>()(
+      exampleMiddleware(
+        immer((set, get) => ({
+          count: 0,
+          inc: () =>
+            set((state) => {
+              state.count = get().count + 1
+            }),
+        })),
+      ),
+    )
+    expect(testDerivedSetStateType).toBeDefined()
+    // the type of the `getState` should include our new property
+    expectTypeOf(testDerivedSetStateType.getState()).toMatchTypeOf<{
+      additional: number
+    }>()
+    // the type of the `setState` should not include our new property
+    expectTypeOf<
+      Parameters<typeof testDerivedSetStateType.setState>[0]
+    >().not.toMatchTypeOf<{
+      additional: number
+    }>()
   })
 
   it('redux', () => {

--- a/tests/middlewareTypes.test.tsx
+++ b/tests/middlewareTypes.test.tsx
@@ -96,6 +96,13 @@ describe('counter state spec (single middleware)', () => {
           inc: () =>
             set((state) => {
               state.count = get().count + 1
+              type OmitFn<T> = Exclude<T, (...args: any[]) => any>
+              expectTypeOf<
+                OmitFn<Parameters<typeof set>[0]>
+              >().not.toMatchTypeOf<{ additional: number }>()
+              expectTypeOf<ReturnType<typeof get>>().toMatchTypeOf<{
+                additional: number
+              }>()
             }),
         })),
       ),


### PR DESCRIPTION
Bases the type of `setState` off of `setState` instead of `getState`.

## Related Bug Reports or Discussions

Fixes #1621

## Summary

This PR fixes the Immer middleware so that the type of `setState` is inferred off of the store's `setState` as opposed to `getState`. When using a middleware like [zustand-computed](https://github.com/chrisvander/zustand-computed), this would previously have the result of a differing `getState` generic would move over to `setState` unintentionally.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
