### PR TITLE
docs(CONTRIBUTING): fix 'npm install' to 'pnpm install'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ If you would like to contribute by fixing an open issue or developing a new feat
 
 ##### Core
 
-1. Run `npm install` to install dependencies.
+1. Run `pnpm install` to install dependencies.
 2. Create failing tests for your fix or new feature in the [`tests`](./tests/) folder.
 3. Implement your changes.
 4. Run `pnpm run build` to build the library. _(Pro-tip: `pnpm run build-watch` runs the build in watch mode)_


### PR DESCRIPTION
## Related Bug Reports or Discussions

N/A

## Summary

Fix incorrect package manager command from `npm install` to `pnpm install` in CONTRIBUTING.md

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs