### PR TITLE
test(vanilla/shallow): add test for pure iterable with different values returns false

### DIFF
--- a/tests/vanilla/shallow.test.tsx
+++ b/tests/vanilla/shallow.test.tsx
@@ -181,6 +181,24 @@ describe('generators', () => {
     expect(Symbol.iterator in gen()).toBe(true)
     expect(shallow(gen(), gen())).toBe(true)
   })
+
+  it('pure iterable with different values returns false', () => {
+    const iterableA = {
+      [Symbol.iterator]: function* (): Generator<number> {
+        yield 1
+        yield 2
+      },
+    }
+
+    const iterableB = {
+      [Symbol.iterator]: function* (): Generator<number> {
+        yield 1
+        yield 3
+      },
+    }
+
+    expect(shallow(iterableA, iterableB)).toBe(false)
+  })
 })
 
 describe('unsupported cases', () => {


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

### AS-IS

<img width="748" alt="image" src="https://github.com/user-attachments/assets/5def50aa-387e-4c71-b442-26d61c37789d" />


### TO-BE

<img width="753" alt="image" src="https://github.com/user-attachments/assets/e68c982e-3a16-4edf-abc5-9dd9bdec4689" />


## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
