### PR TITLE
refactor(middleware): replace export * with explicit named and type exports

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,16 @@
-export * from './middleware/redux.ts'
-export * from './middleware/devtools.ts'
-export * from './middleware/subscribeWithSelector.ts'
-export * from './middleware/combine.ts'
-export * from './middleware/persist.ts'
+export { redux } from './middleware/redux.ts'
+export {
+  devtools,
+  type DevtoolsOptions,
+  type NamedSet,
+} from './middleware/devtools.ts'
+export { subscribeWithSelector } from './middleware/subscribeWithSelector.ts'
+export { combine } from './middleware/combine.ts'
+export {
+  persist,
+  createJSONStorage,
+  type StateStorage,
+  type StorageValue,
+  type PersistStorage,
+  type PersistOptions,
+} from './middleware/persist.ts'


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

* Aligned export format with [`middleware.ts`](https://github.com/pmndrs/zustand/blob/main/src/middleware.ts)
* Even if we use export `*` syntax, we still only export `useShallow` in [`react/shallow.ts`](https://github.com/pmndrs/zustand/blob/main/src/react/shallow.ts) and `shallow` in [`vanilla/shallow.ts`](https://github.com/pmndrs/zustand/blob/main/src/vanilla/shallow.ts)

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
