### PR TITLE
feat: Added `createSetterFn` to the library

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -142,16 +142,14 @@ export function createSetterFn<
   Key extends keyof State,
 >(set: SetFn<State>, key: Key): SetStateFn<State[Key]> {
   type Value = State[Key]
-  type Prev = (oldState: Value) => Value
+  type FunctionState = (oldState: Value) => Value
 
-  const setterFn: SetStateFn<State[Key]> = (
-    newState: SetStateFnParam<State[Key]>,
-  ) => {
+  function setterFn(newState: SetStateFnParam<Value>): void {
     set((oldState) => ({
       ...oldState,
       [key]:
         typeof newState === 'function'
-          ? (newState as Prev)(oldState[key])
+          ? (newState as FunctionState)(oldState[key])
           : newState,
     }))
   }

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -149,7 +149,7 @@ export function createSetterFn<
   ) => {
     set((oldState) => ({
       ...oldState,
-      [key as Key]:
+      [key]:
         typeof newState === 'function'
           ? (newState as Prev)(oldState[key])
           : newState,

--- a/tests/basic.test.tsx
+++ b/tests/basic.test.tsx
@@ -9,7 +9,7 @@ import type { ReactNode } from 'react'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import ReactDOM from 'react-dom'
 import { afterEach, expect, it, vi } from 'vitest'
-import { create } from 'zustand'
+import { create, createSetterFn } from 'zustand'
 import type { StoreApi } from 'zustand'
 import { createWithEqualityFn } from 'zustand/traditional'
 
@@ -131,6 +131,30 @@ it('uses the store with a selector and equality checker', async () => {
   expect(
     await screen.findByText('renderCount: 2, value: 2'),
   ).toBeInTheDocument()
+})
+
+it('uses the store with createSetterFn', async () => {
+  const useBoundStore = create<CounterState>()((set) => {
+    const setCount = createSetterFn(set, 'count')
+    return {
+      count: 0,
+      inc: () => setCount((oldCount) => oldCount + 1),
+    }
+  })
+
+  function Counter() {
+    const { count, inc } = useBoundStore()
+    useEffect(inc, [inc])
+    return <div>count: {count}</div>
+  }
+
+  render(
+    <>
+      <Counter />
+    </>,
+  )
+
+  expect(await screen.findByText('count: 1')).toBeInTheDocument()
 })
 
 it('only re-renders if selected state has changed', async () => {


### PR DESCRIPTION
## Summary

This PR adds a `createSetterFn` which is a really nice way of creating state setters with far less boilerplate.

I was working through the [tic-tac-toe tutorial](https://zustand.docs.pmnd.rs/guides/tutorial-tic-tac-toe) and was unhappy to see the following as the recommended pattern for creating setter state:

```js
// What you have to do without `createSetterFn`

const useGameStore = create(
  combine({ squares: Array(9).fill(null) }, (set) => {
    return {
      // All of this, yuk, so much ugly boilerplate
      setSquares: (nextSquares) => {
        set((state) => ({
          squares:
            typeof nextSquares === 'function'
              ? nextSquares(state.squares)
              : nextSquares,
        }))
      },
    }
  }),
)
```

There is so much boiler plate in that `setSquares` function. I knew that it could be improved.

I built the `createSetterFn` as a more developer friendly way of managing those set functions.

With `createSetterFn`, the new `useGameStore` looks like this when using TypeScript:

```ts
// Refactored using `createSetterFn` and TypeScript

type Squares =  'x' | 'o' | null

interface GameStore {
	squares: Squares
	setSquares: SetStateFn<Squares>
}

const useGameStore = create<GameStore>()((set): GameStore => ({
	squares: new Array(9).fill(null),
    // All the boilerplate cut down to a single easy to read line
	setSquares: createSetterFn(set, 'squares'),
}))
```

`createSetterFn` is fully typed. It infers the `GameStore` interface from the `set` function and restricts the string you pass in the 2nd parameter to a key of the `GameStore` interface.

I really like this syntax it is very human readable. 

> I want to _create a setter function_, that will `set`, the `"squares"` state value


## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
