### PR TITLE
docs(persist): fix signature to require persistOptions

### DIFF
--- a/docs/reference/middlewares/persist.md
+++ b/docs/reference/middlewares/persist.md
@@ -31,7 +31,7 @@ const nextStateCreatorFn = persist(stateCreatorFn, persistOptions)
 ### Signature
 
 ```ts
-persist<T, U>(stateCreatorFn: StateCreator<T, [], []>, persistOptions?: PersistOptions<T, U>): StateCreator<T, [['zustand/persist', U]], []>
+persist<T, U>(stateCreatorFn: StateCreator<T, [], []>, persistOptions: PersistOptions<T, U>): StateCreator<T, [['zustand/persist', U]], []>
 ```
 
 ### Mutator
@@ -42,7 +42,7 @@ persist<T, U>(stateCreatorFn: StateCreator<T, [], []>, persistOptions?: PersistO
 
 ## Reference
 
-### `persist(stateCreatorFn)`
+### `persist(stateCreatorFn, persistOptions)`
 
 #### Parameters
 


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #
-
## Summary
The persist docs showed persistOptions as optional, which is misleading. In practice, persist needs a config object (including a required name), so calling it with only the state creator is not valid. 

This PR updates the TypeScript signature and reference heading in the persist docs to clearly show the correct usage: persist(stateCreatorFn, persistOptions).

Ref: 
https://github.com/pmndrs/zustand/blob/main/src/middleware/persist.ts#L377-L385
https://github.com/pmndrs/zustand/blob/main/src/middleware/persist.ts#L59-L73

## Check List
(docs only change)
- [ ] `pnpm run fix` for formatting and linting code and docs
