### PR TITLE
docs: strict null check in createContext example

### DIFF
--- a/docs/previous-versions/zustand-v3-create-context.md
+++ b/docs/previous-versions/zustand-v3-create-context.md
@@ -111,19 +111,20 @@ Discussion: https://github.com/pmndrs/zustand/discussions/1276
 Here's the new context usage with v4 API.
 
 ```jsx
-import { createContext, useContext, useState } from 'react'
+import { createContext, useContext, useRef } from 'react'
 import { createStore, useStore } from 'zustand'
 
 const StoreContext = createContext(null)
 
 const StoreProvider = ({ children }) => {
-  const [store] = useState(() =>
-    createStore((set) => ({
+  const storeRef = useRef()
+  if (storeRef.current === null) {
+    storeRef.current = createStore((set) => ({
       // ...
     }))
-  )
+  }
   return (
-    <StoreContext.Provider value={store}>
+    <StoreContext.Provider value={storeRef.current}>
       {children}
     </StoreContext.Provider>
   )


### PR DESCRIPTION
## Related Bug Reports or Discussions

N/A

## Summary

~~This PR edits the 'context usage' example from the docs to use state, rather than a ref, to hold the zustand store.~~
This PR edits the 'context usage' example from the docs to use a strict mull check, rather than `!ref.current`, so that the react compiler recognizes the ref is immutable and optimizes the component.

~~Both useState and useRef are correct in practice: useState will only render once since we never set the state after initialization, and useRef is safe to use since the component never needs to rerender when the ref value changes.~~

~~However, lint rules will flag useRef as a mistake, because we are passing a ref value to a child component, which in general can cause stale components since changing refs doesn't trigger re-renders.~~

## Check List

- [x] `pnpm run fix:format` for formatting code and docs
