### PR TITLE
fix: persist documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ const useFishStore = create(
 )
 ```
 
-[See the full documentation for this middleware.](./docs/integrations/persisting-store-data.md)
+[See the full documentation for this middleware.](./docs/reference/integrations/persisting-store-data.md)
 
 ## Immer middleware
 


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

Link to persist documentation led to a 404 page.

## Summary

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
