### PR TITLE
docs(contributing): remove build-watch tip from contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ If you would like to contribute by fixing an open issue or developing a new feat
 1. Run `pnpm install` to install dependencies.
 2. Create failing tests for your fix or new feature in the [`tests`](./tests/) folder.
 3. Implement your changes.
-4. Run `pnpm run build` to build the library. _(Pro-tip: `pnpm run build-watch` runs the build in watch mode)_
+4. Run `pnpm run build` to build the library.
 5. Run the tests by running `pnpm run test` and ensure that they pass.
 6. You can use `pnpm link` to sym-link this package and test it locally on your own project. Alternatively, you may use CodeSandbox CI's canary releases to test the changes in your own project. (requires a PR to be created first)
 7. Follow step 4 and onwards from the [General](#General) guide above to bring it to the finish line.


### PR DESCRIPTION
## Related Bug Reports or Discussions

N/A

## Summary
I have removed the reference to a non-existent `build-watch` script in `CONTRIBUTING.md`.

- **Issue:** The guide suggests using `pnpm run build-watch`, but this script is not defined in Zustand's `package.json`.
- **Cause:** It seems this line was accidentally included during the merge of PR (#2986), which aligned the contribution guides of `jotai` and `zustand`.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
