### PR TITLE
rdocs: typo in typescript docs

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -499,9 +499,8 @@ const bearStore = createStore<BearState>()((set) => ({
   increase: (by) => set((state) => ({ bears: state.bears + by })),
 }))
 
-const createBoundedUseStore = ((store) => (selector) => useStore(store)) as <
-  S extends StoreApi<unknown>,
->(
+const createBoundedUseStore = ((store) => (selector) =>
+  useStore(store, selector)) as <S extends StoreApi<unknown>>(
   store: S,
 ) => {
   (): ExtractState<S>


### PR DESCRIPTION
## Summary

Hello, I noticed a typo in typescript docs in the section "Bounded `useStore` hook for vanilla stores". In the second example, `createBoundedUseStore` is not passing `selector` to `useStore`. 

## Check List

- [x] `pnpm run prettier` for formatting code and docs
