### PR TITLE
docs: Fix typo in "TypeScript Guide" section

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -226,7 +226,7 @@ const useBearStore = create(foo(() => ({ bears: 0 }), 'hello'))
 console.log(useBearStore.foo.toUpperCase())
 ```
 
-Zustand middlewares can mutate the store. But how could we possibly encode the mutation on the type-level? That is to say how could do we type `foo` so that this code compiles?
+Zustand middlewares can mutate the store. But how could we possibly encode the mutation on the type-level? That is to say how could we type `foo` so that this code compiles?
 
 For a usual statically typed language, this is impossible. But thanks to TypeScript, Zustand has something called a "higher-kinded mutator" that makes this possible. If you are dealing with complex type problems, like typing a middleware or using the `StateCreator` type, you will have to understand this implementation detail. For this, you can [check out #710](https://github.com/pmndrs/zustand/issues/710).
 


### PR DESCRIPTION
## Summary

Fix typo in "TypeScript Guide" section.

## Check List

- [ ] `pnpm run prettier` for formatting code and docs
