### PR TITLE
docs: add leo-query to third-party libraries list

### DIFF
--- a/docs/integrations/third-party-libraries.md
+++ b/docs/integrations/third-party-libraries.md
@@ -23,6 +23,7 @@ This can be done using third-party libraries created by the community.
 - [derive-zustand](https://github.com/zustandjs/derive-zustand) — A function to create a derived Zustand store from other Zustand stores.
 - [geschichte](https://github.com/BowlingX/geschichte) — Zustand and Immer-based hook to manage query parameters.
 - [leiten-zustand](https://github.com/hecmatyar/leiten-zustand) — Cleans your store from boilerplate for requests and data transformation.
+- [leo-query](https://github.com/steaks/leo-query) — A simple library to connect async queries to Zustand stores.
 - [mobz](https://github.com/2A5F/Mobz) — Zustand-style MobX API.
 - [ngx-zustand](https://github.com/JoaoPauloLousada/ngx-zustand) — A Zustand adapter for Angular.
 - [persist-and-sync](https://github.com/mayank1513/persist-and-sync) — Zustand middleware to easily persist and sync Zustand state between tabs/windows/iframes with same origin.


### PR DESCRIPTION
## Summary

Add leo-query to third party libs.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
