### PR TITLE
docs: explain persist + SSR hydration trap in the SSR guide

### DIFF
--- a/docs/learn/guides/ssr-and-hydration.md
+++ b/docs/learn/guides/ssr-and-hydration.md
@@ -196,3 +196,92 @@ node server.js
 > React recovers from some hydration errors, but you must fix them like other bugs. In the best case, they’ll lead to a slowdown; in the worst case, event handlers can get attached to the wrong elements.
 
 You can read more about the caveats and pitfalls here: [hydrateRoot](https://react.dev/reference/react-dom/client/hydrateRoot)
+
+## Using `persist` middleware under SSR
+
+A common source of hydration errors when using Zustand with an SSR framework
+(Next.js, Remix, etc.) is the [`persist`](../../reference/middlewares/persist.md)
+middleware. By default `persist` rehydrates from storage **during the first
+client render**, so the component reads the stored value immediately — before
+hydration finishes. The server rendered with the store's initial state, so the
+two renders disagree and React aborts hydration, falling back to a full client
+render of the subtree.
+
+### Symptom
+
+In production you see the minified
+[React error #418 / #423 / #425](https://react.dev/errors/418) in the console
+("Text content did not match. Server: ... Client: ..."). In dev the message
+points at any component that reads a persisted store value — a header that
+shows the cart item count, a layout that renders `locale`, etc.
+
+### Fix: `skipHydration` + manual rehydrate
+
+Tell `persist` not to rehydrate automatically, so the first client render
+matches the server's default state. Then call `persist.rehydrate()` from a
+`useEffect` after mount. The re-render triggered by the rehydrate happens
+after hydration completes, so it's a normal state update, not a mismatch.
+
+```ts
+// src/stores/cart-store.ts
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+type CartState = {
+  items: string[]
+  add: (item: string) => void
+}
+
+export const useCartStore = create<CartState>()(
+  persist(
+    (set) => ({
+      items: [],
+      add: (item) => set((state) => ({ items: [...state.items, item] })),
+    }),
+    {
+      name: 'cart',
+      skipHydration: true,
+    },
+  ),
+)
+```
+
+```tsx
+// src/components/store-rehydrator.tsx
+'use client'
+
+import { useEffect } from 'react'
+import { useCartStore } from '@/stores/cart-store'
+
+// Render once near the top of the tree (e.g. inside the App Router root
+// layout's body). Rehydrate runs after mount, so the initial client render
+// still matches the server HTML.
+export function StoreRehydrator() {
+  useEffect(() => {
+    useCartStore.persist.rehydrate()
+  }, [])
+  return null
+}
+```
+
+If you persist several stores, rehydrate them all from the same effect so the
+initial defaults line up in a single pass:
+
+```tsx
+useEffect(() => {
+  useCartStore.persist.rehydrate()
+  useLanguageStore.persist.rehydrate()
+  useSettingsStore.persist.rehydrate()
+}, [])
+```
+
+### When not to use this pattern
+
+- If the persisted store is only read by client-only components (e.g. a
+  modal that mounts after user interaction), you don't need `skipHydration` —
+  the default behavior is fine.
+- If you render the persisted value behind a `useEffect`-driven "mounted"
+  guard, that also sidesteps the mismatch without touching `persist` config.
+
+`skipHydration` + `rehydrate()` is the right choice when the persisted store
+is read during the initial render of components that are SSR'd.


### PR DESCRIPTION
## Related Bug Reports or Discussions

None — this fills a documentation gap I hit while wiring `persist` in a Next.js app router project.

## Summary

The SSR and Hydration guide lists generic hydration pitfalls (`typeof window`, `matchMedia`, extra whitespace, etc.) but doesn't cover the most common zustand-specific one: `persist` auto-rehydrating from storage during the first client render, so components that read a persisted store disagree with the server's initial-state render and surface as minified React #418/#423/#425.

I added a dedicated section to `docs/learn/guides/ssr-and-hydration.md` covering:

- **Symptom** — what the production error looks like (minified #425 "Text content did not match"), with links to [react.dev/errors/418](https://react.dev/errors/418).
- **Fix** — the documented `skipHydration: true` + `useEffect`-driven `persist.rehydrate()` pattern, with a copy-pasteable `StoreRehydrator` component for app router root layouts.
- **Multi-store example** — rehydrating several persisted stores from the same effect so initial defaults line up in a single pass.
- **When not to use it** — client-only consumers and existing "mounted" guards are called out so readers don't reach for `skipHydration` unnecessarily.

`skipHydration` is already documented in `docs/reference/middlewares/persist.md`, but only as an API flag — this adds the why/when in the learn guide where SSR users actually land via search.

Docs-only change; no runtime or test changes. No overlap with [discussion #2740](https://github.com/pmndrs/zustand/discussions/2740) (which is scoped to per-request stores in the Next.js guide).

## Check List

- [x] `pnpm run test:format` passes (prettier clean on changed file and repo-wide)
- [x] Conventional commit type `docs:`
- [x] PR stays focused in scope (single file, single section added)