### PR TITLE
docs: add currying for createStore

### DIFF
--- a/docs/guides/auto-generating-selectors.md
+++ b/docs/guides/auto-generating-selectors.md
@@ -99,7 +99,7 @@ interface BearState {
   increment: () => void
 }
 
-const store = createStore<BearState>((set) => ({
+const store = createStore<BearState>()((set) => ({
   bears: 0,
   increase: (by) => set((state) => ({ bears: state.bears + by })),
   increment: () => set((state) => ({ bears: state.bears + 1 })),


### PR DESCRIPTION
I hope this is a correct change, but I was reading the docs, and if I didn't misunderstand, we always need to do currying when creating a store with typescript. This seemed to be missing in the code example used in auto generating selectors.