### PR TITLE
test(vanilla/subscribe): add test for covering fireImmediately option in 'subscribeWithSelector'

### DIFF
--- a/tests/vanilla/subscribe.test.tsx
+++ b/tests/vanilla/subscribe.test.tsx
@@ -120,4 +120,15 @@ describe('subscribe()', () => {
     expect(spy2).toHaveBeenCalledTimes(1)
     expect(spy2).toHaveBeenCalledWith(1, 0)
   })
+
+  it('should call listener immediately when fireImmediately is true', () => {
+    const spy = vi.fn()
+    const initialState = { value: 1 }
+    const { subscribe } = createStore(subscribeWithSelector(() => initialState))
+
+    subscribe((s) => s.value, spy, { fireImmediately: true })
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(1, 1)
+  })
 })


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

### AS-IS

<img width="744" alt="image" src="https://github.com/user-attachments/assets/d8aa5be3-8328-441a-bada-54f930bdfb19" />

### TO-BE

<img width="742" alt="image" src="https://github.com/user-attachments/assets/db55c53d-ff43-46ab-96c1-876bff1182b5" />

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
