### PR TITLE
chore(eslint): remove overrides for .js files

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -89,10 +89,4 @@ export default tseslint.config(
       ],
     },
   },
-  {
-    files: ['*.js'],
-    rules: {
-      '@typescript-eslint/no-require-imports': 'off',
-    },
-  },
 )


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

* All `.js` files have been migrated to `.mjs`, making .js-specific ESLint settings obsolete.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
