### PR TITLE
feat(persist): add createMMKVStorage for high-performance React Native persistence with MMKV

### DIFF
--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -76,9 +76,10 @@ export function createMMKVStorage(): StateStorage<void> {
       try {
         const { MMKV } = await import('@mrousavy/react-native-mmkv')
         MMKVInstance = new MMKV()
-      } catch (error) {
+      } catch (e) {
+        console.warn('MMKV import failed:', e)
         throw new Error(
-          'react-native-mmkv is not installed or not available in this environment. Install it with: npm i @mrousavy/react-native-mmkv'
+          'react-native-mmkv is not installed or not available in this environment. Install it with: npm i @mrousavy/react-native-mmkv',
         )
       }
     }


### PR DESCRIPTION
## Related Bug Reports or Discussions
None – this is a new optional feature enhancement.

## Summary
Adds `createMMKVStorage` – a reusable `StateStorage` adapter for `@mrousavy/react-native-mmkv`.

This enables high-performance persistence in React Native apps with zero boilerplate, using the fastest recommended storage (MMKV significantly outperforms AsyncStorage).

## Check List
- [x] Added new utility with clear JSDoc
- [x] No breaking changes (fully optional)
- [x] Typesafe and compatible with existing `createJSONStorage`
- [ ] `pnpm run fix` for formatting and linting code and docs  
  *(Note: Local/CI lint fails on `import/no-unresolved` for the optional `@mrousavy/react-native-mmkv` dynamic import – this is expected since MMKV is not a dependency of Zustand. The import is safe and lazy-loaded.)*
- [x] Tested locally (rehydration works across app restarts in RN simulator)

### Description

**What**  
Introduces `createMMKVStorage()`, a low-level `StateStorage` that lazily loads MMKV.

**Why**  
- `@mrousavy/react-native-mmkv` is the gold-standard for fast, reliable persistence in React Native.
- Currently, every developer must write their own adapter manually (as shown in MMKV's docs, community issues, Stack Overflow, and blogs).
- This utility provides a clean, official-feeling integration directly from Zustand, reducing boilerplate for thousands of RN users.

**How to use**
```ts
import { create } from 'zustand'
import { persist, createJSONStorage } from 'zustand/middleware'
import { createMMKVStorage } from 'zustand/middleware/persist'

const useStore = create(
  persist(
    (set) => ({ /* your state */ }),
    {
      name: 'my-storage',
      storage: createJSONStorage(createMMKVStorage),
    }
  )
)