### PR TITLE
chore(eslint): change 'dist' area in 'ignores', sort rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -69,13 +69,13 @@ export default tseslint.config(
           pathGroupsExcludedImportTypes: ['builtin'],
         },
       ],
+      '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unused-vars': [
         'warn',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
       ],
-      '@typescript-eslint/no-explicit-any': 'off',
-      ...reactHooks.configs.recommended.rules,
       'react-compiler/react-compiler': 'warn',
+      ...reactHooks.configs.recommended.rules,
     },
   },
   {
@@ -85,13 +85,13 @@ export default tseslint.config(
     ...vitest.configs.recommended,
     rules: {
       'import/extensions': ['error', 'never'],
+      '@typescript-eslint/no-unused-vars': 'off',
       'testing-library/no-node-access': 'off',
       'vitest/expect-expect': 'off',
       'vitest/consistent-test-it': [
         'error',
         { fn: 'it', withinDescribe: 'it' },
       ],
-      '@typescript-eslint/no-unused-vars': 'off',
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,7 @@ import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
   {
-    ignores: ['dist/**', 'examples/**'],
+    ignores: ['dist/', 'examples/'],
   },
   eslint.configs.recommended,
   importPlugin.flatConfigs.recommended,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,7 +10,7 @@ import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
   {
-    ignores: ['**/dist/', 'examples/**'],
+    ignores: ['dist/**', 'examples/**'],
   },
   eslint.configs.recommended,
   importPlugin.flatConfigs.recommended,


### PR DESCRIPTION
## Summary

* Change `dist` area in `ignores`.
  * We can just ignore the `./dist`.
* Sort `rules` by the order `plugins` were added and by name.
  * It is to make it more predictable for the user and improve readability.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
