### PR TITLE
docs(create-store.md): fix incorrect usage of `create` function in ex…

### DIFF
--- a/docs/apis/create-store.md
+++ b/docs/apis/create-store.md
@@ -242,7 +242,7 @@ import { createStore } from 'zustand/vanilla'
 
 type PositionStore = [number, number]
 
-const positionStore = create<PositionStore>()(() => [0, 0])
+const positionStore = createStore<PositionStore>()(() => [0, 0])
 
 const $dotContainer = document.getElementById('dot-container') as HTMLDivElement
 const $dot = document.getElementById('dot') as HTMLDivElement


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

Fixed the incorrect usage of `create` function in the PositionStore example by replacing it with `createStore`. Ensured consistency with the rest of the document.

## Check List

- [x] `pnpm run fix:format` for formatting code and docs
