### PR TITLE
docs(CONTRIBUTING.md): change 'pnpm' to 'pnpm install' for installing dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ you can use this suggested workflow:
 
 - Fork this repository;
 - Create a new feature branch based on the `main` branch;
-- Install dependencies by running `pnpm`;
+- Install dependencies by running `pnpm install`;
 - Create failing tests for your fix or new feature;
 - Implement your changes and confirm that all test are passing.
   You can run the tests continuously during development


### PR DESCRIPTION
## Summary

* The correct command is not `pnpm` but `pnpm install`

## Check List

- [x] `pnpm run prettier` for formatting code and docs
