### PR TITLE
refactor(devtools): remove duplicate module augmentation

### DIFF
--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -98,13 +98,6 @@ type Devtools = <
   devtoolsOptions?: DevtoolsOptions,
 ) => StateCreator<T, Mps, [['zustand/devtools', never], ...Mcs]>
 
-declare module '../vanilla' {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface StoreMutators<S, A> {
-    'zustand/devtools': WithDevtools<S>
-  }
-}
-
 type DevtoolsImpl = <T>(
   storeInitializer: StateCreator<T, [], []>,
   devtoolsOptions?: DevtoolsOptions,


### PR DESCRIPTION
## Summary

The `StoreMutators` module augmentation for `'zustand/devtools'` is declared twice in `src/middleware/devtools.ts` — once at line 15 and an identical copy at line 101. Both declare the exact same interface member. Removed the duplicate.

## Changes

- Removed the second `declare module '../vanilla'` block (was identical to the first)
- No behavioral change — TypeScript merges duplicate `declare module` blocks, so this is purely a cleanup

## Verification

- All 196 tests pass
- TypeScript check clean
- ESLint clean