### PR TITLE
feat:   filter out specific actions from being sent to Redux DevTools

### DIFF
--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -2520,3 +2520,53 @@ describe('cleanup', () => {
     )
   })
 })
+
+describe('actionBlacklist', () => {
+  it('should filter out blacklisted actions (array)', async () => {
+    const options = {
+      name: 'test-filter',
+      enabled: true,
+      actionBlacklist: ['secretAction'],
+    }
+    const api = createStore(
+      devtools(() => ({ count: 0 }), options),
+    )
+
+    // Normal action should be sent
+    api.setState({ count: 1 }, false, 'increment')
+    const [connection] = getNamedConnectionApis(options.name)
+    expect(connection.send).toHaveBeenLastCalledWith(
+      { type: 'increment' },
+      { count: 1 },
+    )
+
+    // Blacklisted action should be filtered out
+    connection.send.mockClear()
+    api.setState({ count: 2 }, false, 'secretAction')
+    expect(connection.send).not.toHaveBeenCalled()
+  })
+
+  it('should filter out blacklisted actions (function)', async () => {
+    const options = {
+      name: 'test-func-filter',
+      enabled: true,
+      actionBlacklist: (action: { type: string }) => action.type.startsWith('private'),
+    }
+    const api = createStore(
+      devtools(() => ({ count: 0 }), options),
+    )
+
+    // Normal action should be sent
+    api.setState({ count: 1 }, false, 'publicAction')
+    const [connection] = getNamedConnectionApis(options.name)
+    expect(connection.send).toHaveBeenLastCalledWith(
+      { type: 'publicAction' },
+      { count: 1 },
+    )
+
+    // Blacklisted action should be filtered out
+    connection.send.mockClear()
+    api.setState({ count: 2 }, false, 'privateAction')
+    expect(connection.send).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
# Action Blacklist Feature for Zustand DevTools Middleware

This enhancement adds support for filtering out specific actions from being sent to Redux DevTools, similar to the `actionBlacklist` feature in Redux DevTools.

## Overview

The `actionBlacklist` option allows you to prevent certain actions from appearing in the Redux DevTools extension. This is useful for:

- Hiding sensitive or private actions
- Reducing noise in the DevTools timeline
- Improving debugging experience by focusing on relevant actions
- Filtering out frequently called actions that are not important for debugging

## Usage

### Array-based Filtering

Filter out specific action types by providing an array of action names:

```typescript
import { create } from 'zustand'
import { devtools } from 'zustand/middleware'

const useStore = create()(
  devtools(
    (set) => ({
      count: 0,
      increment: () =>
        set((state) => ({ count: state.count + 1 }), false, 'increment'),
      secretAction: () =>
        set((state) => ({ count: state.count * 2 }), false, 'secretAction'),
    }),
    {
      name: 'counter-store',
      actionBlacklist: ['secretAction'], // This action won't appear in DevTools
    },
  ),
)
```

### Function-based Filtering

For more complex filtering logic, provide a function that receives the action object and returns a boolean:

```typescript
const useStore = create()(
  devtools(
    (set) => ({
      // ... your state and actions
    }),
    {
      name: 'user-store',
      actionBlacklist: (action) => {
        // Filter out password-related and debug actions
        return (
          action.type.toLowerCase().includes('password') ||
          action.type.startsWith('DEBUG_')
        )
      },
    },
  ),
)
```

### With Store Option

The filtering also works when using the `store` option for multiple stores:

```typescript
const useOrderStore = create()(
  devtools(
    (set) => ({
      // ... your state and actions
    }),
    {
      name: 'app-stores',
      store: 'orders',
      actionBlacklist: ['internalCleanup'], // Filtered before store prefix is added
    },
  ),
)
```

## API Reference

### `actionBlacklist`

**Type:** `string[] | ((action: { type: string }) => boolean)`

**Description:** Defines which actions should be filtered out from Redux DevTools.

#### Array Format

- **Type:** `string[]`
- **Description:** Array of action type strings to filter out
- **Example:** `['reset', 'secretAction', 'internalUpdate']`

#### Function Format

- **Type:** `(action: { type: string }) => boolean`
- **Parameters:**
  - `action`: The action object containing at least a `type` property
- **Returns:** `true` if the action should be filtered out, `false` otherwise
- **Example:** `(action) => action.type.startsWith('private')`

## Behavior

- Actions are filtered **before** any store prefixes are added (when using the `store` option)
- Filtered actions still execute normally; they just don't appear in DevTools
- Anonymous actions can be filtered by targeting the `anonymousActionType` or the default 'anonymous' type
- The filtering is applied only to the DevTools output, not to the actual state changes

## Examples

### Filtering Debug Actions

```typescript
actionBlacklist: (action) => action.type.startsWith('DEBUG_')
```

### Filtering Sensitive Operations

```typescript
actionBlacklist: ['updatePassword', 'setApiKey', 'loginWithToken']
```

### Filtering High-Frequency Actions

```typescript
actionBlacklist: (action) =>
  ['mousemove', 'scroll', 'typing'].includes(action.type)
```

### Case-Insensitive Filtering

```typescript
actionBlacklist: (action) => action.type.toLowerCase().includes('secret')
```

## Compatibility

This feature is compatible with all existing DevTools middleware options and works with:

- Single stores and multiple stores
- Named and unnamed connections
- Store prefixes
- All existing DevTools features (time travel, action replay, etc.)

The filtered actions are excluded only from the DevTools display but continue to function normally in your application.
