### PR TITLE
docs: add plaintext language to code block to prevent layout breaks

### DIFF
--- a/docs/migrations/migrating-to-v5.md
+++ b/docs/migrations/migrating-to-v5.md
@@ -105,7 +105,7 @@ const action = useMainStore((state) => {
 
 The error message will be something like this:
 
-```
+```plaintext
 Uncaught Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
 ```
 


### PR DESCRIPTION
## Related Bug Reports or Discussions

N/A

## Summary

Hi everyone, I noticed that the error message code block in the [v5 migration guideline](https://zustand.docs.pmnd.rs/migrations/migrating-to-v5#requiring-stable-selector-outputs)  doesn’t display correctly on the docs site, so I added the `plaintext` language to the code block to prevent layout breaks. 

Feel free to close this if it is unnecessary.

**Before**

![image](https://github.com/user-attachments/assets/d160cd3f-c7da-47a0-85cc-1bb2ad3bad34)

**After**

![image](https://github.com/user-attachments/assets/fbaa7110-ffbf-4984-a7dd-988fd0b536c7)

## Check List

- [x] `pnpm run prettier` for formatting code and docs
