### PR TITLE
fix(readme) : comparison documentaion link

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,4 +509,4 @@ Some users may want to extend Zustand's feature set which can be done using thir
 
 ## Comparison with other libraries
 
-- [Difference between zustand and other state management libraries for React](https://zustand.docs.pmnd.rs/getting-started/comparison)
+- [Difference between zustand and other state management libraries for React](https://zustand.docs.pmnd.rs/learn/getting-started/comparison)


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #3404 

Link to "Difference between zustand and other state management libraries for React" documentation led to a 404 page.

## Summary

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
