### PR TITLE
docs: update hook name from useStore to useBear

### DIFF
--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -45,7 +45,7 @@ The `set` function _merges_ state.
 ```js
 import { create } from 'zustand'
 
-const useStore = create((set) => ({
+const useBear = create((set) => ({
   bears: 0,
   increasePopulation: () => set((state) => ({ bears: state.bears + 1 })),
   removeAllBears: () => set({ bears: 0 }),
@@ -61,12 +61,12 @@ will re-render when that state changes.
 
 ```jsx
 function BearCounter() {
-  const bears = useStore((state) => state.bears)
+  const bears = useBear((state) => state.bears)
   return <h1>{bears} bears around here...</h1>
 }
 
 function Controls() {
-  const increasePopulation = useStore((state) => state.increasePopulation)
+  const increasePopulation = useBear((state) => state.increasePopulation)
   return <button onClick={increasePopulation}>one up</button>
 }
 ```


### PR DESCRIPTION
Zustand already provides a `useStore` hook, and reusing the same name for a custom hook could lead to confusion if someone accidentally imports the wrong one. To avoid this, I’ve renamed the custom hook to `useBear`. The name is short, memorable, and aligns with Zustand’s playful style.

## Related Bug Reports or Discussions

Fixes #

## Summary

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
