### PR TITLE
Docs: fix misinformation about Date persistence with JSONStorage

### DIFF
--- a/docs/integrations/persisting-store-data.md
+++ b/docs/integrations/persisting-store-data.md
@@ -461,9 +461,9 @@ const storage = createJSONStorage(() => sessionStorage, {
     }
     return value
   },
-  replacer: (key, value) => {
-    if (value instanceof Date) {
-      return { type: 'date', value: value.toISOString() }
+  replacer: function (this, key, value) {
+    if (this[key] instanceof Date) {
+      return { type: 'date', value: this[key].toISOString() }
     }
     return value
   },


### PR DESCRIPTION
## Documentation example error

The example in the documentation doesn't work for Date object

## Summary

The updated code uses `this` to access to the Date object directly, the var `value` contains the value of `this[key].toJSON()`

From [the MDN docs for JSON.stringify replacer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter)

> As a function, it takes two parameters: the key and the value being stringified. The object in which the key was found is provided as the replacer's this context.

And
>All [Temporal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal) objects implement the toJSON() method, which returns a string (the same as calling toString()). Thus, they will be serialized as strings. Similarly, [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) objects implement toJSON(), which returns the same as [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString).

## Check List

- [ X] `pnpm run fix` for formatting and linting code and docs
