### PR TITLE
docs(persist): add U=T default to persist middleware signature

### DIFF
--- a/docs/reference/middlewares/persist.md
+++ b/docs/reference/middlewares/persist.md
@@ -31,7 +31,7 @@ const nextStateCreatorFn = persist(stateCreatorFn, persistOptions)
 ### Signature
 
 ```ts
-persist<T, U>(stateCreatorFn: StateCreator<T, [], []>, persistOptions: PersistOptions<T, U>): StateCreator<T, [['zustand/persist', U]], []>
+persist<T, U = T>(stateCreatorFn: StateCreator<T, [], []>, persistOptions: PersistOptions<T, U>): StateCreator<T, [['zustand/persist', U]], []>
 ```
 
 ### Mutator


### PR DESCRIPTION
The `persist` middleware signature in the reference docs is missing the `U = T` default that's present in `src/middleware/persist.ts`:

```ts
// src/middleware/persist.ts
type Persist = <
  T,
  Mps extends [StoreMutatorIdentifier, unknown][] = [],
  Mcs extends [StoreMutatorIdentifier, unknown][] = [],
  U = T,    // ← default
>(
  initializer: StateCreator<T, [...Mps, ['zustand/persist', unknown]], Mcs>,
  options: PersistOptions<T, U>,
) => StateCreator<T, Mps, [['zustand/persist', U], ...Mcs]>
```

Without the default, callers must always specify both generics. With `U = T`, the default case (where the persisted shape matches the full state — i.e. no `partialize`) lets users write `persist<MyStore>(...)` instead of `persist<MyStore, MyStore>(...)`.

### Diff

```diff
- persist<T, U>(stateCreatorFn: StateCreator<T, [], []>, persistOptions: PersistOptions<T, U>): StateCreator<T, [['zustand/persist', U]], []>
+ persist<T, U = T>(stateCreatorFn: StateCreator<T, [], []>, persistOptions: PersistOptions<T, U>): StateCreator<T, [['zustand/persist', U]], []>
```

Single change: `<T, U>` → `<T, U = T>`.

Continuing the reference-docs alignment pass — see [#3487](https://github.com/pmndrs/zustand/pull/3487), [#3489](https://github.com/pmndrs/zustand/pull/3489), [#3491](https://github.com/pmndrs/zustand/pull/3491), [#3492](https://github.com/pmndrs/zustand/pull/3492).

Docs-only — no changeset needed.
