### PR TITLE
docs: Remove unnecessary void operator

### DIFF
--- a/docs/guides/nextjs.md
+++ b/docs/guides/nextjs.md
@@ -264,10 +264,10 @@ export const HomePage = () => {
     <div>
       Count: {count}
       <hr />
-      <button type="button" onClick={() => void incrementCount()}>
+      <button type="button" onClick={incrementCount}>
         Increment Count
       </button>
-      <button type="button" onClick={() => void decrementCount()}>
+      <button type="button" onClick={decrementCount}>
         Decrement Count
       </button>
     </div>
@@ -334,10 +334,10 @@ export const HomePage = () => {
     <div>
       Count: {count}
       <hr />
-      <button type="button" onClick={() => void incrementCount()}>
+      <button type="button" onClick={incrementCount}>
         Increment Count
       </button>
-      <button type="button" onClick={() => void decrementCount()}>
+      <button type="button" onClick={decrementCount}>
         Decrement Count
       </button>
     </div>


### PR DESCRIPTION
## Summary
Removed the unnecessary void operator from the <button> element's onClick handler.

The void operator is not needed since incrementCount does not require explicit suppression of its return value.
Improves code readability and maintainability by eliminating unnecessary operations.

## Check List

- [ ] `pnpm run fix:format` for formatting code and docs
