### PR TITLE
perf(react): don't memoize getServerSnapshot in useStore

### DIFF
--- a/src/react.ts
+++ b/src/react.ts
@@ -30,7 +30,7 @@ export function useStore<TState, StateSlice>(
   const slice = React.useSyncExternalStore(
     api.subscribe,
     React.useCallback(() => selector(api.getState()), [api, selector]),
-    React.useCallback(() => selector(api.getInitialState()), [api, selector]),
+    () => selector(api.getInitialState()),
   )
   React.useDebugValue(slice)
   return slice


### PR DESCRIPTION
React only calls getServerSnapshot during hydration/server rendering and never retains or compares its identity (checked across 18.0-19.2, Fizz, the shim, preact/compat and RN), so the useCallback around it was pure per-render overhead: one hook slot, a deps array and a closure. Dropping it saves ~13% of useStore's per-render allocation and a few bytes.

## Related Bug Reports or Discussions

https://github.com/pmndrs/zustand/discussions/3562

## Summary

## Check List

- [ ] `pnpm run fix` for formatting and linting code and docs
