### PR TITLE
feat(persist): add equalityFn for redundant write dedupe

### DIFF
--- a/docs/reference/integrations/persisting-store-data.md
+++ b/docs/reference/integrations/persisting-store-data.md
@@ -146,6 +146,34 @@ export const useBoundStore = create(
 )
 ```
 
+### `equalityFn`
+
+> Type: `(previousState: Object, nextState: Object) => boolean`
+
+Use `equalityFn` to skip redundant storage writes when the partialized state hasn't changed.
+
+This is especially useful when your store mixes fast-changing transient state with a smaller
+persisted slice, or when your storage backend is asynchronous and expensive to write to.
+
+```ts
+export const useBoundStore = create(
+  persist(
+    (set) => ({
+      count: 0,
+      transient: 0,
+      increment: () => set((state) => ({ count: state.count + 1 })),
+      bumpTransient: () => set((state) => ({ transient: state.transient + 1 })),
+    }),
+    {
+      name: 'counter-storage',
+      partialize: (state) => ({ count: state.count }),
+      equalityFn: (previousState, nextState) =>
+        previousState.count === nextState.count,
+    },
+  ),
+)
+```
+
 ### `onRehydrateStorage`
 
 > Type: `(state: Object) => ((state?: Object, error?: Error) => void) | void`

--- a/docs/reference/middlewares/persist.md
+++ b/docs/reference/middlewares/persist.md
@@ -52,6 +52,8 @@ persist<T, U = T>(stateCreatorFn: StateCreator<T, [], []>, persistOptions: Persi
   - `name`: A unique name of the item for your store in the storage.
   - **optional** `storage`: Defaults to `createJSONStorage(() => localStorage)`.
   - **optional** `partialize`: A function to filter state fields before persisting it.
+  - **optional** `equalityFn`: A function to skip storage writes when the partialized state hasn't
+    changed.
   - **optional** `onRehydrateStorage`: A function or function returning a function that allows
     custom logic before and after state rehydration.
   - **optional** `version`: A version number for the persisted state. If the stored state version

--- a/src/middleware/persist.ts
+++ b/src/middleware/persist.ts
@@ -83,6 +83,14 @@ export interface PersistOptions<
    */
   partialize?: (state: S) => PersistedState
   /**
+   * Optional comparison function that lets you skip persisting unchanged values.
+   *
+   * The comparison receives the partialized state from the previous successful
+   * write and the current partialized state. When it returns `true`, the
+   * current write is skipped.
+   */
+  equalityFn?: (prevState: PersistedState, nextState: PersistedState) => boolean
+  /**
    * A function returning another (optional) function.
    * The main function will be called before the state rehydration.
    * The returned function will be called after the state rehydration or when an error occurred.
@@ -196,6 +204,11 @@ const persistImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
     }),
     ...baseOptions,
   }
+  type PersistedState = ReturnType<typeof options.partialize>
+  type PersistWriteCache = {
+    state: PersistedState
+    writeVersion: number
+  }
 
   let hasHydrated = false
   // Counter to track hydration versions and prevent race conditions
@@ -204,6 +217,18 @@ const persistImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
   const hydrationListeners = new Set<PersistListener<S>>()
   const finishHydrationListeners = new Set<PersistListener<S>>()
   let storage = options.storage
+  let persistedStateCache: PersistWriteCache | undefined
+  let pendingPersistedStateCache: PersistWriteCache | undefined
+  let scheduledWriteVersion = 0
+  let persistCacheVersion = 0
+  let lastSetItemResult: unknown
+
+  const clearPersistedStateCache = () => {
+    persistedStateCache = undefined
+    pendingPersistedStateCache = undefined
+    scheduledWriteVersion = 0
+    persistCacheVersion += 1
+  }
 
   if (!storage) {
     return config(
@@ -220,10 +245,85 @@ const persistImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
 
   const setItem = () => {
     const state = options.partialize({ ...get() })
-    return (storage as PersistStorage<S, unknown>).setItem(options.name, {
-      state,
-      version: options.version,
-    })
+    const equalityFn = options.equalityFn as
+      | ((prevState: PersistedState, nextState: PersistedState) => boolean)
+      | undefined
+
+    if (equalityFn) {
+      if (
+        pendingPersistedStateCache &&
+        equalityFn(pendingPersistedStateCache.state, state)
+      ) {
+        return lastSetItemResult
+      }
+      if (
+        !pendingPersistedStateCache &&
+        persistedStateCache &&
+        equalityFn(persistedStateCache.state, state)
+      ) {
+        return lastSetItemResult
+      }
+    }
+
+    const writeVersion = ++scheduledWriteVersion
+    const cacheVersion = persistCacheVersion
+    pendingPersistedStateCache = { state, writeVersion }
+
+    const setItemResult = (storage as PersistStorage<S, unknown>).setItem(
+      options.name,
+      {
+        state,
+        version: options.version,
+      },
+    )
+
+    const persistWriteCache = { state, writeVersion }
+    const finalizeWrite = () => {
+      if (cacheVersion !== persistCacheVersion) {
+        return
+      }
+      if (
+        !persistedStateCache ||
+        writeVersion > persistedStateCache.writeVersion
+      ) {
+        persistedStateCache = persistWriteCache
+      }
+      if (pendingPersistedStateCache?.writeVersion === writeVersion) {
+        pendingPersistedStateCache = undefined
+      }
+    }
+    const discardPendingWrite = () => {
+      if (cacheVersion !== persistCacheVersion) {
+        return
+      }
+      if (pendingPersistedStateCache?.writeVersion === writeVersion) {
+        pendingPersistedStateCache = undefined
+      }
+    }
+
+    if (
+      typeof setItemResult === 'object' &&
+      setItemResult !== null &&
+      'then' in setItemResult &&
+      typeof setItemResult.then === 'function'
+    ) {
+      const trackedSetItemResult = setItemResult.then(
+        (result: unknown) => {
+          finalizeWrite()
+          return result
+        },
+        (error: unknown) => {
+          discardPendingWrite()
+          throw error
+        },
+      )
+      lastSetItemResult = trackedSetItemResult
+      return trackedSetItemResult
+    }
+
+    finalizeWrite()
+    lastSetItemResult = setItemResult
+    return setItemResult
   }
 
   const savedSetState = api.setState
@@ -260,6 +360,7 @@ const persistImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
 
     // Increment version to invalidate any in-flight hydration
     const currentVersion = ++hydrationVersion
+    clearPersistedStateCache()
     hasHydrated = false
     hydrationListeners.forEach((cb) => cb(get() ?? configResult))
 
@@ -288,6 +389,10 @@ const persistImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
               `State loaded from storage couldn't be migrated since no migrate function was provided`,
             )
           } else {
+            persistedStateCache = {
+              state: deserializedStorageValue.state as PersistedState,
+              writeVersion: 0,
+            }
             return [false, deserializedStorageValue.state] as const
           }
         }
@@ -336,6 +441,13 @@ const persistImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
 
   ;(api as StoreApi<S> & StorePersist<StoreApi<S>, S, unknown>).persist = {
     setOptions: (newOptions) => {
+      const shouldResetPersistedStateCache =
+        'name' in newOptions ||
+        'storage' in newOptions ||
+        'partialize' in newOptions ||
+        'version' in newOptions ||
+        'equalityFn' in newOptions
+
       options = {
         ...options,
         ...newOptions,
@@ -344,8 +456,12 @@ const persistImpl: PersistImpl = (config, baseOptions) => (set, get, api) => {
       if (newOptions.storage) {
         storage = newOptions.storage
       }
+      if (shouldResetPersistedStateCache) {
+        clearPersistedStateCache()
+      }
     },
     clearStorage: () => {
+      clearPersistedStateCache()
       storage?.removeItem(options.name)
     },
     getOptions: () => options,

--- a/tests/persistAsync.test.tsx
+++ b/tests/persistAsync.test.tsx
@@ -608,6 +608,80 @@ describe('persist middleware with async configuration', () => {
     })
   })
 
+  it('can skip duplicate async writes for unchanged partialized values with equalityFn', async () => {
+    const { storage, setItemSpy } = createPersistantStore(null)
+
+    const useBoundStore = create(
+      persist(
+        () => ({
+          count: 0,
+          transient: 0,
+        }),
+        {
+          name: 'test-storage',
+          storage: createJSONStorage<{ count: number }>(() => storage),
+          partialize: (state) => ({ count: state.count }),
+          equalityFn: (prev: { count: number }, next: { count: number }) =>
+            prev.count === next.count,
+        },
+      ),
+    )
+
+    function Counter() {
+      const { count, transient } = useBoundStore()
+      return (
+        <div>
+          count: {count}, transient: {transient}
+        </div>
+      )
+    }
+
+    render(
+      <StrictMode>
+        <Counter />
+      </StrictMode>,
+    )
+
+    await act(() => vi.advanceTimersByTimeAsync(10))
+
+    act(() => {
+      useBoundStore.setState({ transient: 1 })
+      useBoundStore.setState({ transient: 2 })
+      useBoundStore.setState({ transient: 3 })
+    })
+
+    expect(setItemSpy).toHaveBeenCalledTimes(1)
+    expect(setItemSpy).toHaveBeenNthCalledWith(
+      1,
+      'test-storage',
+      JSON.stringify({
+        state: {
+          count: 0,
+        },
+        version: 0,
+      }),
+    )
+
+    await act(() => vi.advanceTimersByTimeAsync(10))
+
+    act(() => {
+      useBoundStore.setState({ count: 1 })
+      useBoundStore.setState({ transient: 4 })
+    })
+
+    expect(setItemSpy).toHaveBeenCalledTimes(2)
+    expect(setItemSpy).toHaveBeenNthCalledWith(
+      2,
+      'test-storage',
+      JSON.stringify({
+        state: {
+          count: 1,
+        },
+        version: 0,
+      }),
+    )
+  })
+
   it('can manually rehydrate through the api', async () => {
     const storageValue = '{"state":{"count":1},"version":0}'
 

--- a/tests/persistSync.test.tsx
+++ b/tests/persistSync.test.tsx
@@ -421,6 +421,106 @@ describe('persist middleware with sync configuration', () => {
     )
   })
 
+  it('can skip persisting unchanged partialized values with equalityFn', () => {
+    const setItemSpy = vi.fn()
+
+    const storage = {
+      getItem: () => null,
+      setItem: setItemSpy,
+      removeItem: () => {},
+    }
+
+    const useBoundStore = create(
+      persist(
+        () => ({
+          count: 0,
+          transient: 0,
+        }),
+        {
+          name: 'test-storage',
+          storage: createJSONStorage<{ count: number }>(() => storage),
+          partialize: (state) => ({ count: state.count }),
+          equalityFn: (prev: { count: number }, next: { count: number }) =>
+            prev.count === next.count,
+        },
+      ),
+    )
+
+    useBoundStore.setState({ transient: 1 })
+    useBoundStore.setState({ transient: 2 })
+    useBoundStore.setState({ count: 1 })
+
+    expect(setItemSpy).toHaveBeenCalledTimes(2)
+    expect(setItemSpy).toHaveBeenNthCalledWith(
+      1,
+      'test-storage',
+      JSON.stringify({
+        state: {
+          count: 0,
+        },
+        version: 0,
+      }),
+    )
+    expect(setItemSpy).toHaveBeenNthCalledWith(
+      2,
+      'test-storage',
+      JSON.stringify({
+        state: {
+          count: 1,
+        },
+        version: 0,
+      }),
+    )
+  })
+
+  it('does not treat merged hydration state as already persisted with equalityFn', () => {
+    const setItemSpy = vi.fn()
+    const storage = {
+      getItem: () =>
+        JSON.stringify({
+          state: { count: 1 },
+          version: 0,
+        }),
+      setItem: setItemSpy,
+      removeItem: () => {},
+    }
+
+    const useBoundStore = create(
+      persist(
+        () => ({
+          count: 0,
+          extra: true,
+        }),
+        {
+          name: 'test-storage',
+          storage: createJSONStorage<{ count: number; extra: boolean }>(
+            () => storage,
+          ),
+          equalityFn: (
+            prev: { count: number; extra: boolean },
+            next: { count: number; extra: boolean },
+          ) => prev.count === next.count && prev.extra === next.extra,
+        },
+      ),
+    )
+
+    expect(useBoundStore.getState()).toEqual({ count: 1, extra: true })
+
+    useBoundStore.setState({})
+
+    expect(setItemSpy).toHaveBeenCalledTimes(1)
+    expect(setItemSpy).toHaveBeenCalledWith(
+      'test-storage',
+      JSON.stringify({
+        state: {
+          count: 1,
+          extra: true,
+        },
+        version: 0,
+      }),
+    )
+  })
+
   it('can access the options through the api', () => {
     const storage = {
       getItem: () => null,


### PR DESCRIPTION
## Related Bug Reports or Discussions

Related to #1135.

## Summary

- add an optional `persist.equalityFn` hook so apps can skip storage writes when the partialized persisted state has not changed
- dedupe in-flight async writes for equal partialized values, while still preserving later changed writes
- document the new option and add sync/async regression coverage for unchanged partialized state and hydration interactions

This keeps the current default behavior unchanged, but gives applications using expensive async storage backends a first-class way to avoid redundant writes.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs

## Validation

- `pnpm run fix`
- `pnpm test:format`
- `pnpm test:types`
- `pnpm test:lint`
- `pnpm build`
- direct runtime verification against the built output for sync dedupe, hydration merge correctness, and async duplicate in-flight writes

## Notes

- I could not run `pnpm run test` / `vitest` successfully in this Windows environment because the repo currently hits a `jsdom` / `html-encoding-sniffer` worker startup `ERR_REQUIRE_ESM` issue before the test files execute.
- Because of that environment-level blocker, I added the direct built-output runtime verification above to make sure the new persist behavior itself was still exercised end to end in-session.