### PR TITLE
refactor: remove unused import in example & fix typo in tests

### DIFF
--- a/examples/demo/src/components/Scene.jsx
+++ b/examples/demo/src/components/Scene.jsx
@@ -1,5 +1,5 @@
 import { Mesh, PlaneGeometry, Group, Vector3, MathUtils } from 'three'
-import { memo, useRef, useState, useLayoutEffect } from 'react'
+import { useRef, useState, useLayoutEffect } from 'react'
 import { createRoot, events, extend, useFrame } from '@react-three/fiber'
 import { Plane, useAspect, useTexture } from '@react-three/drei'
 import {

--- a/tests/types.test.tsx
+++ b/tests/types.test.tsx
@@ -42,7 +42,7 @@ it('can use exposed types', () => {
     num: 1,
     numGet: () => get().num,
     numGetState: () => {
-      // TypeScript can't get the type of storeApi when it trys to enforce the signature of numGetState.
+      // TypeScript can't get the type of storeApi when it tries to enforce the signature of numGetState.
       // Need to explicitly state the type of storeApi.getState().num or storeApi type will be type 'any'.
       const result: number = storeApi.getState().num
       return result


### PR DESCRIPTION
## Related Bug Reports or Discussions

## Summary

remove unused import in example & fix typo in tests

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
