### PR TITLE
docs(react): fix useStore signature in reference docs

### DIFF
--- a/docs/reference/hooks/use-store.md
+++ b/docs/reference/hooks/use-store.md
@@ -26,7 +26,7 @@ const someState = useStore(store, selectorFn)
 ### Signature
 
 ```ts
-useStore<StoreApi<T>, U = T>(store: StoreApi<T>, selectorFn?: (state: T) => U) => UseBoundStore<StoreApi<T>>
+useStore<T, U = T>(store: StoreApi<T>, selectorFn?: (state: T) => U): U
 ```
 
 ## Reference


### PR DESCRIPTION
The signature in `docs/reference/hooks/use-store.md` doesn't match the actual `useStore` from `src/react.ts`. Three issues on one line:

1. `<StoreApi<T>, U = T>` — `StoreApi<T>` is a type instantiation, not a valid generic parameter name.
2. `) => UseBoundStore<...>` — the arrow `=>` should be `:` for a return type annotation.
3. `UseBoundStore<StoreApi<T>>` is what `create()` returns, not `useStore`. The actual return type is `T` (full state) or `U` (selected slice when a selector is passed).

This PR aligns the signature with the same pattern already used in the sister doc [`use-store-with-equality-fn.md`](https://github.com/pmndrs/zustand/blob/main/docs/reference/hooks/use-store-with-equality-fn.md):

```ts
useStoreWithEqualityFn<T, U = T>(store: StoreApi<T>, selectorFn: (state: T) => U, equalityFn?: (a: T, b: T) => boolean): U
```

### Diff

```diff
- useStore<StoreApi<T>, U = T>(store: StoreApi<T>, selectorFn?: (state: T) => U) => UseBoundStore<StoreApi<T>>
+ useStore<T, U = T>(store: StoreApi<T>, selectorFn?: (state: T) => U): U
```

Docs-only change — no changeset needed.
