### PR TITLE
Fix typo

### DIFF
--- a/docs/guides/tutorial-tic-tac-toe.md
+++ b/docs/guides/tutorial-tic-tac-toe.md
@@ -1313,7 +1313,7 @@ export default function Game() {
 
   function jumpTo(nextMove) {
     setCurrentMove(nextMove)
-    setXIsNext(currentMove % 2 === 0)
+    setXIsNext(nextMove % 2 === 0)
   }
 
   return (


### PR DESCRIPTION
xIsNext is determined by the next state of currentMove

## Related Bug Reports or Discussions

Fixes #

## Summary

## Check List

- [ ] `pnpm run fix` for formatting and linting code and docs
