### PR TITLE
docs(create-with-equality-fn.md): fix typos in event handler type definitions

### DIFF
--- a/docs/apis/create-with-equality-fn.md
+++ b/docs/apis/create-with-equality-fn.md
@@ -558,7 +558,7 @@ const usePersonStore = createWithEqualityFn<PersonStore>()(
       lastName: 'Hepworth',
       email: 'bhepworth@sculpture.com',
     },
-    setPerson: (person) => set({ person }),
+    setPerson: (nextPerson) => set({ person: nextPerson })
   }),
   shallow,
 )
@@ -567,15 +567,15 @@ export default function Form() {
   const person = usePersonStore((state) => state.person)
   const setPerson = usePersonStore((state) => state.setPerson)
 
-  function handleFirstNameChange(e: ChangeEvent<HTLMInputElement>) {
+  function handleFirstNameChange(e: ChangeEvent<HTMLInputElement>) {
     setPerson({ ...person, firstName: e.target.value })
   }
 
-  function handleLastNameChange(e: ChangeEvent<HTLMInputElement>) {
+  function handleLastNameChange(e: ChangeEvent<HTMLInputElement>) {
     setPerson({ ...person, lastName: e.target.value })
   }
 
-  function handleEmailChange(e: ChangeEvent<HTLMInputElement>) {
+  function handleEmailChange(e: ChangeEvent<HTMLInputElement>) {
     setPerson({ ...person, email: e.target.value })
   }
 

--- a/docs/apis/create-with-equality-fn.md
+++ b/docs/apis/create-with-equality-fn.md
@@ -558,7 +558,7 @@ const usePersonStore = createWithEqualityFn<PersonStore>()(
       lastName: 'Hepworth',
       email: 'bhepworth@sculpture.com',
     },
-    setPerson: (nextPerson) => set({ person: nextPerson })
+    setPerson: (nextPerson) => set({ person: nextPerson }),
   }),
   shallow,
 )

--- a/docs/apis/shallow.md
+++ b/docs/apis/shallow.md
@@ -78,8 +78,8 @@ shallow(booleanLeft, booleanRight) // -> true
 const bigIntLeft = 1n
 const bigIntRight = 1n
 
-Object.is(bigInLeft, bigInRight) // -> true
-shallow(bigInLeft, bigInRight) // -> true
+Object.is(bigIntLeft, bigIntRight) // -> true
+shallow(bigIntLeft, bigIntRight) // -> true
 ```
 
 ### Comparing Objects


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

### create-with-equality-fn.md
* Fixed incorrect state update pattern in Form example where setPerson was using `person` instead of `{ person: nextPerson }`
* Fixed TypeScript type definition typos in form handlers, correcting `HTLMInputElement` to `HTMLInputElement` in three event handler functions

### shallow.md
Fixed variable name typos in BigInt comparison example `bigInLeft, bigInRight` to `bigIntLeft, bigIntRight`

## Check List

- [x] `pnpm run fix:format` for formatting code and docs
