### PR TITLE
docs(react): add Action constraint to redux middleware signature

### DIFF
--- a/docs/reference/middlewares/redux.md
+++ b/docs/reference/middlewares/redux.md
@@ -25,7 +25,7 @@ const nextStateCreatorFn = redux(reducerFn, initialState)
 ### Signature
 
 ```ts
-redux<T, A>(reducerFn: (state: T, action: A) => T, initialState: T): StateCreator<T & { dispatch: (action: A) => A }, [['zustand/redux', A]], []>
+redux<T, A extends { type: string }>(reducerFn: (state: T, action: A) => T, initialState: T): StateCreator<T & { dispatch: (action: A) => A }, [['zustand/redux', A]], []>
 ```
 
 ### Mutator


### PR DESCRIPTION
The `redux` middleware signature in the reference docs is missing the `Action` constraint that's present in `src/middleware/redux.ts`:

```ts
// src/middleware/redux.ts
type Action = { type: string }

type Redux = <
  T,
  A extends Action,    // ← constraint
  Cms extends [StoreMutatorIdentifier, unknown][] = [],
>(
  reducer: (state: T, action: A) => T,
  initialState: T,
) => StateCreator<Write<T, ReduxState<A>>, Cms, [['zustand/redux', A]]>
```

Without the constraint, the docs allow `A` to be any type. With the constraint, TypeScript enforces that `action.type` is accessible — which is the whole point of the redux pattern (action discriminator).

### Diff

```diff
- redux<T, A>(reducerFn: (state: T, action: A) => T, initialState: T): StateCreator<T & { dispatch: (action: A) => A }, [['zustand/redux', A]], []>
+ redux<T, A extends { type: string }>(reducerFn: (state: T, action: A) => T, initialState: T): StateCreator<T & { dispatch: (action: A) => A }, [['zustand/redux', A]], []>
```

Single change: `<T, A>` → `<T, A extends { type: string }>`.

This is part of an ongoing pass over the reference docs to align signatures with source — see [#3487](https://github.com/pmndrs/zustand/pull/3487), [#3489](https://github.com/pmndrs/zustand/pull/3489), [#3491](https://github.com/pmndrs/zustand/pull/3491).

Docs-only — no changeset needed.
