### PR TITLE
test(shallow): update 'shallow' and 'useShallow' imports to use 'zustand/shallow'

### DIFF
--- a/tests/shallow.test.tsx
+++ b/tests/shallow.test.tsx
@@ -2,9 +2,8 @@ import { useState } from 'react'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { create } from 'zustand'
-import { useShallow } from 'zustand/react/shallow'
+import { shallow, useShallow } from 'zustand/shallow'
 import { createWithEqualityFn } from 'zustand/traditional'
-import { shallow } from 'zustand/vanilla/shallow'
 
 describe('types', () => {
   it('works with useBoundStore and array selector (#1107)', () => {

--- a/tests/vanilla/shallow.test.tsx
+++ b/tests/vanilla/shallow.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { shallow } from 'zustand/vanilla/shallow'
+import { shallow } from 'zustand/shallow'
 
 describe('shallow', () => {
   it('compares primitive values', () => {


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

### before

<img width="749" alt="image" src="https://github.com/user-attachments/assets/8c4cd4dd-cf64-45b1-939b-488470430b9f" />

### after

<img width="756" alt="image" src="https://github.com/user-attachments/assets/13287cfd-60b8-4186-b0af-d281c2d273b4" />

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
