### PR TITLE
docs(combine): add object constraints to T and U in signature

### DIFF
--- a/docs/reference/middlewares/combine.md
+++ b/docs/reference/middlewares/combine.md
@@ -30,7 +30,7 @@ const nextStateCreatorFn = combine(initialState, additionalStateCreatorFn)
 ### Signature
 
 ```ts
-combine<T, U>(initialState: T, additionalStateCreatorFn: StateCreator<T, [], [], U>): StateCreator<Omit<T, keyof U> & U, [], []>
+combine<T extends object, U extends object>(initialState: T, additionalStateCreatorFn: StateCreator<T, [], [], U>): StateCreator<Omit<T, keyof U> & U, [], []>
 ```
 
 ## Reference


### PR DESCRIPTION
## Related Bug Reports or Discussions

N/A — found via source/docs signature audit, matching the convention recently applied in #3491, #3492, #3493.

## Summary

The `combine` signature in [`docs/reference/middlewares/combine.md`](https://github.com/pmndrs/zustand/blob/main/docs/reference/middlewares/combine.md) is missing the `extends object` constraints on `T` and `U` that exist in the source.

Current docs signature:

```ts
combine<T, U>(
  initialState: T,
  additionalStateCreatorFn: StateCreator<T, [], [], U>,
): StateCreator<Omit<T, keyof U> & U, [], []>
```

Source signature in `src/middleware/combine.ts`:

```ts
export function combine<
  T extends object,
  U extends object,
  Mps extends [StoreMutatorIdentifier, unknown][] = [],
  Mcs extends [StoreMutatorIdentifier, unknown][] = [],
>(
  initialState: T,
  create: StateCreator<T, Mps, Mcs, U>,
): StateCreator<Write<T, U>, Mps, Mcs>
```

Without the constraints, the docs imply that `combine` accepts primitives for `initialState`.

For example, `combine({ count: 0 }, ...)` works, while `combine(0, ...)` is rejected by the source's `T extends object` constraint.

This matches the existing convention in `docs/reference/middlewares/redux.md`, which preserves the source's `A extends { type: string }` constraint in its signature.

## Diff

```diff
- combine<T, U>(initialState: T, additionalStateCreatorFn: StateCreator<T, [], [], U>): StateCreator<Omit<T, keyof U> & U, [], []>
+ combine<T extends object, U extends object>(initialState: T, additionalStateCreatorFn: StateCreator<T, [], [], U>): StateCreator<Omit<T, keyof U> & U, [], []>
```

Docs-only change — no changeset needed.

## Check List

- [x] `pnpm run fix` for formatting and linting code and docs