### PR TITLE
perf(shallow): avoid Map allocation for plain object comparison

### DIFF
--- a/src/shallow.ts
+++ b/src/shallow.ts
@@ -1,2 +1,2 @@
-export { shallow } from './vanilla/shallow.ts'
+export { comparePlainObjects, shallow } from './vanilla/shallow.ts'
 export { useShallow } from './react/shallow.ts'

--- a/src/vanilla/shallow.ts
+++ b/src/vanilla/shallow.ts
@@ -45,6 +45,20 @@ const compareIterables = (
   return !!nextA.done && !!nextB.done
 }
 
+export const comparePlainObjects = (
+  objA: Record<string, unknown>,
+  objB: Record<string, unknown>,
+): boolean => {
+  const keysA = Object.keys(objA)
+  if (keysA.length !== Object.keys(objB).length) return false
+  for (const key of keysA) {
+    if (!Object.hasOwn(objB, key) || !Object.is(objA[key], objB[key])) {
+      return false
+    }
+  }
+  return true
+}
+
 export function shallow<T>(valueA: T, valueB: T): boolean {
   if (Object.is(valueA, valueB)) {
     return true
@@ -66,9 +80,8 @@ export function shallow<T>(valueA: T, valueB: T): boolean {
     }
     return compareIterables(valueA, valueB)
   }
-  // assume plain objects
-  return compareEntries(
-    { entries: () => Object.entries(valueA) },
-    { entries: () => Object.entries(valueB) },
+  return comparePlainObjects(
+    valueA as Record<string, unknown>,
+    valueB as Record<string, unknown>,
   )
 }

--- a/tests/shallow.test.tsx
+++ b/tests/shallow.test.tsx
@@ -2,8 +2,42 @@ import { useState } from 'react'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { create } from 'zustand'
-import { shallow, useShallow } from 'zustand/shallow'
+import { comparePlainObjects, shallow, useShallow } from 'zustand/shallow'
 import { createWithEqualityFn } from 'zustand/traditional'
+
+describe('comparePlainObjects', () => {
+  it('returns true for equal objects', () => {
+    expect(comparePlainObjects({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(true)
+  })
+
+  it('returns false when a value differs', () => {
+    expect(comparePlainObjects({ a: 1, b: 2 }, { a: 1, b: 3 })).toBe(false)
+  })
+
+  it('returns false when key count differs', () => {
+    expect(comparePlainObjects({ a: 1 }, { a: 1, b: 2 })).toBe(false)
+  })
+
+  it('returns false when keys differ with same count', () => {
+    expect(comparePlainObjects({ a: 1 }, { b: 1 })).toBe(false)
+  })
+
+  it('distinguishes {x: undefined} from {}', () => {
+    expect(comparePlainObjects({ x: undefined }, {})).toBe(false)
+  })
+
+  it('returns true for empty objects', () => {
+    expect(comparePlainObjects({}, {})).toBe(true)
+  })
+
+  it('uses Object.is semantics (NaN === NaN)', () => {
+    expect(comparePlainObjects({ a: NaN }, { a: NaN })).toBe(true)
+  })
+
+  it('take into account Object.is egde case (+0 !== -0)', () => {
+    expect(comparePlainObjects({ a: +0 }, { a: -0 })).toBe(false)
+  })
+})
 
 describe('types', () => {
   it('works with useBoundStore and array selector (#1107)', () => {


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

This PR replaces compareEntries (Object.entries + new Map) with Object.keys +  direct property access for performance and less GC pressure. Since `shallow` is called on every state change per subscriber - for plain objects it was routing through `compareEntries`, which grows the heap

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
