### PR TITLE
docs: update map and set guide 

### DIFF
--- a/docs/guides/maps-and-sets-usage.md
+++ b/docs/guides/maps-and-sets-usage.md
@@ -12,7 +12,7 @@ Map and Set are mutable data structures. To use them in Zustand, you must create
 ### Reading a Map
 
 ```typescript
-const foo = useSomeStore(state => state.foo);
+const foo = useSomeStore((state) => state.foo)
 ```
 
 ### Updating a Map
@@ -22,26 +22,26 @@ Always create a new Map instance:
 ```ts
 // Update single entry
 set((state) => ({
-  foo: new Map(state.foo).set(key, value)
-}));
+  foo: new Map(state.foo).set(key, value),
+}))
 
 // Delete entry
 set((state) => {
-  const next = new Map(state.foo);
-  next.delete(key);
-  return { foo: next };
-});
+  const next = new Map(state.foo)
+  next.delete(key)
+  return { foo: next }
+})
 
 // Update multiple entries
 set((state) => {
-  const next = new Map(state.foo);
-  next.set('key1', 'value1');
-  next.set('key2', 'value2');
-  return { foo: next };
-});
+  const next = new Map(state.foo)
+  next.set('key1', 'value1')
+  next.set('key2', 'value2')
+  return { foo: next }
+})
 
 // Clear
-set({ foo: new Map() });
+set({ foo: new Map() })
 ```
 
 ## Set
@@ -49,7 +49,7 @@ set({ foo: new Map() });
 ### Reading a Set
 
 ```ts
-const bar = useSomeStore(state => state.bar);
+const bar = useSomeStore((state) => state.bar)
 ```
 
 ### Updating a Set
@@ -59,25 +59,25 @@ Always create a new Set instance:
 ```ts
 // Add item
 set((state) => ({
-  bar: new Set(state.bar).add(item)
-}));
+  bar: new Set(state.bar).add(item),
+}))
 
 // Delete item
 set((state) => {
-  const next = new Set(state.bar);
-  next.delete(item);
-  return { bar: next };
-});
+  const next = new Set(state.bar)
+  next.delete(item)
+  return { bar: next }
+})
 
 // Toggle item
 set((state) => {
-  const next = new Set(state.bar);
-  next.has(item) ? next.delete(item) : next.add(item);
-  return { bar: next };
-});
+  const next = new Set(state.bar)
+  next.has(item) ? next.delete(item) : next.add(item)
+  return { bar: next }
+})
 
 // Clear
-set({ bar: new Set() });
+set({ bar: new Set() })
 ```
 
 ## Why New Instances?
@@ -87,14 +87,14 @@ Zustand detects changes by comparing references. Mutating a Map or Set doesn't c
 ```ts
 // ❌ Wrong - same reference, no re-render
 set((state) => {
-  state.foo.set(key, value);
-  return { foo: state.foo };
-});
+  state.foo.set(key, value)
+  return { foo: state.foo }
+})
 
-// ✅ Correct - new reference, triggers re-render  
+// ✅ Correct - new reference, triggers re-render
 set((state) => ({
-  foo: new Map(state.foo).set(key, value)
-}));
+  foo: new Map(state.foo).set(key, value),
+}))
 ```
 
 ## Pitfall: Type Hints for Empty Collections


### PR DESCRIPTION
## Summary

Expanded the documentation on using Maps and Sets in Zustand, including guidelines for reading and updating these data structures. Added examples for creating new instances and explained the importance of reference changes for state updates.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
