### PR TITLE
docs: Remove unnecessary semicolon

### DIFF
--- a/docs/guides/auto-generating-selectors.md
+++ b/docs/guides/auto-generating-selectors.md
@@ -26,7 +26,7 @@ const createSelectors = <S extends UseBoundStore<StoreApi<object>>>(
   let store = _store as WithSelectors<typeof _store>
   store.use = {}
   for (let k of Object.keys(store.getState())) {
-    ;(store.use as any)[k] = () => store((s) => s[k as keyof typeof s])
+    (store.use as any)[k] = () => store((s) => s[k as keyof typeof s])
   }
 
   return store
@@ -80,7 +80,7 @@ const createSelectors = <S extends StoreApi<object>>(_store: S) => {
   const store = _store as WithSelectors<typeof _store>
   store.use = {}
   for (const k of Object.keys(store.getState())) {
-    ;(store.use as any)[k] = () =>
+    (store.use as any)[k] = () =>
       useStore(_store, (s) => s[k as keyof typeof s])
   }
 


### PR DESCRIPTION
## Summary
The unnecessary semicolons in the document affect readability, so we are removing them.
## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
