### PR TITLE
Avoid inferring action type when explicit action name is provided

### DIFF
--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -207,10 +207,14 @@ const devtoolsImpl: DevtoolsImpl =
     ;(api.setState as any) = ((state, replace, nameOrAction: Action) => {
       const r = set(state, replace as any)
       if (!isRecording) return r
-      const inferredActionType = findCallerName(new Error().stack)
       const action: { type: string } =
         nameOrAction === undefined
-          ? { type: anonymousActionType || inferredActionType || 'anonymous' }
+          ? {
+              type:
+                anonymousActionType ||
+                findCallerName(new Error().stack) ||
+                'anonymous',
+            }
           : typeof nameOrAction === 'string'
             ? { type: nameOrAction }
             : nameOrAction


### PR DESCRIPTION
## Summary

https://github.com/pmndrs/zustand/pull/2987 Added call `findCallerName()` which tries to infer action name from error's callstack even when user explicitly provided action name (`nameOrAction` or `anonymousActionType`). I think it's much better to call `findCallerName` ONLY if user didn't provide anything we can use.


## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
