### PR TITLE
fix(tests): change parameters for 'expect' in test

### DIFF
--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -1474,8 +1474,8 @@ describe('when create devtools was called multiple times with `name` option unde
         subscribers.forEach((sub) => sub(action))
 
         expect(api1.getState()).toStrictEqual(initialState1)
-        expect(api1.getState()).toStrictEqual(initialState1)
-        expect(api1.getState()).toStrictEqual(initialState1)
+        expect(api2.getState()).toStrictEqual(initialState2)
+        expect(api3.getState()).toStrictEqual(initialState3)
         expect(connection1.init).toHaveBeenLastCalledWith(initialState1)
         expect(connection2.init).toHaveBeenLastCalledWith(initialState2)
         expect(connection3.init).toHaveBeenLastCalledWith(initialState3)


### PR DESCRIPTION
## Related Bug Reports or Discussions

There are no related bug reports. It is just a small issue in one of the test files. It was detected while working with Claude Code  with Opus 4.6.

## Summary
The changed lines originally referred to aoi1 and initialstate1 (repeated test). This looks like a copy&paste issue. Change to api2 and api3

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs
