### PR TITLE
docs: remove stray Russian comment in beginner-typescript guide

### DIFF
--- a/docs/guides/beginner-typescript.md
+++ b/docs/guides/beginner-typescript.md
@@ -270,7 +270,7 @@ export const useBearStore = create<BearState>()(
   persist(
     (set) => ({
       bears: 0,
-      increase: () => set((s) => ({ bears: s.bears + 1 })), // <-- тип явно
+      increase: () => set((s) => ({ bears: s.bears + 1 })),
     }),
     { name: 'bear-storage' }, // localStorage key
   ),


### PR DESCRIPTION
## Related Bug Reports or Discussions

N/A

## Summary

Fix a stray Russian comment (`<-- тип явно`) to English in the beginner TypeScript guide.

## Check List

- [v] `pnpm run fix` for formatting and linting code and docs
