### PR TITLE
docs(react): fix equalityFn type in useStoreWithEqualityFn signature

### DIFF
--- a/docs/reference/hooks/use-store-with-equality-fn.md
+++ b/docs/reference/hooks/use-store-with-equality-fn.md
@@ -32,7 +32,7 @@ const someState = useStoreWithEqualityFn(store, selectorFn, equalityFn)
 ### Signature
 
 ```ts
-useStoreWithEqualityFn<T, U = T>(store: StoreApi<T>, selectorFn: (state: T) => U, equalityFn?: (a: T, b: T) => boolean): U
+useStoreWithEqualityFn<T, U = T>(store: StoreApi<T>, selectorFn: (state: T) => U, equalityFn?: (a: U, b: U) => boolean): U
 ```
 
 ## Reference


### PR DESCRIPTION
Following [#3487](https://github.com/pmndrs/zustand/pull/3487) which fixed the `useStore` signature, the sister doc `use-store-with-equality-fn.md` (which I cited as reference for the correct pattern in #3487) has its own related signature bug.

The current signature types `equalityFn` against `T` (the full state), but the actual implementation in `src/react.ts` types it against `U` (the selected slice).

```ts
// src/react.ts
export function useStoreWithEqualityFn<S extends ReadonlyStoreApi<unknown>, U>(
  api: S,
  selector: (state: ExtractState<S>) => U,
  equalityFn?: (a: U, b: U) => boolean,    // compares the selected slice U
): U
```

The equality function compares the result of the selector (the slice), not the full store state. Using `(a: T, b: T)` is misleading for users who pass a selector returning a primitive or a different shape — the equality check operates on that returned value.

### Diff

```diff
- useStoreWithEqualityFn<T, U = T>(store: StoreApi<T>, selectorFn: (state: T) => U, equalityFn?: (a: T, b: T) => boolean): U
+ useStoreWithEqualityFn<T, U = T>(store: StoreApi<T>, selectorFn: (state: T) => U, equalityFn?: (a: U, b: U) => boolean): U
```

Docs-only change — no changeset needed.
