### PR TITLE
docs: Update how-to-reset-state.md according to the new create API

### DIFF
--- a/docs/learn/guides/how-to-reset-state.md
+++ b/docs/learn/guides/how-to-reset-state.md
@@ -17,26 +17,23 @@ const useSomeStore = create<State & Actions>()((set, get, store) => ({
 Resetting multiple stores at once
 
 ```ts
-import type { StateCreator } from 'zustand'
-import { create: actualCreate } from 'zustand'
+import { StateCreator, create as actualCreate } from 'zustand'
 
 const storeResetFns = new Set<() => void>()
 
-const resetAllStores = () => {
+export const resetAllStores = () => {
   storeResetFns.forEach((resetFn) => {
     resetFn()
   })
 }
 
-export const create = (<T>() => {
-  return (stateCreator: StateCreator<T>) => {
-    const store = actualCreate(stateCreator)
-    storeResetFns.add(() => {
-      store.setState(store.getInitialState(), true)
-    })
-    return store
-  }
-}) as typeof actualCreate
+export const create = <T>(stateCreator: StateCreator<T>) => {
+  const store = actualCreate(stateCreator)
+  storeResetFns.add(() => {
+    store.setState(store.getInitialState(), true)
+  })
+  return store
+}
 ```
 
 ## Demo


### PR DESCRIPTION
## Related Bug Reports or Discussions

Fixes #

## Summary

The code sample in `how-to-reset-state.md` uses the old `create` API. This PR updates it to the new API.

Notes:

1) I don't think I can modify the `stackblitz.com` code.

2) The [deepwiki.com](https://deepwiki.com/pmndrs/zustand/6.3-resetting-state) removes the imports from the code samples. It confuses the reader as they don't know what `actualCreate` is.

## Check List

- [ ] `pnpm run fix` for formatting and linting code and docs
