### PR TITLE
fix(devtools): support Firefox/Safari stack format in findCallerName

### DIFF
--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -166,7 +166,14 @@ const removeStoreFromTrackedConnections = (
   }
 }
 
-const findCallerName = (stack: string | undefined) => {
+// V8 (Chrome/Edge/Node): "at <name> (<source>)"
+const v8StackLineRe = /.+ (.+) .+/
+// SpiderMonkey (Firefox) / JavaScriptCore (Safari): "<name>@<source>"
+const geckoStackLineRe = /^([^@]+)@/
+
+export const findCallerName = (
+  stack: string | undefined,
+): string | undefined => {
   if (!stack) return undefined
   const traceLines = stack.split('\n')
   const apiSetStateLineIndex = traceLines.findIndex((traceLine) =>
@@ -174,7 +181,11 @@ const findCallerName = (stack: string | undefined) => {
   )
   if (apiSetStateLineIndex < 0) return undefined
   const callerLine = traceLines[apiSetStateLineIndex + 1]?.trim() || ''
-  return /.+ (.+) .+/.exec(callerLine)?.[1]
+  return (
+    v8StackLineRe.exec(callerLine)?.[1] ||
+    geckoStackLineRe.exec(callerLine)?.[1] ||
+    undefined
+  )
 }
 
 const devtoolsImpl: DevtoolsImpl =

--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -171,9 +171,7 @@ const v8StackLineRe = /.+ (.+) .+/
 // SpiderMonkey (Firefox) / JavaScriptCore (Safari): "<name>@<source>"
 const geckoStackLineRe = /^([^@]+)@/
 
-export const findCallerName = (
-  stack: string | undefined,
-): string | undefined => {
+function findCallerName(stack: string | undefined) {
   if (!stack) return undefined
   const traceLines = stack.split('\n')
   const apiSetStateLineIndex = traceLines.findIndex((traceLine) =>
@@ -183,8 +181,7 @@ export const findCallerName = (
   const callerLine = traceLines[apiSetStateLineIndex + 1]?.trim() || ''
   return (
     v8StackLineRe.exec(callerLine)?.[1] ||
-    geckoStackLineRe.exec(callerLine)?.[1] ||
-    undefined
+    geckoStackLineRe.exec(callerLine)?.[1]
   )
 }
 

--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -3,7 +3,6 @@ import type { Mock } from 'vitest'
 import { devtools, redux } from 'zustand/middleware'
 import { createStore } from 'zustand/vanilla'
 import type { StoreApi } from 'zustand/vanilla'
-import { findCallerName } from '../src/middleware/devtools'
 
 type TupleOfEqualLengthH<
   Arr extends unknown[],
@@ -229,7 +228,52 @@ describe('When state changes with automatic setter inferring...', () => {
       'api.setState@http://localhost/devtools.ts:200:5',
       'setCount@http://localhost/app.ts:10:5',
     ].join('\n')
-    expect(findCallerName(geckoStack)).toBe('setCount')
+
+    const OriginalError = Error
+    function ErrorWithGeckoStack(
+      ...args: ConstructorParameters<typeof OriginalError>
+    ) {
+      const err = new OriginalError(...args)
+      Object.defineProperty(err, 'stack', {
+        value: geckoStack,
+        configurable: true,
+        writable: true,
+      })
+      return err
+    }
+    ErrorWithGeckoStack.prototype = OriginalError.prototype
+    globalThis.Error = ErrorWithGeckoStack as unknown as typeof Error
+
+    try {
+      const options = {
+        name: 'testOptionsName',
+        enabled: true,
+      }
+
+      const api = createStore<{
+        count: number
+        setCount: (count: number) => void
+      }>()(
+        devtools(
+          (set) => ({
+            count: 0,
+            setCount: (newCount: number) => {
+              set({ count: newCount })
+            },
+          }),
+          options,
+        ),
+      )
+
+      api.getState().setCount(10)
+      const [connection] = getNamedConnectionApis(options.name)
+      expect(connection.send).toHaveBeenLastCalledWith(
+        { type: 'setCount' },
+        { count: 10, setCount: expect.any(Function) },
+      )
+    } finally {
+      globalThis.Error = OriginalError
+    }
   })
 })
 

--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -3,6 +3,7 @@ import type { Mock } from 'vitest'
 import { devtools, redux } from 'zustand/middleware'
 import { createStore } from 'zustand/vanilla'
 import type { StoreApi } from 'zustand/vanilla'
+import { findCallerName } from '../src/middleware/devtools'
 
 type TupleOfEqualLengthH<
   Arr extends unknown[],
@@ -221,6 +222,14 @@ describe('When state changes with automatic setter inferring...', () => {
       { type: expect.stringMatching(/^(Object\.setCount|anonymous)$/) },
       { count: 10, setCount: expect.any(Function) },
     )
+  })
+
+  it('infers caller name from Firefox/SpiderMonkey stack format', () => {
+    const geckoStack = [
+      'api.setState@http://localhost/devtools.ts:200:5',
+      'setCount@http://localhost/app.ts:10:5',
+    ].join('\n')
+    expect(findCallerName(geckoStack)).toBe('setCount')
   })
 })
 


### PR DESCRIPTION
## Related Bug Reports or Discussions

no existing issue — built on top of #2987

## Summary

PR #2987 added `findCallerName` to infer action types from the call stack, but the regex `/.+ (.+) .+/` only matches V8-style frames (`at funcName (source:line:col)`). 
SpiderMonkey (Firefox) and JavaScriptCore (Safari) use a different format — `funcName@source:line:col` — with no spaces, so the regex silently falls back to "anonymous".
See [MDN: Error.stack](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack#description) for the format differences across engines.

Changes:
- Add a second regex for the Gecko/JSC stack format (`/^([^@]+)@/`)
- Extract both regexes to module-level constants so they are compiled once, not on every `setState` call
- Export `findCallerName` and add a unit test covering the Firefox stack format

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
