### PR TITLE
docs(create.md): fix state selector syntax in troubleshooting example

### DIFF
--- a/docs/apis/create.md
+++ b/docs/apis/create.md
@@ -449,8 +449,8 @@ const usePersonStore = create<PersonStore>()((set) => ({
 }))
 
 export default function Form() {
-  const person = usePersonStore((state) => person)
-  const setPerson = usePersonStore((state) => setPerson)
+  const person = usePersonStore((state) => state)
+  const setPerson = usePersonStore((state) => state.setPerson)
 
   function handleFirstNameChange(e: ChangeEvent<HTMLInputElement>) {
     person.firstName = e.target.value


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary


Fixed incorrect state selector syntax in the troubleshooting example of create.md. The original code had a circular reference issue where person and setPerson were trying to reference themselves. Updated the selectors to correctly access the state and setPerson from the store state.

## Check List

- [x] `pnpm run fix:format` for formatting code and docs
