### PR TITLE
docs: update vitest config to match vitest docs

### DIFF
--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -283,8 +283,8 @@ export default defineConfig((configEnv) =>
         environment: 'jsdom',
         setupFiles: ['./setup-vitest.ts'],
       },
-    })
-  )
+    }),
+  ),
 )
 ```
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -274,15 +274,17 @@ vi.mock('zustand') // to make it work like Jest (auto-mocking)
 import { defineConfig, mergeConfig } from 'vitest/config'
 import viteConfig from './vite.config'
 
-export default mergeConfig(
-  viteConfig,
-  defineConfig({
-    test: {
-      globals: true,
-      environment: 'jsdom',
-      setupFiles: ['./setup-vitest.ts'],
-    },
-  }),
+export default defineConfig((configEnv) =>
+  mergeConfig(
+    viteConfig(configEnv),
+    defineConfig({
+      test: {
+        globals: true,
+        environment: 'jsdom',
+        setupFiles: ['./setup-vitest.ts'],
+      },
+    })
+  )
 )
 ```
 


### PR DESCRIPTION
in vite,
mergeConfig accepts only config in object form. If you have a config in callback form, you should call it before passing into mergeConfig.

You can use the defineConfig helper to merge a config in callback form with another config:

https://vite.dev/guide/api-javascript.html#mergeconfig

## Related Bug Reports or Discussions

Fixes #

## Summary

## Check List

- [ ] `pnpm run fix` for formatting and linting code and docs
