### PR TITLE
chore(eslint.config): use 'globalIgnores' for ignored directories

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,6 @@
 import eslint from '@eslint/js'
 import vitest from '@vitest/eslint-plugin'
-import { defineConfig } from 'eslint/config'
+import { defineConfig, globalIgnores } from 'eslint/config'
 import importPlugin from 'eslint-plugin-import'
 import jestDom from 'eslint-plugin-jest-dom'
 import react from 'eslint-plugin-react'
@@ -9,9 +9,7 @@ import testingLibrary from 'eslint-plugin-testing-library'
 import tseslint from 'typescript-eslint'
 
 export default defineConfig(
-  {
-    ignores: ['dist/', 'examples/', 'website/', 'coverage/'],
-  },
+  globalIgnores(['dist/', 'examples/', 'website/', 'coverage/']),
   eslint.configs.recommended,
   importPlugin.flatConfigs.recommended,
   tseslint.configs.recommended,


### PR DESCRIPTION
## Related Bug Reports or Discussions

https://github.com/pmndrs/jotai/pull/3218#issuecomment-3768223131

## Summary

Use `globalIgnores` helper function instead of object with `ignores` property for cleaner configuration.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs