### PR TITLE
refactor(vanilla): resolve todo by removing type assertion using inferred type predicates

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -57,6 +57,8 @@ type CreateStoreImpl = <
   initializer: StateCreator<T, [], Mos>,
 ) => Mutate<StoreApi<T>, Mos>
 
+const isFunction = (x: unknown) => typeof x === 'function'
+
 const createStoreImpl: CreateStoreImpl = (createState) => {
   type TState = ReturnType<typeof createState>
   type Listener = (state: TState, prevState: TState) => void
@@ -64,12 +66,7 @@ const createStoreImpl: CreateStoreImpl = (createState) => {
   const listeners: Set<Listener> = new Set()
 
   const setState: StoreApi<TState>['setState'] = (partial, replace) => {
-    // TODO: Remove type assertion once https://github.com/microsoft/TypeScript/issues/37663 is resolved
-    // https://github.com/microsoft/TypeScript/issues/37663#issuecomment-759728342
-    const nextState =
-      typeof partial === 'function'
-        ? (partial as (state: TState) => TState)(state)
-        : partial
+    const nextState = isFunction(partial) ? partial(state) : partial
     if (!Object.is(nextState, state)) {
       const previousState = state
       state =


### PR DESCRIPTION
## Related Bug Reports or Discussions
Fixes #

## Summary
Refer to the TypeScript issue [37663: T | (() => T)](https://github.com/microsoft/TypeScript/issues/37663). (you can see the issue in the previous TODO comment too)

Before TypeScript 5.5, type inference with `typeof` was not possible in this case.  

However, in TS 5.5+, this is now supported thanks to [Inferred Type Predicates](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#inferred-type-predicates).

<img width="875" alt="image" src="https://github.com/user-attachments/assets/8f571779-2e27-4577-9a4f-51799c10136c" />

And I used it to resolve the todo.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
