### PR TITLE
test: calculate coverage for src files only

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     dir: 'tests',
     reporters: 'basic',
     coverage: {
+      include: ['src/**/'],
       reporter: ['text', 'json', 'html', 'text-summary'],
       reportsDirectory: './coverage/',
     },


### PR DESCRIPTION
## Summary

Code coverage should rather take into account files from `src`.

Quote from Vitest docs:

> It's recommended to always define [coverage.include](https://vitest.dev/config/#coverage-include) in your configuration file. This helps Vitest to reduce the amount of files picked by [coverage.all](https://vitest.dev/config/#coverage-all).

## Check List

- [x] `pnpm run prettier` for formatting code and docs
