### PR TITLE
chore(*): replace 'pnpm <command>' with 'pnpm run <command>'

### DIFF
--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -13,5 +13,5 @@ jobs:
           node-version: 'lts/*'
           cache: 'pnpm'
       - run: pnpm install
-      - run: pnpm build
+      - run: pnpm run build
       - run: pnpm dlx pkg-pr-new publish './dist' --compact --template './examples/*'

--- a/.github/workflows/lint-and-type.yml
+++ b/.github/workflows/lint-and-type.yml
@@ -17,6 +17,6 @@ jobs:
           node-version: 'lts/*'
           cache: 'pnpm'
       - run: pnpm install
-      - run: pnpm test:format
-      - run: pnpm test:types
-      - run: pnpm test:lint
+      - run: pnpm run test:format
+      - run: pnpm run test:types
+      - run: pnpm run test:lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
       - run: pnpm install
-      - run: pnpm build
+      - run: pnpm run build
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test-multiple-builds.yml
+++ b/.github/workflows/test-multiple-builds.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 'lts/*'
           cache: 'pnpm'
       - run: pnpm install
-      - run: pnpm build
+      - run: pnpm run build
       - name: Patch for DEV-ONLY
         if: ${{ matrix.env == 'development' }}
         run: |
@@ -46,6 +46,6 @@ jobs:
           NODE_ENV: ${{ matrix.env }}
       - name: Test ${{ matrix.build }} ${{ matrix.env }}
         run: |
-          pnpm test:spec
+          pnpm run test:spec
         env:
           NODE_ENV: ${{ matrix.env }}

--- a/.github/workflows/test-multiple-versions.yml
+++ b/.github/workflows/test-multiple-versions.yml
@@ -17,8 +17,8 @@ jobs:
           node-version: 'lts/*'
           cache: 'pnpm'
       - run: pnpm install
-      - run: pnpm build # we don't have any other workflows to test build
-      - run: pnpm test:spec
+      - run: pnpm run build # we don't have any other workflows to test build
+      - run: pnpm run test:spec
 
   test_matrix:
     runs-on: ubuntu-latest
@@ -44,4 +44,4 @@ jobs:
       - name: Test ${{ matrix.react }} ${{ matrix.devtools-skip }}
         run: |
           pnpm add -D react@${{ matrix.react }} react-dom@${{ matrix.react }}
-          pnpm test:spec
+          pnpm run test:spec

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: 'lts/*'
           cache: 'pnpm'
       - run: pnpm install
-      - run: pnpm build
+      - run: pnpm run build
       - name: Patch for all TS
         run: |
           sed -i~ 's/"isolatedDeclarations": true,//' tsconfig.json
@@ -52,4 +52,4 @@ jobs:
       - name: Install old TypeScript
         run: pnpm add -D typescript@${{ matrix.typescript }}
       - name: Test ${{ matrix.typescript }}
-        run: pnpm test:types
+        run: pnpm run test:types

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "build:vanilla:shallow": "rollup -c --config-vanilla_shallow",
     "build:react:shallow": "rollup -c --config-react_shallow",
     "build:traditional": "rollup -c --config-traditional",
-    "postbuild": "pnpm patch-d-ts && pnpm copy && pnpm patch-old-ts && pnpm patch-esm-ts",
+    "postbuild": "pnpm run patch-d-ts && pnpm run copy && pnpm run patch-old-ts && pnpm run patch-esm-ts",
     "fix:format": "prettier \"*.{js,json,md}\" \"{examples,src,tests,docs}/**/*.{js,jsx,ts,tsx,md,mdx}\" --write",
     "fix:lint": "eslint . --fix",
     "test": "pnpm run \"/^test:.*/\"",


### PR DESCRIPTION
## Summary

### Changes
- We agreed to avoid using aliases.
- Replaced `pnpm <command>` with `pnpm run <command>` for all related commands.
- Explicitly added `run` to avoid potential conflicts with pnpm's lifecycle commands, as omitting `run` can cause conflicts.
- This change was made to maintain consistency with existing commands that already use the `pnpm run <command>` format.

### Reason
- Adding `run` ensures that commands are clearly separated from pnpm's lifecycle commands, preventing conflicts.
- Using `pnpm run` helps clarify the intention of running a script.
- This change aligns with the existing usage of `pnpm run`, maintaining consistency across the codebase.

## Check List

- [x] `pnpm run fix:format` for formatting code and docs
