### PR TITLE
fix: partial state update behaviour

### DIFF
--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -243,8 +243,8 @@ it('can update the equality checker', async () => {
   )
 
   // This will cause a re-render due to the equality checker.
-  act(() => setState({ value: 0 }))
-  await screen.findByText('renderCount: 2, value: 0')
+  act(() => setState({ value: 1 }))
+  await screen.findByText('renderCount: 2, value: 1')
 
   // Set an equality checker that always returns true to never re-render.
   rerender(
@@ -254,8 +254,8 @@ it('can update the equality checker', async () => {
   )
 
   // This will NOT cause a re-render due to the equality checker.
-  act(() => setState({ value: 1 }))
-  await screen.findByText('renderCount: 3, value: 0')
+  act(() => setState({ value: 2 }))
+  await screen.findByText('renderCount: 3, value: 1')
 })
 
 it('can call useBoundStore with progressively more arguments', async () => {

--- a/tests/vanilla/subscribe.test.tsx
+++ b/tests/vanilla/subscribe.test.tsx
@@ -13,14 +13,17 @@ describe('subscribe()', () => {
     expect(spy).not.toHaveBeenCalled()
   })
 
-  it('should be called if new state identity is different', () => {
+  it('should not be called if new state is the same', () => {
     const spy = vi.fn()
-    const initialState = { value: 1, other: 'a' }
+    const symbol = Symbol()
+    const initialState = { value: 1, [symbol]: 'a' }
     const { setState, getState, subscribe } = createStore(() => initialState)
 
     subscribe(spy)
-    setState({ ...getState() })
-    expect(spy).toHaveBeenCalledWith(initialState, initialState)
+    setState({ value: 1 })
+    setState({ [symbol]: 'a' })
+    setState({ value: 1, [symbol]: 'a' })
+    expect(spy).not.toHaveBeenCalled()
   })
 
   it('should not be called when state slice is the same', () => {


### PR DESCRIPTION
## Summary

Currently `setState(state)` does nothing if `state` is same as the previous state. However this is not the case for partial state updates. Right now subscribers are called even if the partial state update leaves the state unchanged.

This PR aligns the behavior of partial state updates with full state updates. If the "update" leaves the state unchanged, subscribers will not be called. This greatly improves performance in scenarios when state is left unchanged.

Note that this does change the behaviour of Zustand, so feedback is welcome.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
