### PR TITLE
fix: updated the "Advanced Typescript Guide" link throughout the documentation

### DIFF
--- a/docs/guides/slices-pattern.md
+++ b/docs/guides/slices-pattern.md
@@ -117,4 +117,4 @@ Please keep in mind you should only apply middlewares in the combined store. App
 
 ## Usage with TypeScript
 
-A detailed guide on how to use the slice pattern in Zustand with TypeScript can be found [here](./typescript.md#slices-pattern).
+A detailed guide on how to use the slice pattern in Zustand with TypeScript can be found [here](./advanced-typescript.md#slices-pattern).

--- a/docs/integrations/immer-middleware.md
+++ b/docs/integrations/immer-middleware.md
@@ -19,7 +19,7 @@ npm install immer
 
 ## Usage
 
-(Notice the extra parentheses after the type parameter as mentioned in the [Typescript Guide](../guides/typescript.md)).
+(Notice the extra parentheses after the type parameter as mentioned in the [Advanced Typescript Guide](../guides/advanced-typescript.md)).
 
 Updating simple states
 

--- a/docs/migrations/migrating-to-v4.md
+++ b/docs/migrations/migrating-to-v4.md
@@ -10,7 +10,7 @@ this guide applies.
 Otherwise, no migration is required.
 
 Also, it's recommended to first read
-the new [TypeScript Guide](../guides/typescript.md),
+the new [TypeScript Guide](../guides/advanced-typescript.md),
 so that the migration is easier to understand.
 
 In addition to this migration guide,
@@ -87,8 +87,8 @@ If you are using `StateCreator`,
 you are likely authoring a middleware
 or using the "slices" pattern.
 For that check the
-[Authoring middlewares and advanced usage](../guides/typescript.md#authoring-middlewares-and-advanced-usage)
-and [Common recipes](../guides/typescript.md#common-recipes)
+[Authoring middlewares and advanced usage](../guides/advanced-typescript.md#authoring-middlewares-and-advanced-usage)
+and [Common recipes](../guides/advanced-typescript.md#common-recipes)
 sections of the TypeScript Guide.
 
 ## `PartialState`


### PR DESCRIPTION
## Related Bug Reports or Discussions
https://github.com/pmndrs/zustand/discussions/3293

## Summary
Updated the "Advanced Typescript Guide" link throughout the documentation after the last renaming of the TS guides.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
