### PR TITLE
docs: fix broken links in beginner TypeScript guide

### DIFF
--- a/docs/learn/guides/beginner-typescript.md
+++ b/docs/learn/guides/beginner-typescript.md
@@ -145,7 +145,7 @@ Sometimes you need more than one property. Returning an object from the selector
 However, directly destructuring properties from that object can cause unnecessary re-renders.
 To avoid this, it’s recommended to wrap the selector with `useShallow`, which prevents re-renders when the selected values remain shallowly equal.
 This is more efficient than subscribing to the whole store. TypeScript ensures you can’t accidentally misspell `bears` or `food`.
-See the [API documentation](https://zustand.docs.pmnd.rs/hooks/use-shallow) for more details on `useShallow`.
+See the [API documentation](../../reference/hooks/use-shallow.md) for more details on `useShallow`.
 
 ```tsx
 import { create } from 'zustand'
@@ -209,7 +209,7 @@ function TotalFood() {
 This middleware separates initial state and actions, making the code cleaner.
 TS automatically infers types from the state and actions, no interface needed.
 This is different from JS, where type safety is missing. It’s a very popular style in TypeScript projects.
-See the [API documentation](https://zustand.docs.pmnd.rs/middlewares/combine) for more details.
+See the [API documentation](../../reference/middlewares/combine.md) for more details.
 
 ```ts
 import { create } from 'zustand'
@@ -232,7 +232,7 @@ export const useBearStore = create<BearState>()(
 
 This middleware connects Zustand to Redux DevTools. You can inspect changes, time-travel, and debug state.
 It’s extremely useful in development. TS ensures your actions and state remain type-checked even here.
-See the [API documentation](https://zustand.docs.pmnd.rs/middlewares/devtools) for more details.
+See the [API documentation](../../reference/middlewares/devtools.md) for more details.
 
 ```ts
 import { create } from 'zustand'
@@ -255,7 +255,7 @@ export const useBearStore = create<BearState>()(
 
 This middleware keeps your store in `localStorage` (or another storage). This means your bears survive a page refresh.
 Great for apps where persistence matters. In TS, the state type stays consistent, so no runtime surprises.
-See the [API documentation](https://zustand.docs.pmnd.rs/middlewares/persist) for more details.
+See the [API documentation](../../reference/middlewares/persist.md) for more details.
 
 ```ts
 import { create } from 'zustand'
@@ -309,7 +309,7 @@ export const useBearStore = create<BearState>()((set) => ({
 
 Variant of `create` with equality built-in. Useful if you always want custom equality checks.
 Not common, but shows Zustand’s flexibility. TS still keeps full type inference.
-See the [API documentation](https://zustand.docs.pmnd.rs/apis/create-with-equality-fn) for more details.
+See the [API documentation](../../reference/apis/create-with-equality-fn.md) for more details.
 
 ```ts
 import { createWithEqualityFn } from 'zustand/traditional'


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary
Fix broken documentation links in docs/learn/guides/beginner-typescript.md by replacing dead zustand.docs.pmnd.rs URLs (404) with repo-relative reference docs:

• useShallow → docs/reference/hooks/use-shallow.md
• combine → docs/reference/middlewares/combine.md
• devtools → docs/reference/middlewares/devtools.md
• persist → docs/reference/middlewares/persist.md
• createWithEqualityFn → docs/reference/apis/create-with-equality-fn.md
Repo-relative links work reliably on GitHub and don’t depend on external site routing.

## Check List

- [ ] `pnpm run fix` for formatting and linting code and docs
