### PR TITLE
fix(devtools): apply serialize.reviver when parsing devtools messages

### DIFF
--- a/src/middleware/devtools.ts
+++ b/src/middleware/devtools.ts
@@ -306,6 +306,10 @@ const devtoolsImpl: DevtoolsImpl =
         ) => (() => void) | undefined
       }
     ).subscribe((message) => {
+      const reviver =
+        typeof options.serialize === 'object'
+          ? options.serialize.reviver
+          : undefined
       switch (message.type) {
         case 'ACTION':
           if (typeof message.payload !== 'string') {
@@ -316,6 +320,7 @@ const devtoolsImpl: DevtoolsImpl =
           }
           return parseJsonThen<{ type: unknown; state?: PartialState }>(
             message.payload,
+            reviver,
             (action) => {
               if (action.type === '__setState') {
                 if (store === undefined) {
@@ -370,7 +375,7 @@ const devtoolsImpl: DevtoolsImpl =
               return connection?.init(getTrackedConnectionState(options.name))
 
             case 'ROLLBACK':
-              return parseJsonThen<S>(message.state, (state) => {
+              return parseJsonThen<S>(message.state, reviver, (state) => {
                 if (store === undefined) {
                   setStateFromDevtools(state)
                   connection?.init(api.getState())
@@ -382,7 +387,7 @@ const devtoolsImpl: DevtoolsImpl =
 
             case 'JUMP_TO_STATE':
             case 'JUMP_TO_ACTION':
-              return parseJsonThen<S>(message.state, (state) => {
+              return parseJsonThen<S>(message.state, reviver, (state) => {
                 if (store === undefined) {
                   setStateFromDevtools(state)
                   return
@@ -423,10 +428,14 @@ const devtoolsImpl: DevtoolsImpl =
   }
 export const devtools = devtoolsImpl as unknown as Devtools
 
-const parseJsonThen = <T>(stringified: string, fn: (parsed: T) => void) => {
+const parseJsonThen = <T>(
+  stringified: string,
+  reviver: ((key: string, value: unknown) => unknown) | undefined,
+  fn: (parsed: T) => void,
+) => {
   let parsed: T | undefined
   try {
-    parsed = JSON.parse(stringified)
+    parsed = JSON.parse(stringified, reviver)
   } catch (e) {
     console.error(
       '[zustand devtools middleware] Could not parse the received json',

--- a/tests/devtools.test.tsx
+++ b/tests/devtools.test.tsx
@@ -736,6 +736,63 @@ describe('when it receives a message of type...', () => {
       )
     })
   })
+
+  describe('serialize.reviver option...', () => {
+    const reviver = (key: string, value: unknown) =>
+      key === 'count' ? Number(value) * 10 : value
+
+    it('applies reviver to ACTION `__setState` payload', async () => {
+      const initialState = { count: 0 }
+      const api = createStore(
+        devtools(() => initialState, { enabled: true, serialize: { reviver } }),
+      )
+
+      const [connectionSubscriber] = getNamedConnectionSubscribers(undefined)
+      connectionSubscriber({
+        type: 'ACTION',
+        payload: '{ "type": "__setState", "state": { "count": 5 } }',
+      })
+
+      expect(api.getState()).toStrictEqual({ ...initialState, count: 50 })
+    })
+
+    it('applies reviver to `message.state` on JUMP_TO_STATE', async () => {
+      const initialState = { count: 0 }
+      const api = createStore(
+        devtools(() => initialState, { enabled: true, serialize: { reviver } }),
+      )
+      const newState = { count: 5 }
+
+      const [connection] = getNamedConnectionApis(undefined)
+      connection.send.mockClear()
+      const [connectionSubscriber] = getNamedConnectionSubscribers(undefined)
+      connectionSubscriber({
+        type: 'DISPATCH',
+        payload: { type: 'JUMP_TO_STATE' },
+        state: JSON.stringify(newState),
+      })
+
+      expect(api.getState()).toStrictEqual({ ...initialState, count: 50 })
+      expect(connection.send).not.toBeCalled()
+    })
+
+    it('applies reviver to `message.state` on ROLLBACK', async () => {
+      const initialState = { count: 0 }
+      const api = createStore(
+        devtools(() => initialState, { enabled: true, serialize: { reviver } }),
+      )
+      const newState = { count: 5 }
+
+      const [connectionSubscriber] = getNamedConnectionSubscribers(undefined)
+      connectionSubscriber({
+        type: 'DISPATCH',
+        payload: { type: 'ROLLBACK' },
+        state: JSON.stringify(newState),
+      })
+
+      expect(api.getState()).toStrictEqual({ ...initialState, count: 50 })
+    })
+  })
 })
 
 describe('with redux middleware', () => {


### PR DESCRIPTION
connect() forwards `serialize` to the extension for outgoing state, but incoming ACTION/ROLLBACK/JUMP_TO_STATE/JUMP_TO_ACTION messages were parsed with a bare JSON.parse, so a configured reviver never ran. Types like Immutable.js collections came back as plain objects after using devtools' Jump/Revert/Rollback controls.

Fixes https://github.com/pmndrs/zustand/discussions/2561

## Related Bug Reports or Discussions

https://github.com/pmndrs/zustand/discussions/2561#discussioncomment-18075656

## Summary

## Check List

- [ ] `pnpm run fix` for formatting and linting code and docs
