### PR TITLE
ci(.github/workflows/compressed-size.yml): remove unnecessary actions

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -7,11 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 'lts/*'
-          cache: 'pnpm'
       - uses: preactjs/compressed-size-action@v2
         with:
           pattern: './dist/**/*.{js,mjs}'


### PR DESCRIPTION
## Summary

* We don't need to use `pnpm/action-setup` and `actions/setup-node` when use `preactjs/compressed-size-action`, so i removed them.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
