### PR TITLE
Fix "previous" and "next" navigation links

### DIFF
--- a/docs/apis/create-store.md
+++ b/docs/apis/create-store.md
@@ -1,7 +1,7 @@
 ---
 title: createStore
 description: How to create vanilla stores
-nav: 202
+nav: 24
 ---
 
 `createStore` lets you create a vanilla store that exposes API utilities.

--- a/docs/apis/create-with-equality-fn.md
+++ b/docs/apis/create-with-equality-fn.md
@@ -1,7 +1,7 @@
 ---
 title: createWithEqualityFn ⚛️
 description: How to create efficient stores
-nav: 203
+nav: 25
 ---
 
 `createWithEqualityFn` lets you create a React Hook with API utilities attached, just like `create`.

--- a/docs/apis/create.md
+++ b/docs/apis/create.md
@@ -1,7 +1,7 @@
 ---
 title: create ⚛️
 description: How to create stores
-nav: 204
+nav: 26
 ---
 
 `create` lets you create a React Hook with API utilities attached.

--- a/docs/apis/shallow.md
+++ b/docs/apis/shallow.md
@@ -1,7 +1,7 @@
 ---
 title: shallow
 description: How compare simple data effectively
-nav: 209
+nav: 27
 ---
 
 `shallow` lets you run fast checks on simple data structures. It effectively identifies changes in

--- a/docs/guides/auto-generating-selectors.md
+++ b/docs/guides/auto-generating-selectors.md
@@ -1,6 +1,6 @@
 ---
 title: Auto Generating Selectors
-nav: 6
+nav: 5
 ---
 
 We recommend using selectors when using either the properties or actions from the store. You can access values from the store like so:

--- a/docs/guides/connect-to-state-with-url-hash.md
+++ b/docs/guides/connect-to-state-with-url-hash.md
@@ -1,6 +1,6 @@
 ---
 title: Connect to state with URL
-nav: 12
+nav: 11
 ---
 
 ## Connect State with URL Hash

--- a/docs/guides/event-handler-in-pre-react-18.md
+++ b/docs/guides/event-handler-in-pre-react-18.md
@@ -1,6 +1,6 @@
 ---
 title: Calling actions outside a React event handler in pre React 18
-nav: 10
+nav: 9
 ---
 
 Because React handles `setState` synchronously if it's called outside an event handler, updating the state outside an event handler will force react to update the components synchronously. Therefore, there is a risk of encountering the zombie-child effect.

--- a/docs/guides/flux-inspired-practice.md
+++ b/docs/guides/flux-inspired-practice.md
@@ -1,6 +1,6 @@
 ---
 title: Flux inspired practice
-nav: 5
+nav: 4
 ---
 
 Although Zustand is an unopinionated library, we do recommend a few patterns.

--- a/docs/guides/how-to-reset-state.md
+++ b/docs/guides/how-to-reset-state.md
@@ -1,6 +1,6 @@
 ---
 title: How to reset state
-nav: 13
+nav: 12
 ---
 
 The following pattern can be used to reset the state to its initial value.

--- a/docs/guides/immutable-state-and-merging.md
+++ b/docs/guides/immutable-state-and-merging.md
@@ -1,6 +1,6 @@
 ---
 title: Immutable state and merging
-nav: 4
+nav: 3
 ---
 
 Like with React's `useState`, we need to update state immutably.

--- a/docs/guides/initialize-state-with-props.md
+++ b/docs/guides/initialize-state-with-props.md
@@ -1,6 +1,6 @@
 ---
 title: Initialize state with props
-nav: 14
+nav: 13
 ---
 
 In cases where [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection) is needed, such as when a store should be initialized with props from a component, the recommended approach is to use a vanilla store with React.context.

--- a/docs/guides/maps-and-sets-usage.md
+++ b/docs/guides/maps-and-sets-usage.md
@@ -1,6 +1,6 @@
 ---
 title: Map and Set Usage
-nav: 11
+nav: 10
 ---
 
 You need to wrap Maps and Sets inside an object. When you want its update to be reflected (e.g. in React),

--- a/docs/guides/nextjs.md
+++ b/docs/guides/nextjs.md
@@ -1,6 +1,6 @@
 ---
 title: Setup with Next.js
-nav: 21
+nav: 17
 ---
 
 [Next.js](https://nextjs.org) is a popular server-side rendering framework for React that presents

--- a/docs/guides/practice-with-no-store-actions.md
+++ b/docs/guides/practice-with-no-store-actions.md
@@ -1,6 +1,6 @@
 ---
 title: Practice with no store actions
-nav: 7
+nav: 6
 ---
 
 The recommended usage is to colocate actions and states within the store (let your actions be located together with your state).

--- a/docs/guides/prevent-rerenders-with-use-shallow.md
+++ b/docs/guides/prevent-rerenders-with-use-shallow.md
@@ -1,6 +1,6 @@
 ---
 title: Prevent rerenders with useShallow
-nav: 16
+nav: 15
 ---
 
 When you need to subscribe to a computed state from a store, the recommended way is to

--- a/docs/guides/slices-pattern.md
+++ b/docs/guides/slices-pattern.md
@@ -1,6 +1,6 @@
 ---
 title: Slices Pattern
-nav: 15
+nav: 14
 ---
 
 ## Slicing the store into smaller stores

--- a/docs/guides/ssr-and-hydration.md
+++ b/docs/guides/ssr-and-hydration.md
@@ -1,6 +1,6 @@
 ---
 title: SSR and Hydration
-nav: 20
+nav: 16
 ---
 
 ## Server-side Rendering (SSR)

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,7 +1,7 @@
 ---
 title: Testing
 description: Writing Tests
-nav: 9
+nav: 8
 ---
 
 ## Setting Up a Test Environment

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -1,6 +1,6 @@
 ---
 title: TypeScript Guide
-nav: 8
+nav: 7
 ---
 
 ## Basic usage

--- a/docs/guides/updating-state.md
+++ b/docs/guides/updating-state.md
@@ -1,6 +1,6 @@
 ---
 title: Updating state
-nav: 3
+nav: 2
 ---
 
 ## Flat updates

--- a/docs/hooks/use-shallow.md
+++ b/docs/hooks/use-shallow.md
@@ -1,7 +1,7 @@
 ---
 title: useShallow ⚛️
 description: How to memoize selector functions
-nav: 211
+nav: 28
 ---
 
 `useShallow` is a React Hook that lets you optimize re-renders.

--- a/docs/hooks/use-store-with-equality-fn.md
+++ b/docs/hooks/use-store-with-equality-fn.md
@@ -1,7 +1,7 @@
 ---
 title: useStoreWithEqualityFn ⚛️
 description: How to use vanilla stores effectively in React
-nav: 212
+nav: 29
 ---
 
 `useStoreWithEqualityFn` is a React Hook that lets you use a vanilla store in React, just like

--- a/docs/hooks/use-store.md
+++ b/docs/hooks/use-store.md
@@ -1,7 +1,7 @@
 ---
 title: useStore ⚛️
 description: How to use vanilla stores in React
-nav: 213
+nav: 30
 ---
 
 `useStore` is a React Hook that lets you use a vanilla store in React.

--- a/docs/integrations/immer-middleware.md
+++ b/docs/integrations/immer-middleware.md
@@ -1,6 +1,6 @@
 ---
 title: Immer middleware
-nav: 16
+nav: 18
 ---
 
 The [Immer](https://github.com/immerjs/immer) middleware enables you

--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -1,6 +1,6 @@
 ---
 title: Persisting store data
-nav: 17
+nav: 20
 ---
 
 The Persist middleware enables you to store

--- a/docs/integrations/third-party-libraries.md
+++ b/docs/integrations/third-party-libraries.md
@@ -1,6 +1,6 @@
 ---
 title: Third-party Libraries
-nav: 16
+nav: 19
 ---
 
 Zustand provides bear necessities for state management.

--- a/docs/migrations/migrating-to-v4.md
+++ b/docs/migrations/migrating-to-v4.md
@@ -1,6 +1,6 @@
 ---
 title: Migrating to v4
-nav: 19
+nav: 22
 ---
 
 The only breaking changes are in types.

--- a/docs/migrations/migrating-to-v5.md
+++ b/docs/migrations/migrating-to-v5.md
@@ -1,6 +1,6 @@
 ---
 title: 'How to Migrate to v5 from v4'
-nav: 30
+nav: 23
 ---
 
 # How to Migrate to v5 from v4

--- a/docs/previous-versions/zustand-v3-create-context.md
+++ b/docs/previous-versions/zustand-v3-create-context.md
@@ -1,6 +1,6 @@
 ---
 title: createContext from zustand/context
-nav: 18
+nav: 21
 ---
 
 A special `createContext` is provided since v3.5,


### PR DESCRIPTION
## Summary

The "next" link at the bottom of  https://zustand.docs.pmnd.rs/guides/prevent-rerenders-with-use-shallow points to https://zustand.docs.pmnd.rs/integrations/immer-middleware when it should be pointing to https://zustand.docs.pmnd.rs/guides/ssr-and-hydration instead (i.e. the next page in the list of links in the sidebar).

This PR updates all the `nav` numbers in order to correct the navigation order. If this is not the right solution, please feel free to edit this PR with a better one.

## Check List

- [x] `pnpm run prettier` for formatting code and docs