### PR TITLE
chore(.github/workflows): change 'node-version' to 'lts/*' in 'actions/setup-node'

### DIFF
--- a/.github/workflows/compressed-size-action.yml
+++ b/.github/workflows/compressed-size-action.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 'lts/*'
           cache: 'pnpm'
       - uses: preactjs/compressed-size-action@v2
         with:

--- a/.github/workflows/compressed-size-action.yml
+++ b/.github/workflows/compressed-size-action.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
       - uses: preactjs/compressed-size-action@v2
         with:

--- a/.github/workflows/compressed-size-action.yml
+++ b/.github/workflows/compressed-size-action.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: 'pnpm'
       - uses: preactjs/compressed-size-action@v2
         with:

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 'lts/*'
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm build

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm build

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm build

--- a/.github/workflows/lint-and-type.yml
+++ b/.github/workflows/lint-and-type.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 'lts/*'
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm test:format

--- a/.github/workflows/lint-and-type.yml
+++ b/.github/workflows/lint-and-type.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm test:format

--- a/.github/workflows/lint-and-type.yml
+++ b/.github/workflows/lint-and-type.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm test:format

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
       - run: pnpm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
       - run: pnpm install

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
       - run: pnpm install

--- a/.github/workflows/test-multiple-builds.yml
+++ b/.github/workflows/test-multiple-builds.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 'lts/*'
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm build

--- a/.github/workflows/test-multiple-builds.yml
+++ b/.github/workflows/test-multiple-builds.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm build

--- a/.github/workflows/test-multiple-builds.yml
+++ b/.github/workflows/test-multiple-builds.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm build

--- a/.github/workflows/test-multiple-versions.yml
+++ b/.github/workflows/test-multiple-versions.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm build # we don't have any other workflows to test build
@@ -38,7 +38,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: 'pnpm'
       - run: pnpm install
       - name: Test ${{ matrix.react }} ${{ matrix.devtools-skip }}

--- a/.github/workflows/test-multiple-versions.yml
+++ b/.github/workflows/test-multiple-versions.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm build # we don't have any other workflows to test build
@@ -38,7 +38,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
       - run: pnpm install
       - name: Test ${{ matrix.react }} ${{ matrix.devtools-skip }}

--- a/.github/workflows/test-multiple-versions.yml
+++ b/.github/workflows/test-multiple-versions.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 'lts/*'
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm build # we don't have any other workflows to test build

--- a/.github/workflows/test-multiple-versions.yml
+++ b/.github/workflows/test-multiple-versions.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 'lts/*'
           cache: 'pnpm'
       - run: pnpm install
       - name: Test ${{ matrix.react }} ${{ matrix.devtools-skip }}

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: lts/*
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm build

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version: 'lts/*'
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm build

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm build


### PR DESCRIPTION
## Summary

* Change `node-version` to `lts/*` to always use the latest LTS version of Node.js.

## Check List

- [x] `pnpm run prettier` for formatting code and docs
