### PR TITLE
feat: add browser condition to package.json exports for better React Native Web and Metro support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
         "types": "./index.d.ts",
         "default": "./index.js"
       },
+      "browser": {
+        "types": "./index.d.ts",
+        "default": "./index.js"
+      },
       "import": {
         "types": "./esm/index.d.mts",
         "default": "./esm/index.mjs"
@@ -42,6 +46,10 @@
     },
     "./*": {
       "react-native": {
+        "types": "./*.d.ts",
+        "default": "./*.js"
+      },
+    "browser": {
         "types": "./*.d.ts",
         "default": "./*.js"
       },


### PR DESCRIPTION
## Summary

This PR adds the `browser` condition to the package.json `exports` field to improve compatibility with React Native Web and Metro bundler (React Native 0.79+).

## Motivation

With React Native 0.79, Metro introduced stable support for package.json `exports` field resolution as part of the modern ES Module resolution strategy. This change ensures that Zustand properly resolves modules in React Native Web environments and Metro bundler configurations.

According to the [React Native 0.79 release notes](https://reactnative.dev/blog/2025/04/08/react-native-0.79#metro-faster-startup-and-package-exports-support), Metro now matches different conditions depending on the platform:
- For native platforms: `react-native` condition
- For web exports: `browser` condition  
- For server exports: `node`, `react-server`, and `workerd` conditions

## Changes

- Added `browser` condition to the root export (`.`) in package.json
- Added `browser` condition to the wildcard export (`./*`) in package.json
- Both conditions point to the CommonJS builds (`./index.js` and `./*.js`)

## Benefits

1. **Better React Native Web support**: Ensures proper module resolution when using Zustand in React Native Web projects
2. **Metro 0.82+ compatibility**: Aligns with Metro's ES Module resolution strategy
3. **Expo compatibility**: Works seamlessly with Expo's Metro configuration (SDK 53+)
4. **Consistent behavior**: Maintains the same module resolution as the existing `react-native` condition

## Testing

The changes maintain backward compatibility as they only add a new condition without modifying existing ones. The resolution order in the exports map ensures that:
1. `react-native` condition is checked first for React Native environments
2. `browser` condition is checked for web/browser environments
3. `import` condition is checked for ESM imports
4. `default` condition is the fallback

## References

- [React Native 0.79 - Metro package exports support](https://reactnative.dev/blog/2025/04/08/react-native-0.79#metro-faster-startup-and-package-exports-support)
- [Expo Metro Config - ES Module resolution](https://docs.expo.dev/versions/v53.0.0/config/metro/#es-module-resolution)
- [Node.js package.json exports documentation](https://nodejs.org/api/packages.html#conditional-exports)

## Checklist

- [x] Follows conventional commit spec
- [x] Changes are focused and minimal
- [x] Maintains backward compatibility
- [x] No breaking changes