### PR TITLE
 fix(docs): correct react-dom test-utils import path

### DIFF
--- a/docs/learn/guides/testing.md
+++ b/docs/learn/guides/testing.md
@@ -26,7 +26,7 @@ See these resources for test runner configuration instructions:
 **We recommend using [React Testing Library (RTL)](https://testing-library.com/docs/react-testing-library/intro)
 to test out React components that connect to Zustand**. RTL is a simple and complete React DOM
 testing utility that encourages good testing practices. It uses ReactDOM's `render` function and
-`act` from `react-dom/tests-utils`. Furthermore, [Native Testing Library (RNTL)](https://testing-library.com/docs/react-native-testing-library/intro)
+`act` from `react-dom/test-utils`. Furthermore, [Native Testing Library (RNTL)](https://testing-library.com/docs/react-native-testing-library/intro)
 is the alternative to RTL to test out React Native components. The [Testing Library](https://testing-library.com/)
 family of tools also includes adapters for many other popular frameworks.
 


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

Fixed import path in `docs/learn/guides/testing.md`: `react-dom/tests-utils` → `react-dom/test-utils`

The correct npm export is `react-dom/test-utils` (singular "test").
The path `react-dom/tests-utils` with an extra 's' does not exist and would cause an import error for anyone copy-pasting the example.

The References section at the bottom of the same file already uses the correct path `react-dom/test-utils`.

 ## Check List

 - [x] `pnpm run fix` for formatting and linting code and docs