### PR TITLE
docs: fix Next.js guide import extension

### DIFF
--- a/docs/guides/nextjs.md
+++ b/docs/guides/nextjs.md
@@ -166,7 +166,7 @@ both architectures should be the same with slight differences related to each ar
 
 ```tsx
 // src/components/pages/home-page.tsx
-import { useCounterStore } from '@/providers/counter-store-provider.ts'
+import { useCounterStore } from '@/providers/counter-store-provider.tsx'
 
 export const HomePage = () => {
   const { count, incrementCount, decrementCount } = useCounterStore(


### PR DESCRIPTION
## Related Bug Reports or Discussions
Fixes #

## Summary
Fix a copy/paste issue in the Next.js (Pages Router) guide where the example imports `counter-store-provider.ts` even though the provider file defined in the guide is `counter-store-provider.tsx`. This updates the import to `.tsx` to match the documented file name and avoid confusion.

## Check List
- [ ] pnpm run fix for formatting and linting code and docs