### PR TITLE
fix(shallow): preserve URLSearchParams duplicates

### DIFF
--- a/src/vanilla/shallow.ts
+++ b/src/vanilla/shallow.ts
@@ -26,6 +26,30 @@ const compareEntries = (
   return true
 }
 
+const compareURLSearchParams = (
+  valueA: URLSearchParams,
+  valueB: URLSearchParams,
+) => {
+  const sortEntries = ([keyA, valueA]: [string, string], [keyB, valueB]: [
+    string,
+    string,
+  ]) => (keyA === keyB ? valueA.localeCompare(valueB) : keyA.localeCompare(keyB))
+  const entriesA = Array.from(valueA.entries()).sort(sortEntries)
+  const entriesB = Array.from(valueB.entries()).sort(sortEntries)
+  if (entriesA.length !== entriesB.length) {
+    return false
+  }
+  for (let index = 0; index < entriesA.length; index++) {
+    if (
+      entriesA[index][0] !== entriesB[index][0] ||
+      entriesA[index][1] !== entriesB[index][1]
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
 // Ordered iterables
 const compareIterables = (
   valueA: Iterable<unknown>,
@@ -61,6 +85,9 @@ export function shallow<T>(valueA: T, valueB: T): boolean {
     return false
   }
   if (isIterable(valueA) && isIterable(valueB)) {
+    if (valueA instanceof URLSearchParams && valueB instanceof URLSearchParams) {
+      return compareURLSearchParams(valueA, valueB)
+    }
     if (hasIterableEntries(valueA) && hasIterableEntries(valueB)) {
       return compareEntries(valueA, valueB)
     }

--- a/tests/vanilla/shallow.test.tsx
+++ b/tests/vanilla/shallow.test.tsx
@@ -164,6 +164,15 @@ describe('shallow', () => {
         new URLSearchParams({ a: 'a', b: 'b' }),
       ),
     ).toBe(true)
+    expect(
+      shallow(
+        new URLSearchParams('a=1&a=2&b=3'),
+        new URLSearchParams('b=3&a=2&a=1'),
+      ),
+    ).toBe(true)
+    expect(
+      shallow(new URLSearchParams('a=1&a=2'), new URLSearchParams('a=2')),
+    ).toBe(false)
   })
 
   it('should work with nested arrays (#2794)', () => {


### PR DESCRIPTION

**Repo:** pmndrs/zustand (⭐ 51000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +36/-0

## What
This change fixes `shallow` so `URLSearchParams` values with duplicate keys are compared without collapsing repeated entries. It adds a dedicated `URLSearchParams` comparison path and covers it with regression tests for both reordered equivalent duplicates and mismatched duplicate-key multiplicity.

## Why
The previous implementation treated `URLSearchParams` like a `Map`, which drops repeated keys and could incorrectly report `new URLSearchParams('a=1&a=2')` as shallow-equal to `new URLSearchParams('a=2')`. That is a real false positive for consumers using query params as selector inputs or derived state.

## Testing
Dependencies are not installed in this clone, so the Vitest suite was not run here. I verified the core failure mode and the normalization logic with lightweight `node` checks, and the added regression test documents the expected runtime behavior for the repo test suite.

## Risk
Low / The change is narrowly scoped to `URLSearchParams` handling and leaves existing array, map, set, and object comparison paths unchanged.
