### PR TITLE
chore(package.json): add 'build-watch' script for watch mode builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ If you would like to contribute by fixing an open issue or developing a new feat
 1. Run `pnpm install` to install dependencies.
 2. Create failing tests for your fix or new feature in the [`tests`](./tests/) folder.
 3. Implement your changes.
-4. Run `pnpm run build` to build the library.
+4. Run `pnpm run build` to build the library. _(Pro-tip: `pnpm run build-watch` runs the build in watch mode)_
 5. Run the tests by running `pnpm run test` and ensure that they pass.
 6. You can use `pnpm link` to sym-link this package and test it locally on your own project. Alternatively, you may use CodeSandbox CI's canary releases to test the changes in your own project. (requires a PR to be created first)
 7. Follow step 4 and onwards from the [General](#General) guide above to bring it to the finish line.

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "scripts": {
     "prebuild": "shx rm -rf dist",
     "build": "pnpm run prebuild && pnpm run \"/^build:.*/\" && pnpm run postbuild",
+    "build-watch": "pnpm run \"/^build:.*/\" --watch",
     "build:base": "rollup -c",
     "build:vanilla": "rollup -c --config-vanilla",
     "build:react": "rollup -c --config-react",


### PR DESCRIPTION
## Related Bug Reports or Discussions

N/A

## Summary

- Add `build-watch` script to `package.json` for watch mode builds
- Restore Pro-tip in `CONTRIBUTING.md` referencing the script

This reverts the docs change from #3355 and adds the actual script that was missing.

References:
- [jotai](https://github.com/pmndrs/jotai/blob/main/package.json#L73)
- [valtio](https://github.com/pmndrs/valtio/blob/main/package.json#L65)

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs