### PR TITLE
docs: update readme TS sample to be less verbose and match TS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,27 +466,16 @@ Basic typescript usage doesn't require anything special except for writing `crea
 
 ```ts
 import { create } from 'zustand'
-import { devtools, persist } from 'zustand/middleware'
-import type {} from '@redux-devtools/extension' // required for devtools typing
 
 interface BearState {
   bears: number
   increase: (by: number) => void
 }
 
-const useBearStore = create<BearState>()(
-  devtools(
-    persist(
-      (set) => ({
-        bears: 0,
-        increase: (by) => set((state) => ({ bears: state.bears + by })),
-      }),
-      {
-        name: 'bear-storage',
-      },
-    ),
-  ),
-)
+const useBearStore = create<BearState>()((set) => ({
+  bears: 0,
+  increase: (by) => set((state) => ({ bears: state.bears + by })),
+}))
 ```
 
 A more complete TypeScript guide is [here](docs/guides/typescript.md).


### PR DESCRIPTION
## Related Bug Reports or Discussions
Will look and update the PR if I find them.

Fixes #

## Summary

In the readme, the typescript sample is very verbose and inconsistent with the actual typescript documentation. I think the consistency and conciseness are important for a first time experience when getting started. 

[Link to docs for comparison.](https://github.com/pmndrs/zustand/blob/main/docs/guides/typescript.md)

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
