### PR TITLE
docs: fix broken migrating-to-v5 link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ const [nuts, honey] = useBearStore(
 const treats = useBearStore(useShallow((state) => Object.keys(state.treats)))
 ```
 
-For more control over re-rendering, you may provide any custom equality function (this example requires the use of [`createWithEqualityFn`](./docs/migrations/migrating-to-v5.md#using-custom-equality-functions-such-as-shallow)).
+For more control over re-rendering, you may provide any custom equality function (this example requires the use of [`createWithEqualityFn`](./docs/reference/migrations/migrating-to-v5.md#using-custom-equality-functions-such-as-shallow)).
 
 ```jsx
 const treats = useBearStore(


### PR DESCRIPTION
The `createWithEqualityFn` note linked to ./docs/migrations/migrating-to-v5.md, but the migration guides live under ./docs/reference/migrations/. Point the link at the existing file so the anchor resolves.


Claude-Session: https://claude.ai/code/session_012TECwEsvMbRbisqtW2R2iV

## Related Bug Reports or Discussions

Fixes #3566

## Summary

## Check List

- [ ] `pnpm run fix` for formatting and linting code and docs
