### PR TITLE
fix(persist): handle storage write errors gracefully

### DIFF
--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -230,13 +230,27 @@ const persistImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
 
   api.setState = (state, replace) => {
     savedSetState(state, replace as any)
-    return setItem()
+    try {
+      return setItem()
+    } catch (e) {
+      console.warn(
+        `[zustand persist middleware] Unable to update item '${options.name}', the given storage threw an error.`,
+        e,
+      )
+    }
   }
 
   const configResult = config(
     (...args) => {
       set(...(args as Parameters<typeof set>))
-      return setItem()
+      try {
+        return setItem()
+      } catch (e) {
+        console.warn(
+          `[zustand persist middleware] Unable to update item '${options.name}', the given storage threw an error.`,
+          e,
+        )
+      }
     },
     get,
     api,

--- a/tests/persistSync.test.tsx
+++ b/tests/persistSync.test.tsx
@@ -757,4 +757,78 @@ describe('persist middleware with sync configuration', () => {
     expect(useBoundStore.persist.hasHydrated()).toBe(true)
     expect(setItem).toBeCalledTimes(0)
   })
+
+  it('should not throw when setItem throws on api.setState', () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const error = new DOMException(
+      'The quota has been exceeded.',
+      'QuotaExceededError',
+    )
+    const storage = {
+      getItem: () => null,
+      setItem: () => {
+        throw error
+      },
+      removeItem: () => {},
+    }
+
+    const useBoundStore = create(
+      persist(() => ({ count: 0 }), {
+        name: 'test-storage',
+        storage: createJSONStorage(() => storage),
+      }),
+    )
+
+    expect(() => {
+      useBoundStore.setState({ count: 1 })
+    }).not.toThrow()
+    expect(useBoundStore.getState().count).toBe(1)
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Unable to update item'),
+      error,
+    )
+    consoleWarn.mockRestore()
+  })
+
+  it('should not throw when setItem throws on set from initializer', () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let shouldThrow = false
+    const error = new DOMException(
+      'The quota has been exceeded.',
+      'QuotaExceededError',
+    )
+    const storage = {
+      getItem: () => null,
+      setItem: () => {
+        if (shouldThrow) {
+          throw error
+        }
+      },
+      removeItem: () => {},
+    }
+
+    const useBoundStore = create<{ count: number; inc: () => void }>()(
+      persist(
+        (set) => ({
+          count: 0,
+          inc: () => set((s) => ({ count: s.count + 1 })),
+        }),
+        {
+          name: 'test-storage',
+          storage: createJSONStorage(() => storage),
+        },
+      ),
+    )
+
+    shouldThrow = true
+    expect(() => {
+      useBoundStore.getState().inc()
+    }).not.toThrow()
+    expect(useBoundStore.getState().count).toBe(1)
+    expect(consoleWarn).toHaveBeenCalledWith(
+      expect.stringContaining('Unable to update item'),
+      error,
+    )
+    consoleWarn.mockRestore()
+  })
 })


### PR DESCRIPTION
## Summary

When `storage.setItem` throws synchronously (e.g., `QuotaExceededError` when localStorage quota is exceeded, or `SecurityError` in private browsing mode), the error propagates from `setState` even though the in-memory state was already successfully updated via the underlying `set` call.

This causes the application to crash on state updates when persistent storage is unavailable or full, despite the store state being correctly updated in memory.

## Changes

- Wrapped `setItem()` calls in `api.setState` and the initializer's `set` wrapper with try-catch
- Logs a warning on storage write failure, consistent with the existing pattern used when storage is initially unavailable (line 211-214)
- The `setItem()` call during hydration is intentionally left unwrapped, as errors there are already handled by the existing `.catch()` block and reported via `onRehydrateStorage`

## Tests

- Added test for `QuotaExceededError` handling when calling `api.setState`
- Added test for `QuotaExceededError` handling when calling `set` from the store initializer
- Verified in-memory state is correctly updated despite storage failure
- All 198 tests pass, TypeScript check clean, lint clean