### PR TITLE
docs: fill in troubleshooting sections for middleware and hooks

### DIFF
--- a/docs/reference/hooks/use-shallow.md
+++ b/docs/reference/hooks/use-shallow.md
@@ -266,4 +266,23 @@ re-renders when necessary, which improves overall performance.
 
 ## Troubleshooting
 
-TBD
+### My component still re-renders even with `useShallow`
+
+`useShallow` performs a shallow comparison, meaning it checks if each top-level property is the
+same by reference. If a property is a new object or array on every render (e.g., created inside
+the selector), `useShallow` will still detect a change:
+
+```tsx
+// Still re-renders because `filter` creates a new array each time
+const items = useStore(
+  useShallow((state) => state.items.filter((item) => item.active)),
+)
+```
+
+Consider memoizing the derived value or restructuring your state so that the selected slice is
+stable across renders.
+
+### `useShallow` vs custom equality function
+
+`useShallow` is a convenience wrapper for common cases. If you need deeper comparison or custom
+logic, use `createWithEqualityFn` with your own equality function instead.

--- a/docs/reference/hooks/use-store-with-equality-fn.md
+++ b/docs/reference/hooks/use-store-with-equality-fn.md
@@ -956,4 +956,27 @@ export default function App() {
 
 ## Troubleshooting
 
-TBD
+### My equality function is never called
+
+Make sure you are passing both a selector and an equality function. The equality function is the
+second argument to the hook:
+
+```tsx
+import { shallow } from 'zustand/shallow'
+
+// Wrong - shallow is not being used as an equality function
+const state = useStoreWithEqualityFn(shallow)
+
+// Correct - selector first, then equality function
+const { x, y } = useStoreWithEqualityFn(
+  (state) => ({ x: state.x, y: state.y }),
+  shallow,
+)
+```
+
+### Component re-renders even though the equality function returns `true`
+
+The equality function only compares the selected slice, not the entire state. If your selector
+returns a new reference each time (e.g., a new object or array), make sure your equality function
+handles this correctly. `shallow` from `zustand/shallow` works for flat objects; for deeper
+structures, you may need a deep equality function.

--- a/docs/reference/hooks/use-store.md
+++ b/docs/reference/hooks/use-store.md
@@ -920,4 +920,20 @@ export default function App() {
 
 ## Troubleshooting
 
-TBD
+### My component re-renders too often
+
+If your component re-renders on every state change, you may be selecting the entire state object.
+Use a selector to pick only the values your component needs:
+
+```tsx
+// Wrong - re-renders on ANY state change
+const state = useStore()
+
+// Correct - only re-renders when `count` changes
+const count = useStore((state) => state.count)
+```
+
+### I'm getting "could not find zustand store" error
+
+This error occurs when `useStore` is used outside of a store provider context. Make sure your
+component is wrapped in the corresponding provider that supplies the store via React context.

--- a/docs/reference/middlewares/combine.md
+++ b/docs/reference/middlewares/combine.md
@@ -100,4 +100,31 @@ Here's the `html` code
 
 ## Troubleshooting
 
-TBD
+### TypeScript can't infer the state type inside actions
+
+When using `combine`, TypeScript infers the state type from the initial state object. If you
+reference properties that don't exist on the initial state inside your creator function, you'll
+get a type error. Make sure all state properties are declared in the initial state:
+
+```ts
+// Wrong - `text` is not in initial state, so `get().text` is a type error
+const useStore = create(
+  combine({ count: 0 }, (set, get) => ({
+    text: 'hello',
+    getText: () => get().text, // Error: Property 'text' does not exist
+  })),
+)
+
+// Correct - all state properties in initial state
+const useStore = create(
+  combine({ count: 0, text: 'hello' }, (set, get) => ({
+    getText: () => get().text,
+  })),
+)
+```
+
+### Actions overwrite initial state properties
+
+If the creator function returns an object with the same keys as the initial state, the creator's
+values take precedence because `combine` uses `Object.assign`. Keep state and actions separate
+to avoid unintentional overrides.

--- a/docs/reference/middlewares/immer.md
+++ b/docs/reference/middlewares/immer.md
@@ -234,4 +234,46 @@ personStore.subscribe(render)
 
 ## Troubleshooting
 
-TBD
+### I'm getting "An immer producer returned a new value AND modified its draft" error
+
+This happens when you both mutate the draft and return a new value in the same updater. With the
+`immer` middleware, you should either mutate the draft directly or return a new state, but not both:
+
+```ts
+// Wrong - mutates AND returns
+set((state) => {
+  state.count++
+  return { count: state.count } // Don't do this
+})
+
+// Correct - just mutate
+set((state) => {
+  state.count++
+})
+
+// Also correct - just return (same as without immer)
+set((state) => ({ count: state.count + 1 }))
+```
+
+### TypeScript errors when using immer with other middleware
+
+When combining `immer` with other middleware like `devtools` or `persist`, the order matters. The
+`immer` middleware should be the innermost (closest to the state creator):
+
+```ts
+// Correct order
+const useStore = create<MyState>()(
+  devtools(
+    persist(
+      immer((set) => ({
+        count: 0,
+        inc: () =>
+          set((state) => {
+            state.count++
+          }),
+      })),
+      { name: 'my-store' },
+    ),
+  ),
+)
+```

--- a/docs/reference/middlewares/persist.md
+++ b/docs/reference/middlewares/persist.md
@@ -983,4 +983,60 @@ Here's the `html` code
 
 ## Troubleshooting
 
-TBD
+### My state is not persisted on page reload
+
+Make sure you are passing a unique `name` option to `persist`. If two stores share the same name,
+they will overwrite each other's data.
+
+Also verify that your storage is available. In some environments (e.g., server-side rendering or
+private browsing mode), `localStorage` may not be accessible. You can check by wrapping the storage
+in a try-catch with `createJSONStorage`:
+
+```ts
+const useStore = create(
+  persist((set) => ({ count: 0 }), {
+    name: 'my-store',
+    storage: createJSONStorage(() => localStorage),
+  }),
+)
+```
+
+### My components flash with old state before showing persisted state
+
+This happens because hydration is asynchronous. The store initializes with default state, then
+rehydrates from storage. Use `onRehydrateStorage` to track when hydration is complete, or use
+`skipHydration` to manually control the timing:
+
+```ts
+const useStore = create(
+  persist((set) => ({ count: 0 }), {
+    name: 'my-store',
+    skipHydration: true,
+  }),
+)
+
+// Later, when ready:
+useStore.persist.rehydrate()
+```
+
+### State migration fails silently after changing the store shape
+
+If you change your store's shape, you need to increment the `version` and provide a `migrate`
+function. Without it, the old persisted state will be merged with the new initial state, which may
+produce unexpected results:
+
+```ts
+const useStore = create(
+  persist((set) => ({ count: 0, name: 'default' }), {
+    name: 'my-store',
+    version: 1,
+    migrate: (persistedState, version) => {
+      if (version === 0) {
+        // migrate from v0 to v1
+        return { ...(persistedState as any), name: 'default' }
+      }
+      return persistedState as any
+    },
+  }),
+)
+```

--- a/docs/reference/middlewares/redux.md
+++ b/docs/reference/middlewares/redux.md
@@ -167,4 +167,39 @@ Here's the `html` code
 
 ## Troubleshooting
 
-TBD
+### Dispatched actions don't update the state
+
+Make sure your reducer returns a new state object for the matched action type. If the reducer
+returns the same reference, subscribers won't be notified:
+
+```ts
+// Wrong - mutates and returns the same reference
+const reducer = (state, action) => {
+  switch (action.type) {
+    case 'INCREMENT':
+      state.count++ // Mutating the original
+      return state // Same reference - no update!
+  }
+}
+
+// Correct - return a new object
+const reducer = (state, action) => {
+  switch (action.type) {
+    case 'INCREMENT':
+      return { ...state, count: state.count + 1 }
+  }
+  return state
+}
+```
+
+### Actions don't appear in Redux DevTools
+
+The `redux` middleware sets the `dispatchFromDevtools` flag automatically, but you need to
+wrap it with `devtools` middleware for actions to appear in Redux DevTools:
+
+```ts
+import { create } from 'zustand'
+import { devtools, redux } from 'zustand/middleware'
+
+const useStore = create(devtools(redux(reducer, initialState)))
+```

--- a/docs/reference/middlewares/subscribe-with-selector.md
+++ b/docs/reference/middlewares/subscribe-with-selector.md
@@ -116,4 +116,45 @@ Here's the `html` code
 
 ## Troubleshooting
 
-TBD
+### My listener fires on every state change even with a selector
+
+Make sure you are passing the selector as the first argument and the listener as the second. If
+you pass only one argument, it behaves like a regular `subscribe` without selector filtering:
+
+```ts
+// Wrong - no selector, fires on every change
+subscribe((state) => {
+  console.log(state.count) // Fires even if `count` didn't change
+})
+
+// Correct - selector + listener
+subscribe(
+  (state) => state.count,
+  (count) => {
+    console.log(count) // Only fires when `count` changes
+  },
+)
+```
+
+### Listener fires for changes that should be equal
+
+By default, `subscribeWithSelector` uses `Object.is` to compare the previous and next slice. If
+your selector returns a new object each time (e.g., `{ a, b }`), it will always be considered
+different. Use a custom `equalityFn` or select a primitive value:
+
+```ts
+// Fires every time because a new object is created each call
+subscribe(
+  (state) => ({ x: state.x, y: state.y }),
+  (pos) => console.log(pos),
+)
+
+// Fix: use shallow equality
+import { shallow } from 'zustand/shallow'
+
+subscribe(
+  (state) => ({ x: state.x, y: state.y }),
+  (pos) => console.log(pos),
+  { equalityFn: shallow },
+)
+```


### PR DESCRIPTION
## Summary

8 reference documentation pages had empty `## Troubleshooting` sections (just "TBD"). This fills them all with practical troubleshooting content covering common issues developers encounter.

## Pages Updated

### Middleware
- **persist** - state not persisted on reload, flash of old state, migration failures
- **immer** - "returned new value AND modified draft" error, middleware ordering with TypeScript
- **combine** - TypeScript inference issues, action key conflicts
- **redux** - dispatched actions not updating state, actions not appearing in DevTools
- **subscribeWithSelector** - listener fires on every change, selector returning new objects

### Hooks
- **useStore** - excessive re-renders, missing store provider
- **useShallow** - component still re-renders, useShallow vs custom equality
- **useStoreWithEqualityFn** - equality function not called, re-renders despite equality

Each section follows the existing troubleshooting format (seen in `create.md`, `devtools.md`) with a problem heading, explanation, and code example.