### PR TITLE
chore(.eslintrc.json): remove unnecessary elements from the plugins, add react/jsx-runtime

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,22 +8,13 @@
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
+    "plugin:react/jsx-runtime",
     "plugin:react-hooks/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",
     "plugin:prettier/recommended"
   ],
-  "plugins": [
-    "@typescript-eslint",
-    "react",
-    "prettier",
-    "react-hooks",
-    "import",
-    "@vitest",
-    "jest-dom",
-    "testing-library",
-    "react-compiler"
-  ],
+  "plugins": ["react-compiler"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2018,
@@ -77,8 +68,6 @@
         "pathGroupsExcludedImportTypes": ["builtin"]
       }
     ],
-    "react/jsx-uses-react": "off",
-    "react/react-in-jsx-scope": "off",
     "sort-imports": [
       "error",
       {


### PR DESCRIPTION
## Summary

* remove duplicate entries from the `plugins` array for libraries already included in `extends`.
* add `plugin:react/jsx-runtime` to `extends`.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
