### PR TITLE
chore(example/starter): update package manager to pnpm@9.15.2

### DIFF
--- a/examples/starter/package.json
+++ b/examples/starter/package.json
@@ -8,6 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview"
   },
+  "packageManager": "pnpm@9.15.2",
   "dependencies": {
     "zustand": "^5.0.2",
     "react": "^18.3.1",


### PR DESCRIPTION
## Summary

This pull request includes a small change to the `examples/starter/package.json` file. The change specifies the package manager to be used for the project. So that the `pnpm-lock.yaml` file will not change when execute `pnpm i`.

* [`examples/starter/package.json`](diffhunk://#diff-0f8ffb6f82d2a180f9426495e2faf686abe5e5bb83ff7034eb442f0ab9f81b98R11): Added `"packageManager": "pnpm@9.15.2"` to specify the use of `pnpm` version 9.15.2 as the package manager.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
