### PR TITLE
docs(react): match createWithEqualityFn reference to source signature

### DIFF
--- a/docs/reference/apis/create-with-equality-fn.md
+++ b/docs/reference/apis/create-with-equality-fn.md
@@ -14,7 +14,7 @@ over when components re-render, improving performance and responsiveness.
 > `use-sync-external-store` library due to `zustand/traditional` relies on `useSyncExternalStoreWithSelector`.
 
 ```js
-const useSomeStore = createWithEqualityFn(stateCreatorFn, equalityFn)
+const useSomeStore = createWithEqualityFn(stateCreatorFn, defaultEqualityFn)
 ```
 
 - [Types](#types)
@@ -35,18 +35,18 @@ const useSomeStore = createWithEqualityFn(stateCreatorFn, equalityFn)
 ### Signature
 
 ```ts
-createWithEqualityFn<T>()(stateCreatorFn: StateCreator<T, [], []>, equalityFn?: (a: T, b: T) => boolean): UseBoundStore<StoreApi<T>>
+createWithEqualityFn<T>()(stateCreatorFn: StateCreator<T, [], []>, defaultEqualityFn?: <U>(a: U, b: U) => boolean): UseBoundStore<StoreApi<T>>
 ```
 
 ## Reference
 
-### `createWithEqualityFn(stateCreatorFn)`
+### `createWithEqualityFn(stateCreatorFn, defaultEqualityFn)`
 
 #### Parameters
 
 - `stateCreatorFn`: A function that takes `set` function, `get` function and `store` as arguments.
   Usually, you will return an object with the methods you want to expose.
-- **optional** `equalityFn`: Defaults to `Object.is`. A function that lets you skip re-renders.
+- **optional** `defaultEqualityFn`: Defaults to `Object.is`. A function that lets you skip re-renders.
 
 #### Returns
 


### PR DESCRIPTION
Following [#3487](https://github.com/pmndrs/zustand/pull/3487) (`useStore` signature) and [#3489](https://github.com/pmndrs/zustand/pull/3489) (`useStoreWithEqualityFn` `equalityFn` type), this PR completes the equality-fn family by aligning the `createWithEqualityFn` reference with the source.

The current docs deviate from `src/traditional.ts` in three ways:

```ts
// src/traditional.ts
type CreateWithEqualityFn = {
  <T, Mos extends [StoreMutatorIdentifier, unknown][] = []>(
    initializer: StateCreator<T, [], Mos>,
    defaultEqualityFn?: <U>(a: U, b: U) => boolean,    // ← param name + polymorphic U
  ): UseBoundStoreWithEqualityFn<Mutate<StoreApi<T>, Mos>>
  ...
}
```

Three docs deviations:

1. **Parameter name** — docs called the second argument `equalityFn`, source names it `defaultEqualityFn`. The `default` qualifier is meaningful: it conveys that this is a fallback used when no per-call equality function is supplied to the bound store.
2. **Equality type** — docs typed it `(a: T, b: T) => boolean` (against the full state). The actual equality function is polymorphic (`<U>(a: U, b: U) => boolean`) because it compares whatever the caller's selector returns, not the full state.
3. **Reference heading** — `### \`createWithEqualityFn(stateCreatorFn)\`` omitted the second parameter; updated to `### \`createWithEqualityFn(stateCreatorFn, defaultEqualityFn)\`` for consistency with `useStoreWithEqualityFn`'s heading style.

### Diff

```diff
- const useSomeStore = createWithEqualityFn(stateCreatorFn, equalityFn)
+ const useSomeStore = createWithEqualityFn(stateCreatorFn, defaultEqualityFn)

- createWithEqualityFn<T>()(stateCreatorFn: StateCreator<T, [], []>, equalityFn?: (a: T, b: T) => boolean): UseBoundStore<StoreApi<T>>
+ createWithEqualityFn<T>()(stateCreatorFn: StateCreator<T, [], []>, defaultEqualityFn?: <U>(a: U, b: U) => boolean): UseBoundStore<StoreApi<T>>

- ### `createWithEqualityFn(stateCreatorFn)`
+ ### `createWithEqualityFn(stateCreatorFn, defaultEqualityFn)`

- - **optional** `equalityFn`: Defaults to `Object.is`. A function that lets you skip re-renders.
+ - **optional** `defaultEqualityFn`: Defaults to `Object.is`. A function that lets you skip re-renders.
```

4 lines changed in one file. Docs-only — no changeset needed.
