### PR TITLE
docs(create): document that state cannot be read during initialization

### DIFF
--- a/docs/reference/apis/create-store.md
+++ b/docs/reference/apis/create-store.md
@@ -21,6 +21,7 @@ const someStore = createStore(stateCreatorFn)
   - [Subscribing to state updates](#subscribing-to-state-updates)
 - [Troubleshooting](#troubleshooting)
   - [I’ve updated the state, but the screen doesn’t update](#i’ve-updated-the-state,-but-the-screen-doesn’t-update)
+  - [Reading the state inside the state creator function throws or returns undefined](#reading-the-state-inside-the-state-creator-function-throws-or-returns-undefined)
 
 ## Types
 
@@ -515,3 +516,44 @@ render(personStore.getInitialState(), personStore.getInitialState())
 
 personStore.subscribe(render)
 ```
+
+### Reading the state inside the state creator function throws or returns undefined
+
+The `store` argument is handed to the state creator function before the store has finished
+initializing, so it cannot be used to read state while that function is still running:
+
+```ts
+import { createStore } from 'zustand/vanilla'
+
+type CountStore = {
+  count: number
+  initialCount: number
+}
+
+const countStore = createStore<CountStore>()((set, get, store) => ({
+  count: 0,
+  // `get()` and `store.getState()` return `undefined` here, and
+  // `store.getInitialState()` throws:
+  // ReferenceError: Cannot access 'initialState' before initialization
+  initialCount: store.getInitialState().count,
+}))
+```
+
+Reading state during initialization is not supported. `set`, `get` and `store` are meant to be
+called later, from actions or from code that runs after `createStore` has returned.
+
+Keep the initial values as plain values instead, and read the state only once the store exists:
+
+```ts
+const initialCount = 0
+
+const countStore = createStore<CountStore>()(() => ({
+  count: initialCount,
+  initialCount,
+}))
+
+countStore.getInitialState() // { count: 0, initialCount: 0 }
+```
+
+The same limitation applies to writes: calling `set` while the state creator function is still
+running has no effect, because the object that function returns replaces the state that was set.

--- a/docs/reference/apis/create-store.md
+++ b/docs/reference/apis/create-store.md
@@ -21,7 +21,6 @@ const someStore = createStore(stateCreatorFn)
   - [Subscribing to state updates](#subscribing-to-state-updates)
 - [Troubleshooting](#troubleshooting)
   - [I’ve updated the state, but the screen doesn’t update](#i’ve-updated-the-state,-but-the-screen-doesn’t-update)
-  - [Reading the state inside the state creator function throws or returns undefined](#reading-the-state-inside-the-state-creator-function-throws-or-returns-undefined)
 
 ## Types
 
@@ -38,7 +37,8 @@ createStore<T>()(stateCreatorFn: StateCreator<T, [], []>): StoreApi<T>
 #### Parameters
 
 - `stateCreatorFn`: A function that takes `set` function, `get` function and `store` as arguments.
-  Usually, you will return an object with the methods you want to expose.
+  Usually, you will return an object with the methods you want to expose. Note that `set`, `get` and
+  `store` cannot be used while this function is running, only after the store has been created.
 
 #### Returns
 
@@ -516,44 +516,3 @@ render(personStore.getInitialState(), personStore.getInitialState())
 
 personStore.subscribe(render)
 ```
-
-### Reading the state inside the state creator function throws or returns undefined
-
-The `store` argument is handed to the state creator function before the store has finished
-initializing, so it cannot be used to read state while that function is still running:
-
-```ts
-import { createStore } from 'zustand/vanilla'
-
-type CountStore = {
-  count: number
-  initialCount: number
-}
-
-const countStore = createStore<CountStore>()((set, get, store) => ({
-  count: 0,
-  // `get()` and `store.getState()` return `undefined` here, and
-  // `store.getInitialState()` throws:
-  // ReferenceError: Cannot access 'initialState' before initialization
-  initialCount: store.getInitialState().count,
-}))
-```
-
-Reading state during initialization is not supported. `set`, `get` and `store` are meant to be
-called later, from actions or from code that runs after `createStore` has returned.
-
-Keep the initial values as plain values instead, and read the state only once the store exists:
-
-```ts
-const initialCount = 0
-
-const countStore = createStore<CountStore>()(() => ({
-  count: initialCount,
-  initialCount,
-}))
-
-countStore.getInitialState() // { count: 0, initialCount: 0 }
-```
-
-The same limitation applies to writes: calling `set` while the state creator function is still
-running has no effect, because the object that function returns replaces the state that was set.

--- a/docs/reference/apis/create.md
+++ b/docs/reference/apis/create.md
@@ -23,6 +23,7 @@ const useSomeStore = create(stateCreatorFn)
   - [Subscribing to state updates](#subscribing-to-state-updates)
 - [Troubleshooting](#troubleshooting)
   - [I’ve updated the state, but the screen doesn’t update](#i’ve-updated-the-state,-but-the-screen-doesn’t-update)
+  - [Reading the state inside the state creator function throws or returns undefined](#reading-the-state-inside-the-state-creator-function-throws-or-returns-undefined)
 
 ## Types
 
@@ -569,3 +570,44 @@ export default function Form() {
   )
 }
 ```
+
+### Reading the state inside the state creator function throws or returns undefined
+
+The `store` argument is handed to the state creator function before the store has finished
+initializing, so it cannot be used to read state while that function is still running:
+
+```ts
+import { create } from 'zustand'
+
+type CountStore = {
+  count: number
+  initialCount: number
+}
+
+const useCountStore = create<CountStore>()((set, get, store) => ({
+  count: 0,
+  // `get()` and `store.getState()` return `undefined` here, and
+  // `store.getInitialState()` throws:
+  // ReferenceError: Cannot access 'initialState' before initialization
+  initialCount: store.getInitialState().count,
+}))
+```
+
+Reading state during initialization is not supported. `set`, `get` and `store` are meant to be
+called later, from actions or from code that runs after `create` has returned.
+
+Keep the initial values as plain values instead, and read the state only once the store exists:
+
+```ts
+const initialCount = 0
+
+const useCountStore = create<CountStore>()(() => ({
+  count: initialCount,
+  initialCount,
+}))
+
+useCountStore.getInitialState() // { count: 0, initialCount: 0 }
+```
+
+The same limitation applies to writes: calling `set` while the state creator function is still
+running has no effect, because the object that function returns replaces the state that was set.

--- a/docs/reference/apis/create.md
+++ b/docs/reference/apis/create.md
@@ -23,7 +23,6 @@ const useSomeStore = create(stateCreatorFn)
   - [Subscribing to state updates](#subscribing-to-state-updates)
 - [Troubleshooting](#troubleshooting)
   - [I’ve updated the state, but the screen doesn’t update](#i’ve-updated-the-state,-but-the-screen-doesn’t-update)
-  - [Reading the state inside the state creator function throws or returns undefined](#reading-the-state-inside-the-state-creator-function-throws-or-returns-undefined)
 
 ## Types
 
@@ -40,7 +39,8 @@ create<T>()(stateCreatorFn: StateCreator<T, [], []>): UseBoundStore<StoreApi<T>>
 #### Parameters
 
 - `stateCreatorFn`: A function that takes `set` function, `get` function and `store` as arguments.
-  Usually, you will return an object with the methods you want to expose.
+  Usually, you will return an object with the methods you want to expose. Note that `set`, `get` and
+  `store` cannot be used while this function is running, only after the store has been created.
 
 #### Returns
 
@@ -570,44 +570,3 @@ export default function Form() {
   )
 }
 ```
-
-### Reading the state inside the state creator function throws or returns undefined
-
-The `store` argument is handed to the state creator function before the store has finished
-initializing, so it cannot be used to read state while that function is still running:
-
-```ts
-import { create } from 'zustand'
-
-type CountStore = {
-  count: number
-  initialCount: number
-}
-
-const useCountStore = create<CountStore>()((set, get, store) => ({
-  count: 0,
-  // `get()` and `store.getState()` return `undefined` here, and
-  // `store.getInitialState()` throws:
-  // ReferenceError: Cannot access 'initialState' before initialization
-  initialCount: store.getInitialState().count,
-}))
-```
-
-Reading state during initialization is not supported. `set`, `get` and `store` are meant to be
-called later, from actions or from code that runs after `create` has returned.
-
-Keep the initial values as plain values instead, and read the state only once the store exists:
-
-```ts
-const initialCount = 0
-
-const useCountStore = create<CountStore>()(() => ({
-  count: initialCount,
-  initialCount,
-}))
-
-useCountStore.getInitialState() // { count: 0, initialCount: 0 }
-```
-
-The same limitation applies to writes: calling `set` while the state creator function is still
-running has no effect, because the object that function returns replaces the state that was set.


### PR DESCRIPTION
The store api passed to the state creator function is not usable for reading state while that function runs: get() and store.getState() return undefined, and store.getInitialState() throws "Cannot access 'initialState' before initialization". Per the discussion, this is a designed limitation rather than a bug, so document it in the create and createStore troubleshooting sections.

Ref: https://github.com/pmndrs/zustand/discussions/3529

## Related Bug Reports or Discussions

Fixes #

## Summary

## Check List

- [ ] `pnpm run fix` for formatting and linting code and docs
