### PR TITLE
ci(.github/workflows): add concurrency

### DIFF
--- a/.github/workflows/compressed-size-action.yml
+++ b/.github/workflows/compressed-size-action.yml
@@ -2,6 +2,10 @@ name: Compressed Size
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -2,6 +2,10 @@ name: Publish Any Commit
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-and-type.yml
+++ b/.github/workflows/lint-and-type.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-multiple-builds.yml
+++ b/.github/workflows/test-multiple-builds.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test_matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-multiple-versions.yml
+++ b/.github/workflows/test-multiple-versions.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-old-typescript.yml
+++ b/.github/workflows/test-old-typescript.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test_matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

* Add `concurrency` in action
  * The `concurrency` setting is needed to prevent duplicate runs when a PR is modified or commits are pushed multiple times, ensuring only the latest run is executed. Multiple executions can lead to resource wastage, and since only the latest state matters, canceling previous runs and keeping the latest one improves efficiency and reduces resource consumption.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
