### PR TITLE
feat(middleare/persist): return storage promise from setState

### DIFF
--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -4,7 +4,7 @@ import type {
   StoreMutatorIdentifier,
 } from '../vanilla.ts'
 
-export interface StateStorage<R> {
+export interface StateStorage<R = unknown> {
   getItem: (name: string) => string | null | Promise<string | null>
   setItem: (name: string, value: string) => R
   removeItem: (name: string) => R
@@ -15,7 +15,7 @@ export type StorageValue<S> = {
   version?: number
 }
 
-export interface PersistStorage<S, R> {
+export interface PersistStorage<S, R = unknown> {
   getItem: (
     name: string,
   ) => StorageValue<S> | null | Promise<StorageValue<S> | null>
@@ -28,7 +28,7 @@ type JsonStorageOptions = {
   replacer?: (key: string, value: unknown) => unknown
 }
 
-export function createJSONStorage<S, R>(
+export function createJSONStorage<S, R = unknown>(
   getStorage: () => StateStorage<R>,
   options?: JsonStorageOptions,
 ): PersistStorage<S, unknown> | undefined {

--- a/tests/persistAsync.test.tsx
+++ b/tests/persistAsync.test.tsx
@@ -165,7 +165,9 @@ describe('persist middleware with async configuration', () => {
     })
 
     // Write something to the store
-    act(() => useBoundStore.setState({ count: 42 }))
+    act(() => {
+      useBoundStore.setState({ count: 42 })
+    })
     expect(await screen.findByText('count: 42')).toBeInTheDocument()
     expect(setItemSpy).toBeCalledWith(
       'test-storage',
@@ -788,7 +790,9 @@ describe('persist middleware with async configuration', () => {
 
     // Write something to the store
     const updatedMap = new Map(map).set('foo', 'bar')
-    act(() => useBoundStore.setState({ map: updatedMap }))
+    act(() => {
+      useBoundStore.setState({ map: updatedMap })
+    })
     expect(await screen.findByText('map-content: bar')).toBeInTheDocument()
 
     expect(setItemSpy).toBeCalledWith(


### PR DESCRIPTION
fix #3196 

persist middleware to mutate `setState` so that it returns what storage.setItem returns.

This is a suboptimal solution as we can't infer types. It's always `unknown`. Nevertheless, it should be usable if we assert types in a certain case.