### PR TITLE
[Zustand Docs] Add third party library `zustand-async-slice`

### DIFF
--- a/docs/integrations/third-party-libraries.md
+++ b/docs/integrations/third-party-libraries.md
@@ -37,6 +37,7 @@ This can be done using third-party libraries created by the community.
 - [zukeeper](https://github.com/oslabs-beta/Zukeeper) — Native devtools with state and action tracking, diffing, tree display, and time travel
 - [zundo](https://github.com/charkour/zundo) — 🍜 Undo and redo middleware for Zustand, enabling time-travel in your apps.
 - [zustand-ards](https://github.com/ivoilic/zustand-ards) — 💁 Simple opinionated utilities for example alternative selector formats and default shallow hooks
+- [zustand-async-slice](https://github.com/mym0404/zustand-async-slice) - Simple Zustand utility to create Async Slice. TypeScript Fully Supported 🖖
 - [zustand-boilerplate](https://github.com/sagiereder/zustand-boilerplate) — A tool that automatically generates getters, setters and more for your zustand store.
 - [zustand-computed](https://github.com/chrisvander/zustand-computed) — A Zustand middleware to create computed states.
 - [zustand-computed-state](https://github.com/yasintz/zustand-computed-state) — Simple middleware to add computed states.
@@ -64,4 +65,3 @@ This can be done using third-party libraries created by the community.
 - [zusteller](https://github.com/timkindberg/zusteller) — Your global state savior. "Just hooks" + Zustand.
 - [zustood](https://github.com/udecode/zustood) — 🐻‍❄️ A modular store factory using Zustand.
 - [zusty](https://github.com/oslabs-beta/Zusty) — Zustand tool to assist debugging with time travel, action logs, state snapshots, store view, render time metrics and state component tree.
-- [zustand-async-slice](https://github.com/mym0404/zustand-async-slice) - Simple Zustand utility to create Async Slice. TypeScript Fully Supported 🖖 

--- a/docs/integrations/third-party-libraries.md
+++ b/docs/integrations/third-party-libraries.md
@@ -64,3 +64,4 @@ This can be done using third-party libraries created by the community.
 - [zusteller](https://github.com/timkindberg/zusteller) — Your global state savior. "Just hooks" + Zustand.
 - [zustood](https://github.com/udecode/zustood) — 🐻‍❄️ A modular store factory using Zustand.
 - [zusty](https://github.com/oslabs-beta/Zusty) — Zustand tool to assist debugging with time travel, action logs, state snapshots, store view, render time metrics and state component tree.
+- [zustand-async-slice](https://github.com/mym0404/zustand-async-slice) - Simple Zustand utility to create Async Slice. TypeScript Fully Supported 🖖 


### PR DESCRIPTION
Hello, I read [contributing guide](https://github.com/pmndrs/zustand/blob/main/CONTRIBUTING.md). However, the docs branch of `website` is missing and I can't find proper way.

So I created a PR in a simple way, and if this causes problems or results in the documentation not being properly updated, I would like to know what actions I should take.

## Summary

Add `zustand-async-slice` package into zustand third party library listing.


## Check List

- [x] `pnpm run prettier` for formatting code and docs
