### PR TITLE
refactor(middleware): rename argument names like 'a', 'f'

### DIFF
--- a/src/middleware/combine.ts
+++ b/src/middleware/combine.ts
@@ -11,5 +11,5 @@ export function combine<
   initialState: T,
   create: StateCreator<T, Mps, Mcs, U>,
 ): StateCreator<Write<T, U>, Mps, Mcs> {
-  return (...a) => Object.assign({}, initialState, (create as any)(...a))
+  return (...args) => Object.assign({}, initialState, (create as any)(...args))
 }

--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -30,9 +30,9 @@ type Write<T, U> = Omit<T, keyof U> & U
 type TakeTwo<T> = T extends { length: 0 }
   ? [undefined, undefined]
   : T extends { length: 1 }
-    ? [...a0: Cast<T, unknown[]>, a1: undefined]
+    ? [...args0: Cast<T, unknown[]>, arg1: undefined]
     : T extends { length: 0 | 1 }
-      ? [...a0: Cast<T, unknown[]>, a1: undefined]
+      ? [...args0: Cast<T, unknown[]>, arg1: undefined]
       : T extends { length: 2 }
         ? T
         : T extends { length: 1 | 2 }
@@ -58,13 +58,13 @@ type Action =
 type StoreDevtools<S> = S extends {
   setState: {
     // capture both overloads of setState
-    (...a: infer Sa1): infer Sr1
-    (...a: infer Sa2): infer Sr2
+    (...args: infer Sa1): infer Sr1
+    (...args: infer Sa2): infer Sr2
   }
 }
   ? {
-      setState(...a: [...a: TakeTwo<Sa1>, action?: Action]): Sr1
-      setState(...a: [...a: TakeTwo<Sa2>, action?: Action]): Sr2
+      setState(...args: [...arg0: TakeTwo<Sa1>, action?: Action]): Sr1
+      setState(...args: [...arg0: TakeTwo<Sa2>, action?: Action]): Sr2
     }
   : never
 
@@ -231,10 +231,10 @@ const devtoolsImpl: DevtoolsImpl =
     ) {
       let didWarnAboutReservedActionType = false
       const originalDispatch = (api as any).dispatch
-      ;(api as any).dispatch = (...a: any[]) => {
+      ;(api as any).dispatch = (...args: any[]) => {
         if (
           import.meta.env?.MODE !== 'production' &&
-          a[0].type === '__setState' &&
+          args[0].type === '__setState' &&
           !didWarnAboutReservedActionType
         ) {
           console.warn(
@@ -243,7 +243,7 @@ const devtoolsImpl: DevtoolsImpl =
           )
           didWarnAboutReservedActionType = true
         }
-        ;(originalDispatch as any)(...a)
+        ;(originalDispatch as any)(...args)
       }
     }
 

--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -372,7 +372,7 @@ const devtoolsImpl: DevtoolsImpl =
   }
 export const devtools = devtoolsImpl as unknown as Devtools
 
-const parseJsonThen = <T>(stringified: string, f: (parsed: T) => void) => {
+const parseJsonThen = <T>(stringified: string, fn: (parsed: T) => void) => {
   let parsed: T | undefined
   try {
     parsed = JSON.parse(stringified)
@@ -382,5 +382,5 @@ const parseJsonThen = <T>(stringified: string, f: (parsed: T) => void) => {
       e,
     )
   }
-  if (parsed !== undefined) f(parsed as T)
+  if (parsed !== undefined) fn(parsed as T)
 }

--- a/src/middleware/immer.ts
+++ b/src/middleware/immer.ts
@@ -40,8 +40,8 @@ type StoreImmer<S> = S extends {
   setState: infer SetState
 }
   ? SetState extends {
-      (...a: infer A1): infer Sr1
-      (...a: infer A2): infer Sr2
+      (...args: infer A1): infer Sr1
+      (...args: infer A2): infer Sr2
     }
     ? {
         // Ideally, we would want to infer the `nextStateOrUpdater` `T` type from the
@@ -53,14 +53,14 @@ type StoreImmer<S> = S extends {
             | Partial<SetStateType<A2>>
             | ((state: Draft<SetStateType<A2>>) => void),
           shouldReplace?: false,
-          ...a: SkipTwo<A1>
+          ...args: SkipTwo<A1>
         ): Sr1
         setState(
           nextStateOrUpdater:
             | SetStateType<A2>
             | ((state: Draft<SetStateType<A2>>) => void),
           shouldReplace: true,
-          ...a: SkipTwo<A2>
+          ...args: SkipTwo<A2>
         ): Sr2
       }
     : never
@@ -73,12 +73,12 @@ type ImmerImpl = <T>(
 const immerImpl: ImmerImpl = (initializer) => (set, get, store) => {
   type T = ReturnType<typeof initializer>
 
-  store.setState = (updater, replace, ...a) => {
+  store.setState = (updater, replace, ...args) => {
     const nextState = (
       typeof updater === 'function' ? produce(updater as any) : updater
     ) as ((s: T) => T) | T | Partial<T>
 
-    return set(nextState, replace as any, ...a)
+    return set(nextState, replace as any, ...args)
   }
 
   return initializer(store.setState, get, store)

--- a/src/middleware/redux.ts
+++ b/src/middleware/redux.ts
@@ -45,6 +45,6 @@ const reduxImpl: ReduxImpl = (reducer, initial) => (set, _get, api) => {
   }
   ;(api as any).dispatchFromDevtools = true
 
-  return { dispatch: (...a) => (api as any).dispatch(...a), ...initial }
+  return { dispatch: (...args) => (api as any).dispatch(...args), ...initial }
 }
 export const redux = reduxImpl as unknown as Redux


### PR DESCRIPTION
## Summary


* `arg` is more clarify than `a`
* `fn` is more clarify than `f`

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
