### PR TITLE
docs: fix getBoth return type

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -428,7 +428,7 @@ interface FishSlice {
 
 interface SharedSlice {
   addBoth: () => void
-  getBoth: () => void
+  getBoth: () => number
 }
 
 const createBearSlice: StateCreator<


### PR DESCRIPTION
## Summary

Fix the return type for `getBoth` in the typescript slices pattern documentation.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
