### PR TITLE
Fix persist middleware crash with Node 25 invalid storage stub

### DIFF
--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -39,6 +39,11 @@ export function createJSONStorage<S, R = unknown>(
     // prevent error if the storage is not defined (e.g. when server side rendering a page)
     return
   }
+  if (!storage || typeof storage.setItem !== 'function') {
+    throw new Error(
+      'Storage does not have setItem method. Please provide a valid storage object.',
+    )
+  }
   const persistStorage: PersistStorage<S, R> = {
     getItem: (name) => {
       const parse = (str: string | null) => {

--- a/tests/persistSync.test.tsx
+++ b/tests/persistSync.test.tsx
@@ -757,4 +757,31 @@ describe('persist middleware with sync configuration', () => {
     expect(useBoundStore.persist.hasHydrated()).toBe(true)
     expect(setItem).toBeCalledTimes(0)
   })
+
+  it('throws error when storage does not have setItem method (Node 25 stub)', () => {
+    // Node 25 with --localstorage-file flag without a path creates a bare {} object
+    const invalidStorage = {} as any
+
+    expect(() => {
+      createJSONStorage(() => invalidStorage)
+    }).toThrow('Storage does not have setItem method')
+  })
+
+  it('throws error when storage is null', () => {
+    expect(() => {
+      createJSONStorage(() => null as any)
+    }).toThrow('Storage does not have setItem method')
+  })
+
+  it('throws error when storage has setItem but it is not a function', () => {
+    const invalidStorage = {
+      getItem: () => null,
+      setItem: 'not-a-function',
+      removeItem: () => {},
+    } as any
+
+    expect(() => {
+      createJSONStorage(() => invalidStorage)
+    }).toThrow('Storage does not have setItem method')
+  })
 })


### PR DESCRIPTION
## Summary

Fixes persist middleware crash when Node.js 25 creates an invalid localStorage stub (bare `{}` object) with the `--localstorage-file` flag without a path.

## Problem

Node.js 25 with `--localstorage-file` flag (without path) creates a bare `{}` object at `globalThis.localStorage`. VS Code's debugger sets this flag automatically, affecting many users who upgrade to Node 25.

The persist middleware's `createJSONStorage()` function trusts `localStorage` blindly and calls `.setItem()`, causing an immediate crash:

```
TypeError: storage.setItem is not a function
```

This is documented in discussion #3266.

## Solution

Added validation in `createJSONStorage()` to check if the storage object has a `setItem` method before attempting to use it. If validation fails, throws a clear error message:

```
Storage does not have setItem method. Please provide a valid storage object.
```

This follows the maintainer's suggestion from the discussion thread.

## Test Plan

Added three test cases to verify the fix:
1. Node 25 stub (bare `{}` object) - throws error
2. `null` storage - throws error  
3. Storage with non-function `setItem` - throws error

All tests pass:
```
pnpm vitest run tests/persistSync.test.tsx
✓ tests/persistSync.test.tsx (25 tests) 6ms
```

## Changes

- `src/middleware/persist.ts`: Added storage validation in `createJSONStorage()`
- `tests/persistSync.test.tsx`: Added 3 test cases for invalid storage scenarios

Fixes #3266