### PR TITLE
chore(.eslintrc.json): remove prettier in extends

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,11 +8,10 @@
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "prettier",
-    "plugin:prettier/recommended",
     "plugin:react-hooks/recommended",
     "plugin:import/errors",
-    "plugin:import/warnings"
+    "plugin:import/warnings",
+    "plugin:prettier/recommended"
   ],
   "plugins": [
     "@typescript-eslint",


### PR DESCRIPTION
## Summary

* remove `prettier` in eslintrc.json's extends because we already use [`plugin:prettier/recommended`, which includes `prettier`](https://github.com/prettier/eslint-plugin-prettier?tab=readme-ov-file#installation)
* 
## Check List

- [x] `pnpm run prettier` for formatting code and docs
