### PR TITLE
fix(shallow): fallback map-like iterator comparison

### DIFF
--- a/src/vanilla/shallow.ts
+++ b/src/vanilla/shallow.ts
@@ -40,10 +40,14 @@ export function shallow<T>(objA: T, objB: T): boolean {
       nextA.value.length === 2 &&
       nextB.value.length === 2
     ) {
-      return compareMapLike(
-        objA as Iterable<[unknown, unknown]>,
-        objB as Iterable<[unknown, unknown]>,
-      )
+      try {
+        return compareMapLike(
+          objA as Iterable<[unknown, unknown]>,
+          objB as Iterable<[unknown, unknown]>,
+        )
+      } catch {
+        // fallback
+      }
     }
     while (!nextA.done && !nextB.done) {
       if (!Object.is(nextA.value, nextB.value)) {

--- a/tests/vanilla/shallow.test.tsx
+++ b/tests/vanilla/shallow.test.tsx
@@ -97,6 +97,11 @@ describe('shallow', () => {
     const b = new URLSearchParams({ zustand: 'shallow' })
     expect(shallow(a, b)).toBe(false)
   })
+
+  it('should work with nested arrays (#2794)', () => {
+    const arr = [1, 2]
+    expect(shallow([arr, 1], [arr, 1])).toBe(true)
+  })
 })
 
 describe('unsupported cases', () => {


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #2794 

## Summary

There is a logic to guess map-like iterator but it's not perfect. This adds fallback.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
