### PR TITLE
docs(updating-state): use curried create form with explicit state type

### DIFF
--- a/docs/learn/guides/updating-state.md
+++ b/docs/learn/guides/updating-state.md
@@ -23,7 +23,7 @@ type Action = {
 }
 
 // Create your store, which includes both state and (optionally) actions
-const usePersonStore = create<State & Action>((set) => ({
+const usePersonStore = create<State & Action>()((set) => ({
   firstName: '',
   lastName: '',
   updateFirstName: (firstName) => set(() => ({ firstName: firstName })),


### PR DESCRIPTION
`updating-state.md` creates a typed store with the non-curried `create<T>(...)` form:

```ts
const usePersonStore = create<State & Action>((set) => ({
```

When the state type is annotated explicitly, Zustand's own TypeScript guides require the curried form `create<T>()(...)`:

- [Advanced TypeScript Guide](https://github.com/pmndrs/zustand/blob/main/docs/learn/guides/advanced-typescript.md): "instead of writing `create(...)`, you have to write `create<T>()(...)` (notice the extra parentheses `()` too along with the type parameter)".
- [Beginner TypeScript Guide](https://github.com/pmndrs/zustand/blob/main/docs/learn/guides/beginner-typescript.md): the store example uses `create<BearState>()((set) => ...)`.

Every other example across the docs that annotates the state type uses the curried form — this guide is the only one that doesn't, which is misleading since `updating-state.md` is one of the first guides a beginner reads.

### Diff

```diff
- const usePersonStore = create<State & Action>((set) => ({
+ const usePersonStore = create<State & Action>()((set) => ({
```

Docs-only change — no changeset needed.
