### PR TITLE
chore(docs): Adds import statements to devtools code example

### DIFF
--- a/docs/middlewares/devtools.md
+++ b/docs/middlewares/devtools.md
@@ -69,6 +69,7 @@ This example shows you how you can use `Redux Devtools` to debug a store
 
 ```ts
 import { create, StateCreator } from 'zustand'
+import { devtools } from 'zustand/middleware'
 
 type JungleStore = {
   bears: number


### PR DESCRIPTION
## Summary

Came to this page to double check where I import `devtools` from, noticed it missing from the code sample

## Check List

- [x] `pnpm run prettier` for formatting code and docs
