### PR TITLE
docs: corrected example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,10 +94,7 @@ const useBearStore = create(set => ({
   nuts: 0,
   honey: 0,
   treats: {},
-  increaseNuts: () => set(state => ({ nuts: state.nuts + 1 })),
-  increaseHoney: () => set(state => ({ honey: state.honey + 1 })),
-  increaseTreats: (treat: string, count?: number) =>
-    set(state => ({ treats: { ...state.treats, [treat]: (state.treats[treat] ?? 0) + 1 } })),
+  ...
 }))
 
 // Object pick, re-renders the component when either state.nuts or state.honey change
@@ -114,7 +111,7 @@ const [nuts, honey] = useBearStore(
 const treats = useBearStore(useShallow((state) => Object.keys(state.treats)))
 ```
 
-For more control over re-rendering, you may provide any custom equality function.
+For more control over re-rendering, you may provide any custom equality function (this example requires the use of [`createWithEqualityFn`](./docs/migrations/migrating-to-v5.md#using-custom-equality-functions-such-as-shallow)).
 
 ```jsx
 const treats = useBearStore(

--- a/readme.md
+++ b/readme.md
@@ -90,10 +90,14 @@ If you want to construct a single object with multiple state-picks inside, simil
 import { create } from 'zustand'
 import { useShallow } from 'zustand/react/shallow'
 
-const useBearStore = create((set) => ({
-  bears: 0,
-  increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
-  removeAllBears: () => set({ bears: 0 }),
+const useBearStore = create(set => ({
+  nuts: 0,
+  honey: 0,
+  treats: {},
+  increaseNuts: () => set(state => ({ nuts: state.nuts + 1 })),
+  increaseHoney: () => set(state => ({ honey: state.honey + 1 })),
+  increaseTreats: (treat: string, count?: number) =>
+    set(state => ({ treats: { ...state.treats, [treat]: (state.treats[treat] ?? 0) + 1 } })),
 }))
 
 // Object pick, re-renders the component when either state.nuts or state.honey change

--- a/readme.md
+++ b/readme.md
@@ -90,7 +90,7 @@ If you want to construct a single object with multiple state-picks inside, simil
 import { create } from 'zustand'
 import { useShallow } from 'zustand/react/shallow'
 
-const useBearStore = create(set => ({
+const useBearStore = create((set) => ({
   nuts: 0,
   honey: 0,
   treats: {},

--- a/readme.md
+++ b/readme.md
@@ -94,7 +94,7 @@ const useBearStore = create(set => ({
   nuts: 0,
   honey: 0,
   treats: {},
-  ...
+  // ...
 }))
 
 // Object pick, re-renders the component when either state.nuts or state.honey change


### PR DESCRIPTION
## Summary

Corrected store shape in "Selecting multiple state slices" to be consistent with the example (which use `nuts`, `honey`, and `treats` instead of `bears`).

## Check List

- [x] `pnpm run prettier` for formatting code and docs
