### PR TITLE
Update Next.js guide to have explicitly nullable `useRef` type argument

### DIFF
--- a/docs/guides/nextjs.md
+++ b/docs/guides/nextjs.md
@@ -124,7 +124,7 @@ export interface CounterStoreProviderProps {
 export const CounterStoreProvider = ({
   children,
 }: CounterStoreProviderProps) => {
-  const storeRef = useRef<CounterStoreApi>(null)
+  const storeRef = useRef<CounterStoreApi | null>(null)
   if (!storeRef.current) {
     storeRef.current = createCounterStore()
   }

--- a/docs/guides/nextjs.md
+++ b/docs/guides/nextjs.md
@@ -125,7 +125,7 @@ export const CounterStoreProvider = ({
   children,
 }: CounterStoreProviderProps) => {
   const storeRef = useRef<CounterStoreApi | null>(null)
-  if (!storeRef.current) {
+  if (storeRef.current === null) {
     storeRef.current = createCounterStore()
   }
 
@@ -218,7 +218,7 @@ export const CounterStoreProvider = ({
   children,
 }: CounterStoreProviderProps) => {
   const storeRef = useRef<CounterStoreApi | null>(null)
-  if (!storeRef.current) {
+  if (storeRef.current === null) {
     storeRef.current = createCounterStore(initCounterStore())
   }
 

--- a/docs/guides/nextjs.md
+++ b/docs/guides/nextjs.md
@@ -217,7 +217,7 @@ export interface CounterStoreProviderProps {
 export const CounterStoreProvider = ({
   children,
 }: CounterStoreProviderProps) => {
-  const storeRef = useRef<CounterStoreApi>(null)
+  const storeRef = useRef<CounterStoreApi | null>(null)
   if (!storeRef.current) {
     storeRef.current = createCounterStore(initCounterStore())
   }


### PR DESCRIPTION
Resolves #3052 by explicitly making the type argument to `useRef` nullable.