### PR TITLE
Fix migrating to v5 doc

### DIFF
--- a/docs/migrations/migrating-to-v5.md
+++ b/docs/migrations/migrating-to-v5.md
@@ -190,7 +190,7 @@ const args = [{ bears: 5 }, replaceFlag] as Parameters<
 store.setState(...args)
 ```
 
-#### Persist middlware no longer stores item at store creation
+#### Persist middleware no longer stores item at store creation
 
 Previously, the `persist` middleware stored the initial state during store creation. This behavior has been removed in v5 (and v4.5.5).
 


### PR DESCRIPTION
## Related Bug Reports or Discussions


## Summary
I've replaced `middlware` with `middleware` in md file.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
