### PR TITLE
docs(immer): fix setPerson updater type in usage examples

### DIFF
--- a/docs/reference/middlewares/immer.md
+++ b/docs/reference/middlewares/immer.md
@@ -66,9 +66,9 @@ type PersonStoreState = {
 
 type PersonStoreActions = {
   setPerson: (
-    nextPerson: (
-      person: PersonStoreState['person'],
-    ) => PersonStoreState['person'] | PersonStoreState['person'],
+    nextPerson:
+      | PersonStoreState['person']
+      | ((person: PersonStoreState['person']) => PersonStoreState['person']),
   ) => void
 }
 
@@ -165,9 +165,9 @@ type PersonStoreState = {
 
 type PersonStoreActions = {
   setPerson: (
-    nextPerson: (
-      person: PersonStoreState['person'],
-    ) => PersonStoreState['person'] | PersonStoreState['person'],
+    nextPerson:
+      | PersonStoreState['person']
+      | ((person: PersonStoreState['person']) => PersonStoreState['person']),
   ) => void
 }
 


### PR DESCRIPTION
The `setPerson` action type in both usage examples of `immer.md` is malformed — a misplaced parenthesis puts `| PersonStoreState['person']` inside the function's return type instead of making it a top-level union member.

Current:

```ts
setPerson: (
  nextPerson: (
    person: PersonStoreState['person'],
  ) => PersonStoreState['person'] | PersonStoreState['person'],
) => void
```

This types `nextPerson` as `(person: P) => (P | P)` — i.e. always a function, with a redundant `P | P` return type. But the example's own implementation handles both a value and an updater function:

```ts
setPerson: (nextPerson) =>
  set((state) => ({
    person:
      typeof nextPerson === 'function'
        ? nextPerson(state.person)
        : nextPerson,
  })),
```

With the current type the `: nextPerson` branch is unreachable.

The intended type is a value-or-updater union — the same pattern already used correctly by `setAge` in [`create.md`](https://github.com/pmndrs/zustand/blob/main/docs/reference/apis/create.md):

```ts
nextAge:
  | AgeStoreState['age']
  | ((currentAge: AgeStoreState['age']) => AgeStoreState['age']),
```

### Diff

```diff
  setPerson: (
-   nextPerson: (
-     person: PersonStoreState['person'],
-   ) => PersonStoreState['person'] | PersonStoreState['person'],
+   nextPerson:
+     | PersonStoreState['person']
+     | ((person: PersonStoreState['person']) => PersonStoreState['person']),
  ) => void
```

Applied to both usage examples (the plain `createStore` example and the `immer` example). Docs-only change — no changeset needed.
