### PR TITLE
chore: match the typescript docs

### DIFF
--- a/docs/migrations/migrating-to-v5.md
+++ b/docs/migrations/migrating-to-v5.md
@@ -180,11 +180,14 @@ store.setState({}, true) // Error
 
 #### Handling Dynamic `replace` Flag
 
-If the value of the `replace` flag is dynamic and determined at runtime, you might face issues. To handle this, you can use a workaround by annotating the `replace` parameter with `as any`:
+If the value of the `replace` flag is dynamic and determined at runtime, you might face issues. To handle this, you can use a workaround by annotating the `replace` parameter with the parameters of the `setState` function:
 
 ```ts
 const replaceFlag = Math.random() > 0.5
-store.setState(partialOrFull, replaceFlag as any)
+const args = [{ bears: 5 }, replaceFlag] as Parameters<
+  typeof useBearStore.setState
+>
+store.setState(...args)
 ```
 
 #### Persist middlware no longer stores item at store creation


### PR DESCRIPTION
## Related Bug Reports or Discussions

NA

## Summary

Update the v5 Migration docs to match the TypeScript documentation: https://github.com/pmndrs/zustand/blob/main/docs/guides/typescript.md#handling-dynamic-replace-flag. This ensures consistency in both places.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
