### PR TITLE
docs: fix typo in tutorial-tic-tac-toe.md

### DIFF
--- a/docs/guides/tutorial-tic-tac-toe.md
+++ b/docs/guides/tutorial-tic-tac-toe.md
@@ -352,7 +352,7 @@ export default function Board() {
 ```
 
 `Array(9).fill(null)` creates an array with nine elements and sets each of them to `null`. The
-`useSquaresStore` declares a `squares` state that's initially set to that array. Each entry in the
+`useGameStore` declares a `squares` state that's initially set to that array. Each entry in the
 array corresponds to the value of a square. When you fill the board in later, the squares array
 will look like this:
 


### PR DESCRIPTION
## Related Bug Reports or Discussions

There is a  mistake in the store name

Fixes #
It's should be `useGameStore`  as seen in the code block above

wrong : `useSquaresStore` declares a `squares` state that's initially set to that array. Each entry in the
correct : `useGameStore` declares a `squares` state that's initially set to that array. Each entry in the

## Summary



## Check List

- [ ] `pnpm run prettier` for formatting code and docs
