### PR TITLE
ci(.github/workflows): rename 'cr' to 'preview-release'

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,9 +1,9 @@
-name: Publish Any Commit
+name: Preview Release
 
 on: [push, pull_request]
 
 jobs:
-  build:
+  preview_release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

* relate https://github.com/pmndrs/zustand/pull/3059
  * In `pkg-pr-new`, `pr` stands for `preview release`. Therefore, I concluded that changing it to `preview release` feels more natural than using `cr`.
  * I have determined that `preview release` is also appropriate for standardizing the `file name`, `title`, and `job name`

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
