### PR TITLE
test: add runtime tests for combine and redux middleware

### DIFF
--- a/tests/combine.test.tsx
+++ b/tests/combine.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest'
+import { create } from 'zustand'
+import { combine } from 'zustand/middleware'
+import { createStore } from 'zustand/vanilla'
+
+describe('combine middleware', () => {
+  it('should merge initial state with creator return value', () => {
+    const useBoundStore = create(
+      combine({ count: 0, text: 'hello' }, (set) => ({
+        inc: () => set((state) => ({ count: state.count + 1 })),
+        setText: (text: string) => set({ text }),
+      })),
+    )
+
+    expect(useBoundStore.getState().count).toBe(0)
+    expect(useBoundStore.getState().text).toBe('hello')
+    expect(typeof useBoundStore.getState().inc).toBe('function')
+    expect(typeof useBoundStore.getState().setText).toBe('function')
+  })
+
+  it('should update state via actions', () => {
+    const useBoundStore = create(
+      combine({ count: 0 }, (set) => ({
+        inc: () => set((state) => ({ count: state.count + 1 })),
+      })),
+    )
+
+    useBoundStore.getState().inc()
+    expect(useBoundStore.getState().count).toBe(1)
+
+    useBoundStore.getState().inc()
+    expect(useBoundStore.getState().count).toBe(2)
+  })
+
+  it('should work with setState directly', () => {
+    const useBoundStore = create(
+      combine({ count: 0 }, () => ({
+        doubled: () => 0,
+      })),
+    )
+
+    useBoundStore.setState({ count: 5 })
+    expect(useBoundStore.getState().count).toBe(5)
+  })
+
+  it('should work with vanilla createStore', () => {
+    const store = createStore(
+      combine({ value: 'initial' }, (set) => ({
+        update: (value: string) => set({ value }),
+      })),
+    )
+
+    expect(store.getState().value).toBe('initial')
+    store.getState().update('updated')
+    expect(store.getState().value).toBe('updated')
+  })
+
+  it('should provide get and api to creator', () => {
+    const store = createStore(
+      combine({ count: 0 }, (set, get, api) => ({
+        inc: () => set({ count: get().count + 1 }),
+        reset: () => api.setState({ count: 0 }, true),
+      })),
+    )
+
+    store.getState().inc()
+    store.getState().inc()
+    expect(store.getState().count).toBe(2)
+
+    store.getState().reset()
+    expect(store.getState().count).toBe(0)
+  })
+
+  it('should notify subscribers on state change', () => {
+    const spy = vi.fn()
+    const store = createStore(
+      combine({ count: 0 }, (set) => ({
+        inc: () => set((state) => ({ count: state.count + 1 })),
+      })),
+    )
+
+    store.subscribe(spy)
+    store.getState().inc()
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should preserve initial state in getInitialState', () => {
+    const store = createStore(
+      combine({ count: 0 }, (set) => ({
+        inc: () => set((state) => ({ count: state.count + 1 })),
+      })),
+    )
+
+    store.getState().inc()
+    expect(store.getState().count).toBe(1)
+    expect(store.getInitialState().count).toBe(0)
+  })
+})

--- a/tests/redux.test.tsx
+++ b/tests/redux.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from 'vitest'
+import { create } from 'zustand'
+import { redux } from 'zustand/middleware'
+import { createStore } from 'zustand/vanilla'
+
+type CounterState = { count: number }
+type CounterAction =
+  | { type: 'INCREMENT' }
+  | { type: 'DECREMENT' }
+  | { type: 'SET'; payload: number }
+
+const counterReducer = (
+  state: CounterState,
+  action: CounterAction,
+): CounterState => {
+  switch (action.type) {
+    case 'INCREMENT':
+      return { count: state.count + 1 }
+    case 'DECREMENT':
+      return { count: state.count - 1 }
+    case 'SET':
+      return { count: action.payload }
+    default:
+      return state
+  }
+}
+
+describe('redux middleware', () => {
+  it('should create store with initial state', () => {
+    const store = createStore(redux(counterReducer, { count: 0 }))
+
+    expect(store.getState().count).toBe(0)
+    expect(typeof store.getState().dispatch).toBe('function')
+  })
+
+  it('should dispatch actions and update state', () => {
+    const store = createStore(redux(counterReducer, { count: 0 }))
+
+    store.getState().dispatch({ type: 'INCREMENT' })
+    expect(store.getState().count).toBe(1)
+
+    store.getState().dispatch({ type: 'INCREMENT' })
+    expect(store.getState().count).toBe(2)
+
+    store.getState().dispatch({ type: 'DECREMENT' })
+    expect(store.getState().count).toBe(1)
+  })
+
+  it('should handle actions with payload', () => {
+    const store = createStore(redux(counterReducer, { count: 0 }))
+
+    store.getState().dispatch({ type: 'SET', payload: 42 })
+    expect(store.getState().count).toBe(42)
+  })
+
+  it('should return the dispatched action', () => {
+    const store = createStore(redux(counterReducer, { count: 0 }))
+
+    const action = store.getState().dispatch({ type: 'INCREMENT' })
+    expect(action).toEqual({ type: 'INCREMENT' })
+  })
+
+  it('should notify subscribers on dispatch', () => {
+    const spy = vi.fn()
+    const store = createStore(redux(counterReducer, { count: 0 }))
+
+    store.subscribe(spy)
+    store.getState().dispatch({ type: 'INCREMENT' })
+
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not notify subscribers when state is unchanged', () => {
+    const spy = vi.fn()
+    const reducer = (state: { count: number }) => state
+    const store = createStore(
+      redux(reducer as typeof counterReducer, { count: 0 }),
+    )
+
+    store.subscribe(spy)
+    store.getState().dispatch({ type: 'INCREMENT' })
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('should work with create (React)', () => {
+    const useBoundStore = create(redux(counterReducer, { count: 0 }))
+
+    expect(useBoundStore.getState().count).toBe(0)
+
+    useBoundStore.getState().dispatch({ type: 'INCREMENT' })
+    expect(useBoundStore.getState().count).toBe(1)
+  })
+
+  it('should also expose dispatch on the api object', () => {
+    const store = createStore(redux(counterReducer, { count: 0 }))
+
+    ;(store as any).dispatch({ type: 'SET', payload: 10 })
+    expect(store.getState().count).toBe(10)
+  })
+
+  it('should set dispatchFromDevtools flag', () => {
+    const store = createStore(redux(counterReducer, { count: 0 }))
+
+    expect((store as any).dispatchFromDevtools).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Both `combine` and `redux` middleware only had type-level tests in `middlewareTypes.test.tsx`. This adds dedicated runtime test suites covering actual behavior.

## Tests Added

### `combine` middleware (7 tests)
- Merges initial state with creator return value
- Updates state via actions
- Works with `setState` directly
- Works with vanilla `createStore`
- Provides `get` and `api` to creator function
- Notifies subscribers on state change
- Preserves initial state in `getInitialState`

### `redux` middleware (9 tests)
- Creates store with initial state and dispatch
- Dispatches actions and updates state correctly
- Handles actions with payload
- Returns the dispatched action
- Notifies subscribers on dispatch
- Does not notify when state reference is unchanged
- Works with `create` (React API)
- Exposes dispatch on the API object
- Sets `dispatchFromDevtools` flag

## Verification

- All 212 tests pass (196 existing + 16 new)
- TypeScript check clean
- ESLint clean
- Prettier clean