### PR TITLE
fix(typo):  fix import of setPosition 

### DIFF
--- a/docs/hooks/use-store.md
+++ b/docs/hooks/use-store.md
@@ -70,7 +70,7 @@ will use the store to track and update the dot's position.
 ```tsx
 function MovingDot() {
   const position = useStore(positionStore, (state) => state.position)
-  const setPosition = useStore(positionStore, (state) => state.setPositionStore)
+  const setPosition = useStore(positionStore, (state) => state.setPosition)
 
   return (
     <div
@@ -131,7 +131,7 @@ const positionStore = createStore<PositionStore>()((set) => ({
 
 function MovingDot() {
   const position = useStore(positionStore, (state) => state.position)
-  const setPosition = useStore(positionStore, (state) => state.setPositionStore)
+  const setPosition = useStore(positionStore, (state) => state.setPosition)
 
   return (
     <div


### PR DESCRIPTION
there is a typo mistake while importing the setposition from positionstore

 wrong : const setPosition = useStore(positionStore, (state) => state.setPositionStore)
correct :  const setPosition = useStore(positionStore, (state) => state.setPosition)

## Related Bug Reports or Discussions

Fixes #
spelling mistake  of this line 
```
const setPosition = useStore(positionStore, (state) => state.setPosition)
```

## Summary



## Check List

- [x] `pnpm run prettier` for formatting code and docs
