### PR TITLE
Update TypeScript guide links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ const useBearStore = create<BearState>()(
 )
 ```
 
-A more detailed TypeScript guide is [here](docs/guides/beginner-typescript.md) and [there](docs/guides/advanced-typescript.md).
+A more detailed TypeScript guide is [here](docs/learn/guides/beginner-typescript.md) and [there](docs/learn/guides/advanced-typescript.md).
 
 ## Best practices
 


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes README-Typescript link.

## Summary
This pull request updates the TypeScript guide links in the `README.md` to point to their new locations under the `docs/learn/guides/` directory. This ensures that users are directed to the correct documentation paths.

* Updated TypeScript guide links in `README.md` to reference `docs/learn/guides/beginner-typescript.md` and `docs/learn/guides/advanced-typescript.md` instead of the old paths.
