### PR TITLE
docs(devtools): add missing devtools import to troubleshooting example

### DIFF
--- a/docs/reference/middlewares/devtools.md
+++ b/docs/reference/middlewares/devtools.md
@@ -302,6 +302,7 @@ Here's the fixed previous example
 
 ```ts
 import { create, StateCreator } from 'zustand'
+import { devtools } from 'zustand/middleware'
 
 type BearSlice = {
   bears: number


### PR DESCRIPTION
The "fixed example" in the **"All action names are labeled as 'anonymous'"** troubleshooting section uses the `devtools` middleware but doesn't import it.

The example calls `devtools(...)`:

```ts
const useJungleStore = create<JungleStore>()(
  devtools((...args) => ({
    ...createBearSlice(...args),
    ...createFishSlice(...args),
  })),
)
```

but only imports `create` and `StateCreator`:

```ts
import { create, StateCreator } from 'zustand'
```

The "broken example" directly above it imports `devtools` correctly. Since the fixed example is meant to be the corrected version of that broken example, it should keep the same imports — as written it would throw a `ReferenceError`.

### Diff

```diff
  import { create, StateCreator } from 'zustand'
+ import { devtools } from 'zustand/middleware'
```

Docs-only change — no changeset needed.
